### PR TITLE
feat: add minimal scheduled radar workflow

### DIFF
--- a/.github/workflows/radar-scheduled.yml
+++ b/.github/workflows/radar-scheduled.yml
@@ -1,0 +1,39 @@
+name: radar-scheduled
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 6 * * *"
+
+permissions:
+  contents: write
+
+jobs:
+  radar:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests PyYAML
+
+      - name: Run radar
+        run: python scripts/radar_check.py
+
+      - name: Commit updated radar state
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/radar/STATUS.md data/radar/sources_registry.yaml
+          git diff --cached --quiet && exit 0
+          git commit -m "chore: refresh radar status"
+          git push

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -25,6 +25,13 @@ Output:
 
 - [STATUS.md](../data/radar/STATUS.md)
 
+Scheduling v0:
+
+- run giornaliero via GitHub Actions
+- `workflow_dispatch` disponibile per run manuali
+- il modello v0 e' `report-only`: aggiorna `STATUS.md` e `sources_registry.yaml`
+- nessuna issue automatica o alerting complesso in questa fase
+
 ## Catalog-watch
 
 Output correnti:


### PR DESCRIPTION
﻿## Cosa cambia
- aggiunge un workflow GitHub Actions minimo per eseguire `radar_check.py` con cadenza giornaliera
- abilita anche `workflow_dispatch` per run manuali
- documenta nel runbook che il modello v0 e' `report-only`

## Perche'
`source-observatory` ha gia' chiarito il proprio perimetro v0, ma mancava ancora una decisione operativa esplicita su come far girare il radar in modo regolare senza introdurre alerting o automazioni pesanti troppo presto.

## Come verificare
- controllare `.github/workflows/radar-scheduled.yml`
- verificare che il workflow aggiorni solo `data/radar/STATUS.md` e `data/radar/sources_registry.yaml`
- verificare il blocco `Scheduling v0` in `docs/runbook.md`

## Rischi residui
- il run giornaliero e' una scelta minima v0, non un modello definitivo di scheduling
- non introduce ancora issue automatiche o triage operativo sui warning
