### PR TITLE
add OpenBDAP as observed catalog in radar

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ Non è:
 
 ## V0 attuale
 
-La v0 pubblicabile è concentrata su 3 cataloghi ricchi:
+La v0 pubblicabile è concentrata su pochi cataloghi ricchi:
 
 - `istat_sdmx`
 - `anac`
 - `inps`
+- `openbdap`
 
 La regola guida è semplice:
 
-- meglio 3 cataloghi ricchi con segnali leggibili
+- meglio 4 cataloghi ricchi con segnali leggibili
 - peggio 12 fonti miste con poco segnale
 
 ## Componenti

--- a/data/radar/STATUS.md
+++ b/data/radar/STATUS.md
@@ -8,12 +8,16 @@ Ultimo run: 2026-04-02
 - GREEN: 1
 - YELLOW: 1
 - RED: 1
+- Fonti controllate: 4
+- GREEN: 2
+- YELLOW: 1
+- RED: 1
 
 ## Tipi sorgente
 
 | Tipo | Conteggio |
 | --- | --- |
-| catalog | 3 |
+| catalog | 4 |
 | portal | 0 |
 | source | 0 |
 
@@ -22,7 +26,7 @@ Ultimo run: 2026-04-02
 | Modalita' | Conteggio | Significato |
 | --- | --- | --- |
 | radar-only | 0 | Salute della fonte senza segnali di inventario |
-| catalog-watch | 3 | Inventario e drift strutturale del catalogo |
+| catalog-watch | 4 | Inventario e drift strutturale del catalogo |
 | monitor-active | 0 | Caso ristretto con monitoraggio piu' vicino alla risorsa |
 
 Nota: lo stato radar descrive la salute della fonte, non il valore o l'aggiornamento del dataset.
@@ -34,6 +38,7 @@ Nota: lo stato radar descrive la salute della fonte, non il valore o l'aggiornam
 | istat_sdmx | catalog | sdmx | catalog-watch | RED | 500 | popolazione-istat |
 | anac | catalog | ckan | catalog-watch | YELLOW | 403 | - |
 | inps | catalog | ckan | catalog-watch | GREEN | 200 | pens_2017, pens_2024 |
+| openbdap | catalog | ckan | catalog-watch | GREEN | 200 | dipendenti-pubblici, opencoesione-pagamenti-ue-2014-2020 |
 
 ## Note
 

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -43,3 +43,21 @@ inps:
   datasets_in_use:
   - pens_2017
   - pens_2024
+openbdap:
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
+  last_probed: '2026-04-02'
+  catalog_baseline:
+    captured_at: '2026-04-02'
+    metric: package_count
+    value: 3772
+    note: Conteggio totale package rilevati via package_list; package_search restituisce
+      count inaffidabile.
+  verdict: go
+  note: Catalogo CKAN molto ricco; osservazione iniziale stretta a livello inventario
+    senza intake o monitor diffuso.
+  datasets_in_use:
+  - dipendenti-pubblici
+  - opencoesione-pagamenti-ue-2014-2020

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,6 +63,7 @@ Per la v0 il set va tenuto deliberatamente piccolo:
 - `istat_sdmx`
 - `anac`
 - `inps`
+- `openbdap`
 
 Se una fonte non produce segnali chiari e difendibili, resta fuori dalla v0.
 
@@ -106,6 +107,7 @@ Buoni candidati v0:
 - ISTAT SDMX
 - ANAC
 - INPS
+- OpenBDAP
 
 ## Cosa sta nel resource monitor
 


### PR DESCRIPTION
Closes #10.

## Contesto
Questa PR aggiunge `openbdap` al perimetro v0 di `source-observatory` come catalogo osservato.

La scelta resta volutamente stretta:
- nessun intake dataset
- nessun monitor diffuso di file o directory
- nessun allargamento oltre il livello inventario

## Cosa contiene
- nuova entry `openbdap` in `data/radar/sources_registry.yaml`
- baseline iniziale `package_count = 3772`
- aggiornamento di `README.md` e `docs/architecture.md`
- rerun di `scripts/radar_check.py` con aggiornamento di `data/radar/STATUS.md`

## Decisione operativa
`OpenBDAP` entra come:
- `source_kind: catalog`
- `protocol: ckan`
- `observation_mode: catalog-watch`

Base URL scelta:
- `https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1`

## Nota metodologica
La CKAN API e' reale e raggiungibile.
Per la baseline iniziale usiamo `package_list`, che restituisce stabilmente l'inventario completo.
`package_search?rows=0` restituisce `count: 0`, quindi non e' usato come metrica canonica in questa v0.

## Perimetro tenuto fuori
- niente `catalog-watch` piu' ricco di questo
- niente source-check aggiuntivi in questa PR
- niente monitor di dataset singoli
