### PR TITLE
docs: tighten source-observatory signal semantics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,6 +146,8 @@ Tassonomia raccomandata dei segnali:
 - `follow_up_candidate`
 - `missing_data`
 
+Per la v0 questa tassonomia va tenuta stretta: non va espansa facilmente e non dovrebbe mescolare segnale osservato e passo successivo.
+
 Questa tassonomia serve a evitare che il layer catalogo degeneri in:
 
 - scraping rumoroso

--- a/docs/catalog_watch_measurement_policy.md
+++ b/docs/catalog_watch_measurement_policy.md
@@ -78,6 +78,12 @@ Usare:
 
 `measurement anomaly` può vivere come descrizione nel dettaglio, ma il tipo segnale da esporre nel report dovrebbe restare `missing_data`.
 
+`follow_up_candidate` non dovrebbe invece sostituire il segnale principale:
+
+- se il delta è debole o non confrontabile, resta `missing_data`
+- se il delta è difendibile, può diventare `inventory_change`
+- solo dopo, se serve davvero revisione umana, il report può suggerire un follow-up
+
 ## Regola editoriale
 
 Nel report:

--- a/workflows/catalog-watch.md
+++ b/workflows/catalog-watch.md
@@ -154,6 +154,11 @@ Usare questa tassonomia dei segnali:
 - `[DATO MANCANTE]`
   - non c'è abbastanza evidenza per classificare il segnale in modo affidabile
 
+Regola pratica v0:
+
+- per ogni fonte e per ogni run usare un solo segnale primario
+- `follow-up candidate` va trattato come raccomandazione di follow-up, non come tipo segnale concorrente
+
 ### Step 4 - Aggiorna il registry
 
 Per ogni fonte controllata, aggiornare il campo `last_probed` in `sources_registry.yaml`


### PR DESCRIPTION
## Cosa cambia
- chiarisce che in `catalog-watch` ogni fonte deve avere un solo segnale primario per run
- distingue meglio tra segnale osservato e suggerimento di follow-up umano
- rafforza la semantica di `missing_data` vs `inventory_change`

## Perché
Prima di allargare il set di fonti, il repo deve tenere stretta la semantica dei segnali per evitare drift, inflation e report che mescolano evidenza osservata e next step del Lab.

## Come verificare
- leggere `workflows/catalog-watch.md`
- leggere `docs/catalog_watch_measurement_policy.md`
- leggere `docs/architecture.md`
- verificare che il delta non introduca nuovi tipi di segnale, ma chiarisca meglio quelli esistenti

## Rischi residui
- il report storico esistente puo' ancora mostrare classificazioni miste; questo commit fissa soprattutto la convenzione futura
- eventuali follow-up piu' forti sui segnali resteranno comunque separati dalla semantica base

Closes #3