### PR TITLE
Rendi piu' espliciti i workflow e il funnel di source-observatory

### DIFF
--- a/data/monitor/README.md
+++ b/data/monitor/README.md
@@ -39,3 +39,13 @@ Tenere solo un set Tier 1 molto piccolo ed evitare di trattare gli snapshot del 
 - usage note: `source-observatory/docs/usage.md`
 - config audit: `source-observatory/docs/config_audit_2026-03-27.md`
 - architecture note: `source-observatory/docs/architecture.md`
+
+## Stato del monitor
+
+Il monitor e' congelato come utility legacy su poche fonti gia' presenti.
+
+Regola pratica:
+
+- nessuna nuova fonte va aggiunta qui come primo passo
+- i nuovi portali passano da `portal-scout` / `source-check`
+- i futuri source ping orientati al dataset vanno preferibilmente vicino ai candidate in `dataset-incubator`

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,21 +1,41 @@
-# Workflows - Source Observatory
+# Workflows
 
-I workflow canonici del repo stanno in `source-observatory/workflows/`.
+Indice minimo dei workflow canonici di `source-observatory`.
 
-Per ora includono:
+## Come orientarsi
 
-- `source-check.md`
-- `radar-check.md`
-- `catalog-watch.md`
-- `resource-monitor.md`
+- [source-check.md](./source-check.md)
+  - verifica se una fonte o un dataset pubblico regge davvero come pista del Lab
+  - esce con un verdetto singolo e un next step esplicito
 
-Gli eval repo-specifici stanno in:
+- [catalog-watch.md](./catalog-watch.md)
+  - osserva pochi cataloghi in modalita' inventariale
+  - cerca segnali di cambiamento sul catalogo, non sul singolo file
 
-- `source-observatory/workflows/evals/catalog-watch/`
+- [radar-check.md](./radar-check.md)
+  - controlla la salute infrastrutturale della fonte
+  - risponde alla domanda: la fonte e' viva?
 
-I workflow cross-repo piu completi del Lab restano invece in `lab-ops/skills/`.
+- [resource-monitor.md](./resource-monitor.md)
+  - monitora poche risorse note ad alto valore
+  - segnala cambi che possono richiedere un next step umano sul dataset
 
-Nel repo:
+## Boundary rapido
 
-- `source-check.md` e' il workflow pubblico/light di scouting della fonte
-- `radar-check.md`, `catalog-watch.md` e `resource-monitor.md` sono workflow di osservazione posseduti dal repo
+- `radar-check`:
+  - health della fonte o del portale
+- `catalog-watch`:
+  - cambi inventariali o strutturali del catalogo
+- `resource-monitor`:
+  - cambi su risorse note e ristrette
+- `source-check`:
+  - valutazione umana della fonte come possibile filone del Lab
+
+## Regola pratica
+
+Se la domanda e':
+
+- "la fonte e' viva?" -> `radar-check`
+- "il catalogo ha cambiato inventario o struttura?" -> `catalog-watch`
+- "questa risorsa nota e' cambiata in modo rilevante?" -> `resource-monitor`
+- "questa fonte regge davvero come pista del Lab?" -> `source-check`

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -4,17 +4,21 @@ Indice minimo dei workflow canonici di `source-observatory`.
 
 ## Come orientarsi
 
+- [portal-scout.md](./portal-scout.md)
+  - classifica un portale o una superficie dati prima dell'ingresso nel funnel
+  - decide se ha senso `catalog-watch`, `radar-only` o `source-check` item-based
+
 - [source-check.md](./source-check.md)
   - verifica se una fonte o un dataset pubblico regge davvero come pista del Lab
   - esce con un verdetto singolo e un next step esplicito
 
 - [catalog-watch.md](./catalog-watch.md)
-  - osserva pochi cataloghi in modalita' inventariale
+  - osserva pochi cataloghi in modalita inventariale
   - cerca segnali di cambiamento sul catalogo, non sul singolo file
 
 - [radar-check.md](./radar-check.md)
   - controlla la salute infrastrutturale della fonte
-  - risponde alla domanda: la fonte e' viva?
+  - risponde alla domanda: la fonte e viva?
 
 - [resource-monitor.md](./resource-monitor.md)
   - monitora poche risorse note ad alto valore
@@ -22,22 +26,25 @@ Indice minimo dei workflow canonici di `source-observatory`.
 
 ## Boundary rapido
 
-- `radar-check`:
+- `portal-scout`
+  - classificazione iniziale del portale
+- `radar-check`
   - health della fonte o del portale
-- `catalog-watch`:
+- `catalog-watch`
   - cambi inventariali o strutturali del catalogo
-- `resource-monitor`:
+- `resource-monitor`
   - cambi su risorse note e ristrette
-- `source-check`:
-  - valutazione umana della fonte come possibile filone del Lab
+- `source-check`
+  - valutazione umana della fonte come possibile pista del Lab
 
 ## Regola pratica
 
-Se la domanda e':
+Se la domanda e:
 
-- "la fonte e' viva?" -> `radar-check`
+- "la fonte e viva?" -> `radar-check`
+- "questo portale e davvero un catalogo osservabile?" -> `portal-scout`
 - "il catalogo ha cambiato inventario o struttura?" -> `catalog-watch`
-- "questa risorsa nota e' cambiata in modo rilevante?" -> `resource-monitor`
+- "questa risorsa nota e cambiata in modo rilevante?" -> `resource-monitor`
 - "questa fonte regge davvero come pista del Lab?" -> `source-check`
 
 ## Onboarding portali
@@ -59,19 +66,22 @@ Esiti canonici del gate:
 
 Regola di orientamento:
 
-- se il metodo di enumerazione degli item e' stabile e riproducibile -> `catalog-watch`
-- se il portale e' utile ma non inventariabile in modo affidabile -> `radar-only`
+- se il metodo di enumerazione degli item e stabile e riproducibile -> `catalog-watch`
+- se il portale e utile ma non inventariabile in modo affidabile -> `radar-only`
 - se il valore sta in pochi item noti e non nel portale come catalogo -> `source-check item-based`
 
 ## Nota: catalog inventory
 
-`catalog inventory` non e' un workflow. E' un artifact derivato:
+`catalog inventory` non e un workflow. E un artifact derivato:
 uno snapshot tabulare di tutti gli item in un catalogo noto, prodotto da `scripts/build_catalog_inventory.py`.
 
 La distinzione rispetto a `catalog-watch`:
-- `catalog-watch` osserva se il catalogo e' cambiato (segnale)
-- `catalog inventory` enumera cosa c'e' dentro (snapshot per scouting)
 
-Il catalog inventory serve per scouting e triage di item promettenti, non per rilevare cambiamenti. Se nasce un dubbio su quale dei due usare: `catalog-watch` risponde a "e' cambiato qualcosa?", `catalog inventory` risponde a "cosa c'e' in questo catalogo?"
+- `catalog-watch` osserva se il catalogo e cambiato
+- `catalog inventory` enumera cosa c'e dentro
 
-L'inventory nasce solo dopo un esito `GO catalog-watch` e solo se esiste un metodo di enumerazione verificato. Se il portale e' `radar-only` o `source-check item-based`, l'inventory non e' il passo giusto.
+Il catalog inventory serve per scouting e triage di item promettenti, non per rilevare cambiamenti.
+Se nasce un dubbio su quale dei due usare: `catalog-watch` risponde a "e cambiato qualcosa?", `catalog inventory` risponde a "cosa c'e in questo catalogo?"
+
+L'inventory nasce solo dopo un esito `GO catalog-watch` e solo se esiste un metodo di enumerazione verificato.
+Se il portale e `radar-only` o `source-check item-based`, l'inventory non e il passo giusto.

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -39,3 +39,14 @@ Se la domanda e':
 - "il catalogo ha cambiato inventario o struttura?" -> `catalog-watch`
 - "questa risorsa nota e' cambiata in modo rilevante?" -> `resource-monitor`
 - "questa fonte regge davvero come pista del Lab?" -> `source-check`
+
+## Nota: catalog inventory
+
+`catalog inventory` non e' un workflow. E' un artifact derivato:
+uno snapshot tabulare di tutti gli item in un catalogo noto, prodotto da `scripts/build_catalog_inventory.py`.
+
+La distinzione rispetto a `catalog-watch`:
+- `catalog-watch` osserva se il catalogo e' cambiato (segnale)
+- `catalog inventory` enumera cosa c'e' dentro (snapshot per scouting)
+
+Il catalog inventory serve per scouting e triage di item promettenti, non per rilevare cambiamenti. Se nasce un dubbio su quale dei due usare: `catalog-watch` risponde a "e' cambiato qualcosa?", `catalog inventory` risponde a "cosa c'e' in questo catalogo?"

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -40,6 +40,29 @@ Se la domanda e':
 - "questa risorsa nota e' cambiata in modo rilevante?" -> `resource-monitor`
 - "questa fonte regge davvero come pista del Lab?" -> `source-check`
 
+## Onboarding portali
+
+Sequenza canonica minima per un nuovo portale:
+
+1. `portal-scout`
+2. decision gate
+3. eventuale ingresso nel registry
+4. eventuale baseline o inventory
+5. eventuale `source-check` su item specifici
+
+Esiti canonici del gate:
+
+- `GO catalog-watch`
+- `GO radar-only`
+- `GO source-check item-based`
+- `NO per ora`
+
+Regola di orientamento:
+
+- se il metodo di enumerazione degli item e' stabile e riproducibile -> `catalog-watch`
+- se il portale e' utile ma non inventariabile in modo affidabile -> `radar-only`
+- se il valore sta in pochi item noti e non nel portale come catalogo -> `source-check item-based`
+
 ## Nota: catalog inventory
 
 `catalog inventory` non e' un workflow. E' un artifact derivato:
@@ -50,3 +73,5 @@ La distinzione rispetto a `catalog-watch`:
 - `catalog inventory` enumera cosa c'e' dentro (snapshot per scouting)
 
 Il catalog inventory serve per scouting e triage di item promettenti, non per rilevare cambiamenti. Se nasce un dubbio su quale dei due usare: `catalog-watch` risponde a "e' cambiato qualcosa?", `catalog inventory` risponde a "cosa c'e' in questo catalogo?"
+
+L'inventory nasce solo dopo un esito `GO catalog-watch` e solo se esiste un metodo di enumerazione verificato. Se il portale e' `radar-only` o `source-check item-based`, l'inventory non e' il passo giusto.

--- a/workflows/catalog-watch.md
+++ b/workflows/catalog-watch.md
@@ -1,6 +1,6 @@
 ---
 name: catalog-watch
-description: Workflow canonico del Source Observatory per osservare pochi cataloghi in modalita' `catalog-watch` e produrre un report locale di intelligence senza aprire issue o avviare pipeline.
+description: Workflow canonico del Source Observatory per osservare pochi cataloghi in modalita catalog-watch e produrre un report locale di intelligence senza aprire issue o avviare pipeline.
 license: MIT
 metadata:
   version: "1.5"
@@ -10,15 +10,15 @@ metadata:
 
 # Workflow: catalog-watch
 
-Workflow canonico di osservazione periodica per le fonti in modalita' `catalog-watch`.
-Versione: 1.5 - 2026-04-08
+Workflow canonico di `source-observatory`.
+Versione: 1.5 - 2026-04-10
 
 ## Obiettivo di fase
 
 Controllare i pochi cataloghi classificati come `catalog-watch` nel registry e capire se:
 
-- l'inventario e' cambiato
-- la struttura del catalogo e' cambiata
+- l'inventario e cambiato
+- la struttura del catalogo e cambiata
 - esiste un segnale che merita un follow-up umano
 
 Questo workflow serve a:
@@ -37,7 +37,7 @@ Non serve a:
 
 ## Quando usarlo
 
-Usalo quando hai gia':
+Usarlo quando hai gia:
 
 - fonti classificate come `catalog-watch` nel registry
 - una baseline inventariale o qualitativa dichiarata
@@ -46,80 +46,47 @@ Usalo quando hai gia':
 
 Non usarlo quando:
 
-- la domanda vera e' solo "la fonte e' viva?"
+- la domanda vera e solo "la fonte e viva?"
 - il caso richiede un `source-check` puntuale su una fonte o dataset specifico
-- il caso e' un monitor file-level o resource-level
-- la baseline non e' abbastanza comparabile da sostenere un confronto serio
-
-## Input minimi
-
-Per partire servono almeno:
-
-- registry `sources_registry.yaml`
-- fonti con `observation_mode: catalog-watch`
-- `protocol`, `base_url` e `catalog_baseline` leggibili
+- il caso e un monitor file-level o resource-level
+- la baseline non e abbastanza comparabile da sostenere un confronto serio
 
 ## Preconditions minime
 
-Prima del run dovrebbero esserci almeno:
+Per partire servono almeno:
 
-- una baseline dichiarata o un segnale qualitativo confrontabile
-- un protocollo abbastanza chiaro
-- un metodo di conteggio o osservazione esplicitato, se il confronto e' numerico
+- registry `source-observatory/data/radar/sources_registry.yaml`
+- fonti con `observation_mode: catalog-watch`
+- `protocol`, `base_url` e `catalog_baseline` leggibili
+- output canonici confermati:
+  - `source-observatory/data/catalog/CATALOG_WATCH_REPORT.md`
+  - `source-observatory/data/catalog/catalog_signals.json`
 
 Nel dubbio:
 
-- se il metodo attuale non e' comparabile con la baseline, meglio `[DATO MANCANTE]` che una conclusione forzata
-
-## Modello di esecuzione v0
-
-Per la v0 pubblica, `catalog-watch` resta `human-run`.
-
-Questo significa:
-
-- nessun workflow schedulato dedicato
-- nessuna esecuzione automatica giornaliera o settimanale
-- nessuna apertura automatica di issue o source-check
-- output canonici confermati:
-  - `data/catalog/CATALOG_WATCH_REPORT.md`
-  - `data/catalog/catalog_signals.json`
+- se il metodo attuale non e comparabile con la baseline, meglio `[DATO MANCANTE]` che una conclusione forzata
 
 ## Stop rules
 
-Fermati e non forzare conclusioni quando:
+Fermarsi quando:
 
-- il protocollo reale non e' chiaro
+- il protocollo reale non e chiaro
 - l'endpoint non restituisce dati comparabili con la baseline
 - il delta osservato dipende chiaramente da un mismatch di metodo
-- il catalogo e' troppo fragile per distinguere tra `health` e `inventory change`
+- il catalogo e troppo fragile per distinguere tra `health` e `inventory change`
 - stai per trasformare un segnale grezzo in decisione automatica
-
-## Protocolli core
-
-Tratta come protocolli core, in questo ordine:
-
-1. `ckan`
-2. `sdmx`
-3. `rest_json` quando il catalogo e' davvero inventory-like
-4. `xlsx_direct` o `html` solo se inevitabili e con aspettativa di maggior rumore
-
-Regola pratica:
-
-- se il protocollo e' fragile e il segnale non e' chiaramente rilevante, preferire `[DATO MANCANTE]` o `nessuna conclusione`
 
 ## Passi canonici
 
 ### 1. Leggi il registry
 
-File canonico:
+Leggere `source-observatory/data/radar/sources_registry.yaml`.
 
-- `source-observatory/data/radar/sources_registry.yaml`
-
-Filtra solo le fonti con:
+Filtrare solo le fonti con:
 
 - `observation_mode: catalog-watch`
 
-Per ciascuna annota almeno:
+Per ciascuna annotare almeno:
 
 - `protocol`
 - `base_url`
@@ -132,16 +99,16 @@ Per ciascuna annota almeno:
 
 ### 2. Controlla ciascuna fonte col metodo giusto
 
-Per ogni fonte, esegui il check coerente col protocollo.
+Per ogni fonte, eseguire il check coerente col protocollo.
 
-#### SDMX
+Per `sdmx`:
 
 - chiamare il listing dei dataflow
 - contare i dataflow totali
 - verificare se i dataflow correlati a `datasets_in_use` sono ancora presenti
 - se la baseline usa `dataflow_count`, confrontare il conteggio con il valore atteso
 
-#### CKAN
+Per `ckan`:
 
 - usare l'endpoint dichiarato nel registry
 - identificare il metodo di conteggio dichiarato nella baseline
@@ -152,20 +119,20 @@ Regola:
 
 - se `package_list` e `package_search` descrivono universi diversi, trattare il caso come mismatch di metodo, non come `inventory change`
 
-#### REST JSON
+Per `rest_json`:
 
-- verificare disponibilita' e struttura di massima
+- verificare disponibilita e struttura di massima
 - segnalare cambi di schema o endpoint irraggiungibili
 
-#### XLSX direct / HTML
+Per `xlsx_direct` o `html`:
 
-- verificare raggiungibilita'
-- controllare se la struttura dei link di download e' cambiata
-- usare confronti qualitativi se la baseline e' qualitativa
+- verificare raggiungibilita
+- controllare se la struttura dei link di download e cambiata
+- usare confronti qualitativi se la baseline e qualitativa
 
 ### 3. Classifica il segnale primario
 
-Per ogni fonte e per ogni run, usa un solo segnale primario:
+Per ogni fonte e per ogni run, usare un solo segnale primario:
 
 - `no signal`
 - `health`
@@ -176,17 +143,17 @@ Per ogni fonte e per ogni run, usa un solo segnale primario:
 
 Regole:
 
-- `follow-up candidate` e' un suggerimento di follow-up umano, non un automatismo
-- se il metodo osservato non e' comparabile con la baseline, preferire `[DATO MANCANTE]`
-- se il problema e' soprattutto di raggiungibilita' o affidabilita', preferire `health`
+- `follow-up candidate` e un suggerimento di follow-up umano, non un automatismo
+- se il metodo osservato non e comparabile con la baseline, preferire `[DATO MANCANTE]`
+- se il problema e soprattutto di raggiungibilita o affidabilita, preferire `health`
 
 ### 4. Produci il report
 
-Scrivi il report in:
+Scrivere il report in:
 
 - `source-observatory/data/catalog/CATALOG_WATCH_REPORT.md`
 
-Per ogni fonte, il report dovrebbe lasciare almeno:
+Per ogni fonte, il report deve lasciare almeno:
 
 - fonte controllata
 - protocollo usato
@@ -197,7 +164,7 @@ Per ogni fonte, il report dovrebbe lasciare almeno:
 
 ### 5. Aggiorna il registry
 
-Per ogni fonte controllata, aggiorna:
+Per ogni fonte controllata, aggiornare:
 
 - `last_probed`
 
@@ -223,23 +190,22 @@ Un run buono di `catalog-watch` lascia:
 
 - tutte le fonti `catalog-watch` controllate con tool reali
 - `CATALOG_WATCH_REPORT.md` aggiornato
+- `catalog_signals.json` aggiornato
 - `last_probed` aggiornato nel registry
 - un segnale primario per fonte
 - un next step umano suggerito, se serve
 
 ## Definition of done
 
-Il workflow e' chiuso bene quando:
+Il workflow e chiuso bene quando:
 
 - tutte le fonti `catalog-watch` del registry sono state controllate
-- il report e' aggiornato
-- nessun delta numerico e' stato forzato senza comparabilita' di metodo
+- il report e aggiornato
+- nessun delta numerico e stato forzato senza comparabilita di metodo
 - non sono state aperte issue, source-check o pipeline in automatico
-- il maintainer puo' leggere il report e capire subito se esiste un follow-up umano plausibile
+- il maintainer puo leggere il report e capire subito se esiste un follow-up umano plausibile
 
 ## Stati finali ammessi
-
-Segnali primari:
 
 - `no signal`
 - `health`

--- a/workflows/catalog-watch.md
+++ b/workflows/catalog-watch.md
@@ -1,25 +1,75 @@
 ---
 name: catalog-watch
-description: Workflow del Source Observatory per osservare fonti in modalità catalog-watch e produrre un report locale di intelligence senza aprire issue o avviare pipeline. Usare quando serve capire se un catalogo ha esposto segnali nuovi o strutturalmente rilevanti.
+description: Workflow canonico del Source Observatory per osservare pochi cataloghi in modalita' `catalog-watch` e produrre un report locale di intelligence senza aprire issue o avviare pipeline.
 license: MIT
 metadata:
-  version: "1.4"
+  version: "1.5"
   owner: "DataCivicLab"
   tags: [source-observatory, catalog-watch, monitoring, scouting]
 ---
 
 # Workflow: catalog-watch
 
-Workflow per l'osservazione periodica delle fonti in modalità `catalog-watch` nel Source Observatory.
-Versione: 1.4 - 2026-04-02
-
----
+Workflow canonico di osservazione periodica per le fonti in modalita' `catalog-watch`.
+Versione: 1.5 - 2026-04-08
 
 ## Obiettivo di fase
 
-Controllare le fonti classificate come `catalog-watch` in `sources_registry.yaml` e produrre
-un report strutturato di intelligence. Non apre issue, non esegue source-check, non avvia
-pipeline. Risponde a: "questo catalogo ha esposto qualcosa di nuovo o strutturalmente rilevante?"
+Controllare i pochi cataloghi classificati come `catalog-watch` nel registry e capire se:
+
+- l'inventario e' cambiato
+- la struttura del catalogo e' cambiata
+- esiste un segnale che merita un follow-up umano
+
+Questo workflow serve a:
+
+- osservare l'inventario del catalogo
+- confrontare lo stato attuale con una baseline dichiarata
+- produrre un report di intelligence leggibile
+- suggerire, ma non eseguire, il next step umano
+
+Non serve a:
+
+- fare `source-check` automatici
+- aprire issue o PR
+- avviare pipeline o candidate
+- monitorare ogni dataset o file singolarmente
+
+## Quando usarlo
+
+Usalo quando hai gia':
+
+- fonti classificate come `catalog-watch` nel registry
+- una baseline inventariale o qualitativa dichiarata
+- una domanda del tipo:
+  - questo catalogo ha esposto qualcosa di nuovo o strutturalmente rilevante?
+
+Non usarlo quando:
+
+- la domanda vera e' solo "la fonte e' viva?"
+- il caso richiede un `source-check` puntuale su una fonte o dataset specifico
+- il caso e' un monitor file-level o resource-level
+- la baseline non e' abbastanza comparabile da sostenere un confronto serio
+
+## Input minimi
+
+Per partire servono almeno:
+
+- registry `sources_registry.yaml`
+- fonti con `observation_mode: catalog-watch`
+- `protocol`, `base_url` e `catalog_baseline` leggibili
+
+## Preconditions minime
+
+Prima del run dovrebbero esserci almeno:
+
+- una baseline dichiarata o un segnale qualitativo confrontabile
+- un protocollo abbastanza chiaro
+- un metodo di conteggio o osservazione esplicitato, se il confronto e' numerico
+
+Nel dubbio:
+
+- se il metodo attuale non e' comparabile con la baseline, meglio `[DATO MANCANTE]` che una conclusione forzata
 
 ## Modello di esecuzione v0
 
@@ -34,175 +84,173 @@ Questo significa:
   - `data/catalog/CATALOG_WATCH_REPORT.md`
   - `data/catalog/catalog_signals.json`
 
-Il motivo è semplice: il valore del layer sta nella lettura metodologicamente difendibile dei segnali, non nella frequenza di esecuzione. Finché il confronto con la baseline non è abbastanza stabile su tutto l'universo v0, meglio pochi run umani chiari che automazione rumorosa.
+## Stop rules
 
-## Definition of done
+Fermati e non forzare conclusioni quando:
 
-Il workflow è completo quando:
-
-- tutte le fonti `catalog-watch` nel registry sono state controllate con tool reali
-- il report `CATALOG_WATCH_REPORT.md` è stato aggiornato
-- `last_probed` è stato aggiornato nel registry, ma non la baseline
-- ogni segnale ha un'azione suggerita chiara
-- non sono state aperte issue, source-check o pipeline in automatico
-
----
-
-## Input
-
-File canonico: `source-observatory/data/radar/sources_registry.yaml`
-
-Leggere il file e filtrare le fonti con `observation_mode: catalog-watch`.
-Se presente, leggere anche `catalog_baseline`, inclusi `metric`, `value`, `method`, `reliability` e `note`.
-
-## Perimetro corretto
-
-`catalog-watch` è un layer sopra il dataset-level.
-
-Serve a osservare:
-
-- inventario del catalogo
-- drift strutturale
-- segnali che meritano follow-up
-
-Non serve a:
-
-- fare source-check automatici
-- aprire issue
-- monitorare in modo diffuso il singolo dataset o file
+- il protocollo reale non e' chiaro
+- l'endpoint non restituisce dati comparabili con la baseline
+- il delta osservato dipende chiaramente da un mismatch di metodo
+- il catalogo e' troppo fragile per distinguere tra `health` e `inventory change`
+- stai per trasformare un segnale grezzo in decisione automatica
 
 ## Protocolli core
 
-Trattare come protocolli core, in questo ordine:
+Tratta come protocolli core, in questo ordine:
 
 1. `ckan`
 2. `sdmx`
-3. `rest_json` quando il catalogo è davvero inventory-like
+3. `rest_json` quando il catalogo e' davvero inventory-like
 4. `xlsx_direct` o `html` solo se inevitabili e con aspettativa di maggior rumore
 
-Se il protocollo è fragile e il segnale non è chiaramente rilevante, preferire `[DATO MANCANTE]`
-o `nessuna conclusione` a una lettura forzata.
+Regola pratica:
 
----
+- se il protocollo e' fragile e il segnale non e' chiaramente rilevante, preferire `[DATO MANCANTE]` o `nessuna conclusione`
 
-## Tool disponibili per protocollo
+## Passi canonici
 
-| Protocollo | Tool |
-|---|---|
-| `sdmx` | `mcp__istat-sdmx__istat_list_dataflows` |
-| `ckan` | `mcp__fetch__fetch_json` sull'endpoint dichiarato e su eventuali endpoint comparabili |
-| `rest_json` | `mcp__fetch__fetch_json` sull'endpoint base |
-| `xlsx_direct` | `mcp__fetch__fetch_readable` o `mcp__fetch__fetch_html` sulla pagina catalogo |
+### 1. Leggi il registry
 
-Per CKAN: il `base_url` nel registry punta già all'endpoint di probe corretto.
-Usare quello come punto di partenza, non costruire URL da zero.
-Se la baseline dichiara un `method`, il confronto numerico va fatto con lo stesso metodo.
+File canonico:
 
----
+- `source-observatory/data/radar/sources_registry.yaml`
 
-## Workflow
+Filtra solo le fonti con:
 
-### Step 1 - Leggi il registry
+- `observation_mode: catalog-watch`
 
-Leggere `sources_registry.yaml`. Per ogni fonte con `observation_mode: catalog-watch`:
-- estrarre `protocol`, `base_url`, `last_probed`, `note`, `datasets_in_use`, `catalog_baseline`
-- annotare esplicitamente `catalog_baseline.method` e `catalog_baseline.reliability`, se presenti
+Per ciascuna annota almeno:
 
-### Step 2 - Controlla ciascuna fonte
+- `protocol`
+- `base_url`
+- `last_probed`
+- `datasets_in_use`
+- `catalog_baseline.metric`
+- `catalog_baseline.value`
+- `catalog_baseline.method`
+- `catalog_baseline.reliability`
 
-Per ogni fonte, eseguire il check appropriato al protocollo:
+### 2. Controlla ciascuna fonte col metodo giusto
 
-**SDMX**
-- Chiamare `istat_list_dataflows`
-- Contare i dataflow totali
-- Verificare se i dataflow correlati a `datasets_in_use` sono ancora presenti
-- Se esiste `catalog_baseline.metric = dataflow_count`, confrontare il conteggio con `catalog_baseline.value`
-- Se il conteggio è cambiato, segnalarlo esplicitamente nel report
+Per ogni fonte, esegui il check coerente col protocollo.
 
-**CKAN**
-- Chiamare `fetch_json` su `{base_url}`
-- identificare il metodo di conteggio dichiarato nella baseline:
-  - se `method = package_list`, usare `package_list`
-  - se `method = package_search`, usare `package_search?rows=0`
-  - se il metodo non e' dichiarato, fermarsi a `[DATO MANCANTE]` per il delta numerico
-- Se esiste `catalog_baseline.metric = package_count`, confrontare il totale solo se il metodo osservato coincide con `catalog_baseline.method`
-- Se ci sono `datasets_in_use`, verificare che i package noti siano ancora presenti
-- Se `package_list` e `package_search` espongono universi diversi, trattare il delta come mismatch di metodo e non come `inventory_change`
+#### SDMX
 
-**REST JSON**
-- Chiamare `fetch_json` sull'endpoint base
-- Verificare disponibilità e struttura di massima
-- Segnalare cambi di schema o endpoint irraggiungibili
+- chiamare il listing dei dataflow
+- contare i dataflow totali
+- verificare se i dataflow correlati a `datasets_in_use` sono ancora presenti
+- se la baseline usa `dataflow_count`, confrontare il conteggio con il valore atteso
 
-**XLSX direct / HTML**
-- Chiamare `fetch_readable` o `fetch_html` sulla pagina catalogo
-- Verificare raggiungibilità
-- Segnalare se la struttura dei link di download è cambiata
-- Se `catalog_baseline.metric = qualitative_signal`, confrontare il segnale attuale con la baseline testuale disponibile
+#### CKAN
 
-### Step 3 - Produci il report
+- usare l'endpoint dichiarato nel registry
+- identificare il metodo di conteggio dichiarato nella baseline
+- confrontare il totale solo se il metodo osservato coincide con quello dichiarato
+- verificare, se presenti, i package correlati a `datasets_in_use`
 
-Scrivere il report in:
-`source-observatory/data/catalog/CATALOG_WATCH_REPORT.md`
+Regola:
 
-Usare questa tassonomia dei segnali:
+- se `package_list` e `package_search` descrivono universi diversi, trattare il caso come mismatch di metodo, non come `inventory change`
+
+#### REST JSON
+
+- verificare disponibilita' e struttura di massima
+- segnalare cambi di schema o endpoint irraggiungibili
+
+#### XLSX direct / HTML
+
+- verificare raggiungibilita'
+- controllare se la struttura dei link di download e' cambiata
+- usare confronti qualitativi se la baseline e' qualitativa
+
+### 3. Classifica il segnale primario
+
+Per ogni fonte e per ogni run, usa un solo segnale primario:
 
 - `no signal`
-  - nessuna novità affidabile
 - `health`
-  - il problema osservato è soprattutto di raggiungibilità o affidabilità della fonte
 - `inventory change`
-  - cambia il conteggio o l'inventario del catalogo
 - `structural drift`
-  - cambia la struttura, il pattern di naming o il layout del catalogo
 - `follow-up candidate`
-  - emerge un segnale che giustifica un follow-up umano, di solito `source-check`
 - `[DATO MANCANTE]`
-  - non c'è abbastanza evidenza per classificare il segnale in modo affidabile
 
-Regola pratica v0:
+Regole:
 
-- per ogni fonte e per ogni run usare un solo segnale primario
-- `follow-up candidate` va trattato come raccomandazione di follow-up, non come tipo segnale concorrente
-- se il metodo osservato non e' comparabile con la baseline dichiarata, preferire `[DATO MANCANTE]`
+- `follow-up candidate` e' un suggerimento di follow-up umano, non un automatismo
+- se il metodo osservato non e' comparabile con la baseline, preferire `[DATO MANCANTE]`
+- se il problema e' soprattutto di raggiungibilita' o affidabilita', preferire `health`
 
-### Step 4 - Aggiorna il registry
+### 4. Produci il report
 
-Per ogni fonte controllata, aggiornare il campo `last_probed` in `sources_registry.yaml`
-con la data corrente.
+Scrivi il report in:
 
-Non modificare `catalog_baseline` senza istruzione esplicita.
-La baseline va aggiornata solo quando il maintainer decide che il nuovo stato osservato diventa il nuovo riferimento.
-Se la baseline ha `method` o `reliability`, non cambiarli implicitamente durante il run.
+- `source-observatory/data/catalog/CATALOG_WATCH_REPORT.md`
 
----
+Per ogni fonte, il report dovrebbe lasciare almeno:
 
-## STOP POINT
+- fonte controllata
+- protocollo usato
+- baseline rilevante
+- osservazione principale
+- segnale primario
+- suggerimento di next step umano, se esiste
 
-Fermarsi qui. Il report è pronto per revisione del maintainer.
+### 5. Aggiorna il registry
 
-- Non aprire issue
-- Non eseguire source-check autonomamente
-- Non modificare candidate o dataset
+Per ogni fonte controllata, aggiorna:
 
-Se un segnale sembra urgente, segnalarlo
-chiaramente nel report con `[ATTENZIONE]` e aspettare istruzioni.
+- `last_probed`
 
----
+Non modificare:
 
-## Vincoli
+- `catalog_baseline`
+- `method`
+- `reliability`
 
-- Solo dati reali dai tool. Non stimare conteggi o inventare stati.
-- Se un endpoint non risponde, segnalarlo come `errore` nel report, non come `nessuna novità`.
-- Scrivere `[DATO MANCANTE]` se non riesci a ottenere un confronto affidabile.
-- Non trasformare delta numerici grezzi in decisioni automatiche: il follow-up umano resta separato.
-- Niente emoji, niente em dash.
+senza istruzione esplicita.
 
----
+## Errori tipici
 
-## Riferimenti
+- confrontare numeri prodotti da metodi diversi
+- trattare un endpoint rotto come `inventory change`
+- scambiare un problema di health per un segnale di catalogo
+- aprire follow-up automatici senza verifica umana
+- aggiornare la baseline implicitamente durante il run
 
-- Registry: `source-observatory/data/radar/sources_registry.yaml`
-- Output: `source-observatory/data/catalog/CATALOG_WATCH_REPORT.md`
-- Architettura: `source-observatory/docs/architecture.md`
-- Runbook: `source-observatory/docs/runbook.md`
+## Output minimo atteso
+
+Un run buono di `catalog-watch` lascia:
+
+- tutte le fonti `catalog-watch` controllate con tool reali
+- `CATALOG_WATCH_REPORT.md` aggiornato
+- `last_probed` aggiornato nel registry
+- un segnale primario per fonte
+- un next step umano suggerito, se serve
+
+## Definition of done
+
+Il workflow e' chiuso bene quando:
+
+- tutte le fonti `catalog-watch` del registry sono state controllate
+- il report e' aggiornato
+- nessun delta numerico e' stato forzato senza comparabilita' di metodo
+- non sono state aperte issue, source-check o pipeline in automatico
+- il maintainer puo' leggere il report e capire subito se esiste un follow-up umano plausibile
+
+## Stati finali ammessi
+
+Segnali primari:
+
+- `no signal`
+- `health`
+- `inventory change`
+- `structural drift`
+- `follow-up candidate`
+- `[DATO MANCANTE]`
+
+## Dove orientarsi
+
+- [README.md](../README.md)
+- [workflows/README.md](./README.md)
+- [docs/architecture.md](../docs/architecture.md)
+- [docs/runbook.md](../docs/runbook.md)

--- a/workflows/portal-scout.md
+++ b/workflows/portal-scout.md
@@ -1,0 +1,165 @@
+---
+name: portal-scout
+description: Workflow pubblico/light del Source Observatory per capire se un portale dati o una superficie web puo' entrare nel funnel del repo come catalog-watch, radar-only o sorgente da verificare item per item.
+license: MIT
+metadata:
+  version: "0.1"
+  owner: "DataCivicLab"
+  tags: [source-observatory, portal-scout, scouting, workflows]
+---
+
+# Workflow: portal-scout
+
+Workflow pubblico/light del Source Observatory.
+Versione: 0.1 - 2026-04-10
+
+---
+
+## Obiettivo di fase
+
+Capire che tipo di superficie e' un portale e quale metodo di osservazione ha senso nel repo.
+
+Questo workflow serve a rispondere a:
+
+- e' davvero un catalogo o solo un contenitore di file?
+- esiste una superficie osservabile stabile?
+- il portale e' inventariabile oppure no?
+- conviene trattarlo come `catalog-watch`, `radar-only` o solo come ingresso a futuri `source-check`?
+
+Non serve a:
+
+- verificare in profondita' un singolo dataset
+- costruire subito un inventory completo
+- fare monitoraggio continuo
+- sostituire `source-check`, `catalog-watch` o `resource-monitor`
+
+## Output minimo atteso
+
+Una nota o checklist verificata che chiuda con un solo verdetto:
+
+- `portale pronto per catalog-watch`
+- `portale da tenere radar-only`
+- `portale utile solo per source-check item-based`
+- `superficie non abbastanza chiara`
+
+## Quando usarla
+
+Usarla quando:
+
+- un portale nuovo entra nel radar del repo
+- una landing dati sembra catalogo ma la superficie reale non e' ancora chiara
+- una fonte sembra promettente ma non e' chiaramente CKAN, SDMX o altra famiglia gia' nota
+- serve una classificazione prima di aggiornare `sources_registry.yaml`
+
+Non usarla quando:
+
+- devi verificare una singola fonte o file: in quel caso usare `source-check`
+- hai gia' un inventory leggibile e devi shortlistare item: in quel caso lavorare sull'inventory
+- il portale e' gia' in `catalog-watch` e stai solo leggendo segnali o delta
+- devi seguire nel tempo una singola resource Tier 1
+
+## Workflow minimo
+
+### 1. Inquadra la superficie
+
+Annotare almeno:
+
+- nome del portale
+- URL base
+- istituzione o publisher apparente
+- dominio e sottodominio rilevanti
+- eventuali superfici secondarie osservate
+
+### 2. Identifica il tipo di portale
+
+Provare a classificare la superficie come una di queste:
+
+- `ckan`
+- `sdmx`
+- `html` con sitemap o listing stabile
+- `aem` o CMS con Open API
+- `sparql`
+- `custom`
+- `non chiaro`
+
+Se il protocollo non e' chiaro, annotare cosa e' stato osservato senza forzare la classificazione.
+
+### 3. Individua la superficie osservabile reale
+
+Capire qual e' il punto giusto da osservare, per esempio:
+
+- action API
+- endpoint dataflow
+- sitemap
+- listing HTML
+- Open API
+- endpoint SPARQL
+
+Separare sempre:
+
+- home o branding del portale
+- superficie tecnica reale usabile per osservazione
+
+### 4. Valuta l'inventariabilita'
+
+Chiedersi in modo esplicito:
+
+- si possono enumerare gli item?
+- il metodo e' riproducibile?
+- il conteggio e' difendibile?
+- la superficie e' stabile abbastanza per una baseline?
+
+Classificare l'esito come:
+
+- `inventariabile`
+- `parzialmente inventariabile`
+- `osservabile ma non inventariabile`
+- `non chiaro`
+
+### 5. Controllo leggero di overlap
+
+Verificare in modo leggero se il portale o il tema sono gia' presenti in:
+
+- `sources_registry.yaml`
+- workflow o note del repo gia' esistenti
+- filoni o candidate gia' chiaramente collegati
+
+Non serve un audit completo. Serve evitare di trattare come nuovo un portale gia' capito o gia' classificato.
+
+### 6. Chiudi con un verdetto
+
+Chiudere con uno di questi esiti:
+
+- `portale pronto per catalog-watch`
+- `portale da tenere radar-only`
+- `portale utile solo per source-check item-based`
+- `superficie non abbastanza chiara`
+
+Il verdetto deve dire anche:
+
+- metodo osservabile piu' plausibile
+- limite principale
+- next step minimo
+
+## Regole
+
+- non forzare `catalog-watch` senza metodo inventariale chiaro
+- non trattare come catalogo qualcosa che regge solo item per item
+- non costruire inventory completi troppo presto
+- non confondere sito istituzionale e superficie tecnica utile
+- meglio `radar-only` esplicito che classificazione debole
+
+## Come si collega al resto del repo
+
+- `portal-scout` classifica il portale e decide il metodo plausibile
+- `catalog-watch` osserva un catalogo con metodo stabile
+- `source-check` verifica una fonte specifica o un item promettente
+- `resource-monitor` segue una resource nota nel tempo
+
+## Prossimo passo tipico
+
+Se il verdetto e' positivo:
+
+- aggiornare o proporre aggiornamento di `sources_registry.yaml`
+- oppure passare a `source-check` su item specifici
+- oppure lasciare il portale in `radar-only` fino a metodo migliore

--- a/workflows/radar-check.md
+++ b/workflows/radar-check.md
@@ -1,59 +1,97 @@
 # Workflow: radar-check
 
-Workflow per l'esecuzione del radar di salute portali nel Source Observatory.
-Versione: 1.1 - 2026-03-30
+Workflow canonico di `source-observatory` per il controllo di salute dei portali.
+Versione: 1.2 - 2026-04-08
 
----
+## Obiettivo di fase
 
-## Scopo
+Verificare la raggiungibilita' e la salute infrastrutturale delle fonti nel registry.
 
-Verificare la raggiungibilità e la salute infrastrutturale dei portali nel registry.
-Risponde a: "questo portale è vivo?"
+Questo workflow serve a rispondere a:
 
-Non risponde a:
-- "il dataset è aggiornato?"
-- "c'è qualcosa di nuovo nel catalogo?"
-- "vale la pena analizzarlo?"
+- questa fonte e' viva?
+- il portale risponde?
+- ci sono errori di SSL, DNS, timeout o risposta anomala?
 
-Queste domande appartengono rispettivamente a:
-- `resource-monitor` nei pochissimi casi Tier 1 già giustificati
-- `catalog-watch`
-- `source-check`
+Questo workflow serve a:
 
----
-
-## Input
-
-- Registry: `source-observatory/data/radar/sources_registry.yaml`
-- Script: `source-observatory/scripts/radar_check.py`
-- Output script: `source-observatory/data/radar/STATUS.md`
-
-## Perimetro corretto
-
-`radar-check` è il layer più alto e più semplice del repo.
-
-Serve a osservare:
-
-- salute della fonte
-- raggiungibilità
-- errori SSL, DNS, timeout o risposta anomala
+- controllare la salute della fonte
+- produrre uno stato radar leggibile
+- distinguere rapidamente tra `ok` e problema infrastrutturale
 
 Non serve a:
 
-- leggere il catalogo
-- inferire update di dataset
-- proporre source-check in automatico
+- dire se il dataset e' aggiornato
+- dire se il catalogo contiene qualcosa di nuovo
+- dire se la fonte merita lavoro del Lab
+- aprire follow-up automatici
 
----
+Queste domande appartengono invece a:
 
-## Workflow
+- `catalog-watch`
+- `resource-monitor`
+- `source-check`
 
-### Step 1 - Leggi il registry
+## Quando usarlo
 
-Leggere `sources_registry.yaml` per avere il contesto delle fonti prima del run:
-- elencare le fonti con il loro `verdict` attuale e `observation_mode`
+Usalo quando:
 
-### Step 2 - Esegui radar_check
+- vuoi controllare la salute attuale delle fonti nel registry
+- vuoi aggiornare `STATUS.md`
+- vuoi capire se esistono problemi infrastrutturali ricorrenti
+
+Non usarlo quando:
+
+- la domanda vera e' sul contenuto del catalogo
+- la domanda vera e' sul valore della fonte
+- stai cercando di fare source-check o intake
+
+## Input minimi
+
+Per partire servono almeno:
+
+- registry `source-observatory/data/radar/sources_registry.yaml`
+- script `source-observatory/scripts/radar_check.py`
+
+## Preconditions minime
+
+Prima del run dovrebbero esserci almeno:
+
+- un registry leggibile
+- una ragione semplice per eseguire il check:
+  - health snapshot
+  - dry-run
+  - verifica dopo fix
+
+Nel dubbio:
+
+- se la domanda vera non e' "questa fonte e' viva?", probabilmente non sei nel workflow giusto
+
+## Stop rules
+
+Fermati e non allargare il lavoro quando:
+
+- stai cercando di inferire aggiornamenti di contenuto dai soli segnali radar
+- stai per trasformare un warning infrastrutturale in giudizio sul dataset
+- stai per aprire issue o source-check in automatico
+- stai per modificare il registry a mano invece di limitarti a leggere il risultato del run
+
+## Passi canonici
+
+### 1. Leggi il registry
+
+Leggi:
+
+- `source-observatory/data/radar/sources_registry.yaml`
+
+Giusto per avere il contesto delle fonti prima del run:
+
+- `protocol`
+- `source_kind`
+- `observation_mode`
+- eventuale `verdict`
+
+### 2. Esegui il run
 
 Dalla root del workspace:
 
@@ -67,11 +105,17 @@ Per un dry-run senza scrivere lo stato:
 python source-observatory/scripts/radar_check.py --dry-run
 ```
 
-### Step 3 - Leggi STATUS.md
+Regola pratica:
 
-Leggere `source-observatory/data/radar/STATUS.md` dopo il run.
+- se vuoi solo capire come si comporta il probe, parti da `--dry-run`
 
-Classificare ogni fonte in uno di questi stati:
+### 3. Leggi `STATUS.md`
+
+Dopo il run, leggi:
+
+- `source-observatory/data/radar/STATUS.md`
+
+Classifica almeno cosi':
 
 | Classificazione | Segnale |
 |---|---|
@@ -79,48 +123,55 @@ Classificare ogni fonte in uno di questi stati:
 | `warning infrastrutturale` | stato `YELLOW` o `RED` per timeout, SSL, DNS, request error |
 | `da osservare` | note ripetute o fallback SSL usato anche se la fonte risponde |
 
-### Step 4 - Sintesi
+### 4. Fai una sintesi breve
 
-Produrre un breve output con:
+Lascia una sintesi con:
+
 - conteggio per classificazione
-- lettura rapida dei tipi sorgente e delle modalità osservazione
-- fonti con `warning infrastrutturale` o `da osservare` con dettaglio
-- eventuali fonti `go` nel registry che ora mostrano problemi
+- fonti con `warning infrastrutturale`
+- fonti `da osservare`
+- eventuali fonti considerate importanti che ora mostrano problemi
 
----
+## Errori tipici
+
+- leggere `GREEN` come segnale di valore del dataset
+- trattare un warning SSL, DNS o timeout come aggiornamento di contenuto
+- usare il radar per decidere da solo un source-check
+- confondere un problema di health con un problema del candidate o del dataset
 
 ## Regole di interpretazione
 
-- `GREEN` / `ok` non implica lavoro sul dataset: è solo salute della fonte
-- Un warning SSL, DNS o timeout non è un aggiornamento di contenuto
-- Se una fonte SDMX restituisce 404 su HEAD: è un falso negativo noto
-- Errori ripetuti sulla stessa fonte: segnalarlo a Gabri, non modificare il registry da soli
-- La modalità osservazione aiuta a capire il next step atteso, ma non cambia il significato del segnale radar
+- `GREEN` non implica lavoro sul dataset: e' solo salute della fonte
+- un warning SSL, DNS o timeout non e' un aggiornamento di contenuto
+- se una fonte SDMX restituisce `404` su `HEAD`, puo' essere un falso negativo noto
+- la modalita' di osservazione aiuta a capire il contesto, ma non cambia il significato del segnale radar
 
----
+## Output minimo atteso
 
-## STOP POINT
+Un run buono di `radar-check` lascia:
 
-Fermarsi dopo la sintesi. Non aprire issue, non fare source-check, non modificare il registry
-senza istruzione esplicita.
+- `STATUS.md` aggiornato oppure un dry-run leggibile
+- una classificazione semplice per fonte
+- una sintesi rapida dei problemi infrastrutturali osservati
 
-Se una fonte mostra un problema rilevante, segnalarlo chiaramente con `[ATTENZIONE]`
-e aspettare istruzioni.
+## Definition of done
 
----
+Il workflow e' chiuso bene quando:
 
-## Vincoli
+- il run e' stato eseguito o simulato in modo esplicito
+- `STATUS.md` e' leggibile
+- la sintesi distingue chiaramente tra fonti sane e warning infrastrutturali
+- non sono stati aperti follow-up automatici
+- non sono state fatte inferenze improprie sul contenuto dei dataset
 
-- Niente emoji, niente em dash
-- Non modificare `sources_registry.yaml`: il registry è aggiornato dallo script, non dalla skill
-- Non promuovere fonti a `monitor-active` o `catalog-watch` senza conferma
-- Non trattare una fonte come problema di dataset solo perché è collegata a un candidate o a un dataset noto
+## Stati finali ammessi
 
----
+- `ok`
+- `warning infrastrutturale`
+- `da osservare`
 
-## Riferimenti
+## Dove orientarsi
 
-- Script: `source-observatory/scripts/radar_check.py`
-- Registry: `source-observatory/data/radar/sources_registry.yaml`
-- Output: `source-observatory/data/radar/STATUS.md`
-- Runbook: `source-observatory/docs/runbook.md`
+- [README.md](../README.md)
+- [docs/runbook.md](../docs/runbook.md)
+- [data/radar/README.md](../data/radar/README.md)

--- a/workflows/radar-check.md
+++ b/workflows/radar-check.md
@@ -10,93 +10,74 @@ metadata:
 
 # Workflow: radar-check
 
-Workflow canonico di `source-observatory` per il controllo di salute dei portali.
-Versione: 1.2 - 2026-04-08
+Workflow canonico di `source-observatory`.
+Versione: 1.2 - 2026-04-10
 
 ## Obiettivo di fase
 
-Verificare la raggiungibilita' e la salute infrastrutturale delle fonti nel registry.
-
-Questo workflow serve a rispondere a:
-
-- questa fonte e' viva?
-- il portale risponde?
-- ci sono errori di SSL, DNS, timeout o risposta anomala?
+Verificare la raggiungibilita e la salute infrastrutturale delle fonti nel registry.
 
 Questo workflow serve a:
 
-- controllare la salute della fonte
-- produrre uno stato radar leggibile
-- distinguere rapidamente tra `ok` e problema infrastrutturale
+- capire se una fonte e viva
+- rilevare errori SSL, DNS, timeout o risposta anomala
+- produrre una sintesi infrastrutturale leggibile
 
 Non serve a:
 
-- dire se il dataset e' aggiornato
-- dire se il catalogo contiene qualcosa di nuovo
-- dire se la fonte merita lavoro del Lab
+- capire se un dataset e aggiornato
+- leggere il catalogo
+- decidere il valore civico della fonte
 - aprire follow-up automatici
-
-Queste domande appartengono invece a:
-
-- `catalog-watch`
-- `resource-monitor`
-- `source-check`
 
 ## Quando usarlo
 
-Usalo quando:
+Usarlo quando hai gia:
 
-- vuoi controllare la salute attuale delle fonti nel registry
-- vuoi aggiornare `STATUS.md`
-- vuoi capire se esistono problemi infrastrutturali ricorrenti
+- `sources_registry.yaml` aggiornato
+- script `source-observatory/scripts/radar_check.py`
+- bisogno di un check rapido sulla salute delle fonti
 
 Non usarlo quando:
 
-- la domanda vera e' sul contenuto del catalogo
-- la domanda vera e' sul valore della fonte
-- stai cercando di fare source-check o intake
+- devi verificare una fonte specifica o un file
+- devi leggere delta di catalogo
+- devi interpretare un segnale a livello dataset
 
 ## Preconditions minime
 
-Prima del run dovrebbero esserci almeno:
+Per partire servono:
 
-- registry `source-observatory/data/radar/sources_registry.yaml`
-- script `source-observatory/scripts/radar_check.py`
-- un registry leggibile
-- una ragione semplice per eseguire il check:
-  - health snapshot
-  - dry-run
-  - verifica dopo fix
+- registry leggibile
+- script radar eseguibile
+- output atteso chiaro: `source-observatory/data/radar/STATUS.md`
+- fonti con `base_url` plausibile
 
 Nel dubbio:
 
-- se la domanda vera non e' "questa fonte e' viva?", probabilmente non sei nel workflow giusto
+- se la domanda vera non e "questa fonte e viva?", probabilmente non sei nel workflow giusto
 
 ## Stop rules
 
-Fermati e non allargare il lavoro quando:
+Fermarsi se:
 
-- stai cercando di inferire aggiornamenti di contenuto dai soli segnali radar
-- stai per trasformare un warning infrastrutturale in giudizio sul dataset
-- stai per aprire issue o source-check in automatico
+- stai per interpretare un problema infrastrutturale come update di contenuto
+- il caso appartiene a `catalog-watch` o `source-check`
+- il run produce solo rumore da una fonte gia nota come fragile
 - stai per modificare il registry a mano invece di limitarti a leggere il risultato del run
 
 ## Passi canonici
 
 ### 1. Leggi il registry
 
-Leggi:
+Leggere `source-observatory/data/radar/sources_registry.yaml` per avere il contesto delle fonti prima del run:
 
-- `source-observatory/data/radar/sources_registry.yaml`
-
-Giusto per avere il contesto delle fonti prima del run:
-
+- fonte
 - `protocol`
-- `source_kind`
+- `verdict`
 - `observation_mode`
-- eventuale `verdict`
 
-### 2. Esegui il run
+### 2. Esegui il radar
 
 Dalla root del workspace:
 
@@ -104,70 +85,52 @@ Dalla root del workspace:
 python source-observatory/scripts/radar_check.py
 ```
 
-Per un dry-run senza scrivere lo stato:
+Per un dry-run:
 
 ```powershell
 python source-observatory/scripts/radar_check.py --dry-run
 ```
 
-Regola pratica:
-
-- se vuoi solo capire come si comporta il probe, parti da `--dry-run`
-
 ### 3. Leggi `STATUS.md`
 
-Dopo il run, leggi:
+Leggere `source-observatory/data/radar/STATUS.md` e classificare ogni fonte in uno di questi stati:
 
-- `source-observatory/data/radar/STATUS.md`
+- `ok`
+- `warning infrastrutturale`
+- `da osservare`
 
-Classifica almeno cosi':
+### 4. Produci la sintesi
 
-| Classificazione | Segnale |
-|---|---|
-| `ok` | stato `GREEN`, nessun errore rilevante |
-| `warning infrastrutturale` | stato `YELLOW` o `RED` per timeout, SSL, DNS, request error |
-| `da osservare` | note ripetute o fallback SSL usato anche se la fonte risponde |
-
-### 4. Fai una sintesi breve
-
-Lascia una sintesi con:
+Produrre una sintesi breve con:
 
 - conteggio per classificazione
-- fonti con `warning infrastrutturale`
-- fonti `da osservare`
-- eventuali fonti considerate importanti che ora mostrano problemi
+- fonti con warning o problemi ripetuti
+- eventuali fonti `go` che ora mostrano problemi infrastrutturali
 
 ## Errori tipici
 
-- leggere `GREEN` come segnale di valore del dataset
-- trattare un warning SSL, DNS o timeout come aggiornamento di contenuto
+- confondere salute del portale con update del dataset
+- promuovere un warning a decisione di workflow successivo
+- trattare un falso negativo noto come rottura reale
 - usare il radar per decidere da solo un source-check
-- confondere un problema di health con un problema del candidate o del dataset
-
-## Regole di interpretazione
-
-- `GREEN` non implica lavoro sul dataset: e' solo salute della fonte
-- un warning SSL, DNS o timeout non e' un aggiornamento di contenuto
-- se una fonte SDMX restituisce `404` su `HEAD`, puo' essere un falso negativo noto
-- la modalita' di osservazione aiuta a capire il contesto, ma non cambia il significato del segnale radar
 
 ## Output minimo atteso
 
-Un run buono di `radar-check` lascia:
+Alla fine devono esistere:
 
-- `STATUS.md` aggiornato oppure un dry-run leggibile
-- una classificazione semplice per fonte
-- una sintesi rapida dei problemi infrastrutturali osservati
+- `STATUS.md` aggiornato dallo script oppure un dry-run leggibile
+- sintesi leggibile del run
+- eventuali fonti problematiche chiaramente evidenziate
 
 ## Definition of done
 
-Il workflow e' chiuso bene quando:
+Il workflow e chiuso bene quando:
 
-- il run e' stato eseguito o simulato in modo esplicito
-- `STATUS.md` e' leggibile
-- la sintesi distingue chiaramente tra fonti sane e warning infrastrutturali
-- non sono stati aperti follow-up automatici
-- non sono state fatte inferenze improprie sul contenuto dei dataset
+- il radar e stato eseguito o simulato in modo esplicito
+- `STATUS.md` e leggibile
+- i problemi infrastrutturali sono distinti dai problemi di contenuto
+- il registry non e stato modificato manualmente
+- non sono stati aperti altri artefatti o workflow
 
 ## Stati finali ammessi
 

--- a/workflows/radar-check.md
+++ b/workflows/radar-check.md
@@ -1,3 +1,13 @@
+---
+name: radar-check
+description: Workflow canonico del Source Observatory per controllare la salute infrastrutturale delle fonti nel registry.
+license: MIT
+metadata:
+  version: "1.2"
+  owner: "DataCivicLab"
+  tags: [source-observatory, radar-check, health, monitoring]
+---
+
 # Workflow: radar-check
 
 Workflow canonico di `source-observatory` per il controllo di salute dei portali.
@@ -46,17 +56,12 @@ Non usarlo quando:
 - la domanda vera e' sul valore della fonte
 - stai cercando di fare source-check o intake
 
-## Input minimi
-
-Per partire servono almeno:
-
-- registry `source-observatory/data/radar/sources_registry.yaml`
-- script `source-observatory/scripts/radar_check.py`
-
 ## Preconditions minime
 
 Prima del run dovrebbero esserci almeno:
 
+- registry `source-observatory/data/radar/sources_registry.yaml`
+- script `source-observatory/scripts/radar_check.py`
 - un registry leggibile
 - una ragione semplice per eseguire il check:
   - health snapshot

--- a/workflows/resource-monitor.md
+++ b/workflows/resource-monitor.md
@@ -1,48 +1,90 @@
 # Workflow: resource-monitor
 
-Workflow per l'esecuzione del monitor di risorse nel Source Observatory.
-Versione: 1.1 - 2026-03-30
+Workflow canonico di `source-observatory` per il monitor di un insieme ristretto di risorse note.
+Versione: 1.2 - 2026-04-08
 
----
+## Obiettivo di fase
 
-## Scopo
+Rilevare cambi su un insieme molto ristretto di fonti note e capire se il segnale osservato richiede davvero un next step umano sul dataset.
 
-Rilevare cambi su un insieme ristretto di fonti note e decidere il next step giusto.
-Risponde a: "questa fonte nota è cambiata in modo da richiedere lavoro sul dataset?"
+Questo workflow serve a rispondere a:
 
-Non apre issue, non rilancia candidate, non fa source-check autonomamente.
+- questa fonte nota e' cambiata in modo da richiedere lavoro sul dataset?
+- il segnale osservato e' un vero cambio di risorsa o solo rumore di monitoraggio?
 
-## Perimetro corretto
+Questo workflow serve a:
 
-`resource-monitor` non è uno degli assi core del repo.
+- leggere i segnali del monitor su pochi casi ad alto valore
+- distinguere tra cambio utile e rumore
+- suggerire un next step umano plausibile
 
-Va trattato come supporto ristretto per pochissimi casi ad alto segnale, quando:
+Non serve a:
 
-- la fonte è già importante per il Lab
+- aprire issue o rilanciare candidate
+- fare `source-check` autonomamente
+- diventare watchlist generica di dataset
+- sostituire `catalog-watch` o `source-check`
+
+## Quando usarlo
+
+Usalo quando:
+
+- la fonte e' gia' importante per il Lab
 - esiste un next step plausibile se il segnale cambia
 - il monitor costa meno di uno scouting umano ripetuto
 
-Non va usato come:
+Non usarlo quando:
 
-- watchlist generica di dataset
-- default per nuove fonti
-- sostituto di `catalog-watch` o `source-check`
+- la fonte e' ancora solo interessante ma non ancora centrale
+- il caso e' meglio descritto da `radar-check`
+- il caso e' meglio descritto da `catalog-watch`
+- il monitor non porta quasi mai a decisioni utili
 
----
+## Input minimi
 
-## Input
+Per partire servono almeno:
 
-- Config fonti: `source-observatory/scripts/monitor/resource_monitor.sources.yml`
-  (se non esiste ancora: `resource_monitor.sources.yml.example` come riferimento)
-- Script: `source-observatory/scripts/monitor/resource_monitor.py`
-- Output script: `source-observatory/data/monitor/reports/latest.md`
-- Snapshot più recente: `source-observatory/data/monitor/snapshots/`
+- config fonti:
+  - `source-observatory/scripts/monitor/resource_monitor.sources.yml`
+  - oppure `resource_monitor.sources.yml.example` come riferimento
+- script:
+  - `source-observatory/scripts/monitor/resource_monitor.py`
+- output atteso:
+  - `source-observatory/data/monitor/reports/latest.md`
 
----
+## Preconditions minime
 
-## Workflow
+Prima del run dovrebbero esserci almeno:
 
-### Step 1 - Esegui resource_monitor
+- una fonte Tier 1 o equivalente, gia' giustificata
+- un adapter abbastanza chiaro
+- un next step plausibile se compare un vero segnale
+
+Nel dubbio:
+
+- se non riesci a spiegare quale decisione concreta potrebbe seguire al segnale, la fonte probabilmente non dovrebbe stare nel monitor
+
+## Stop rules
+
+Fermati e non forzare conclusioni quando:
+
+- il segnale e' chiaramente infrastrutturale e appartiene a `radar-check`
+- il cambio osservato dipende da rumore HTML o da fragilita' dell'adapter
+- non esiste un next step difendibile anche se il segnale fosse vero
+- stai per trattare un `changed` come rerun automatico senza leggere il tipo di cambio
+
+## Passi canonici
+
+### 1. Verifica il perimetro del monitor
+
+Prima del run, chiediti:
+
+- questa fonte e' davvero un caso da monitor ristretto?
+- esiste un next step plausibile se il segnale cambia?
+
+Se la risposta e' no, il problema puo' essere nel perimetro del monitor, non nel dataset.
+
+### 2. Esegui il monitor
 
 Dalla root del workspace:
 
@@ -50,90 +92,102 @@ Dalla root del workspace:
 python source-observatory/scripts/monitor/resource_monitor.py --sources source-observatory/scripts/monitor/resource_monitor.sources.yml
 ```
 
-### Step 2 - Leggi latest.md
+### 3. Leggi `latest.md`
 
-Leggere `source-observatory/data/monitor/reports/latest.md`.
+Leggi:
 
-Prima di interpretare il report, chiedersi:
+- `source-observatory/data/monitor/reports/latest.md`
 
-- questa fonte è davvero un caso Tier 1?
-- il segnale osservato può portare a un next step reale?
-
-Se la risposta è no, il problema può essere nel perimetro del monitor, non nel dataset.
-
-Classificare ogni segnale:
+Classifica ogni segnale in una di queste classi:
 
 | Tipo | Significato |
 |---|---|
 | `new` | risorsa comparsa per la prima volta |
 | `changed` | URL, nome, formato o metadati modificati |
-| `removed` | risorsa presente in precedenza non più visibile |
+| `removed` | risorsa presente in precedenza non piu' visibile |
 | `error` | problema di adapter o di portale |
 
-### Step 3 - Applica la matrice del runbook
+### 4. Valuta l'affidabilita' dell'adapter
 
-Per ogni segnale non nullo:
+Regola pratica:
 
-**1. Valuta l'affidabilità dell'adapter**
-- `single_url` o `ckan`: segnale più affidabile
-- `html`: più sospetto, attendi più falsi positivi
+- `single_url` o `ckan` = segnale piu' affidabile
+- `html` = piu' sospetto, aspettati piu' falsi positivi
 
-**2. Classifica il next step**
+Se il segnale viene da un adapter fragile:
+
+- alza il livello di cautela
+- non saltare subito a conclusioni sul dataset
+
+### 5. Classifica il next step umano
+
+Per ogni segnale non nullo, usa questa logica:
 
 | Condizione | Next step |
 |---|---|
 | `di_candidate` attivo con config runnable | ispeziona candidate, poi valuta rerun |
 | dataset stabile pubblico | verifica se serve update pubblico |
-| watchlist o support dataset | source-check, non rerun |
+| watchlist o support dataset | `source-check`, non rerun |
 | errore SSL/DNS/timeout | problema da radar, non da dataset |
 | nessun next step difendibile | proporre demotion o rimozione dal monitor |
 
-**3. Fermati se il segnale è infrastrutturale**
-- SSL, DNS, timeout, drift HTML sono segnali da `radar-check`, non da monitor
-- Non trattarli come update del dataset
+### 6. Fai una sintesi breve
 
-### Step 4 - Sintesi
+La sintesi dovrebbe lasciare:
 
-Produrre un output strutturato con:
-- conteggio segnali per tipo (`new`, `changed`, `removed`, `error`)
-- per ogni segnale rilevante: fonte, tipo, azione suggerita
-- fonti senza segnale: ok, nessuna azione
+- conteggio segnali per tipo
+- per ogni segnale rilevante:
+  - fonte
+  - tipo
+  - affidabilita' dell'adapter
+  - azione suggerita
+- fonti senza segnale:
+  - `ok, nessuna azione`
 
----
+## Errori tipici
+
+- trattare `changed` come rerun automatico
+- scambiare rumore HTML per cambio vero
+- leggere `error` infrastrutturali come problema del dataset
+- tenere nel monitor fonti che quasi non producono mai decisioni utili
+- allargare il monitor a nuove fonti solo per entusiasmo
 
 ## Regole di interpretazione
 
 - `changed` non implica rerun automatico: dipende dal tipo di cambio
-- `removed` dopo modifiche alla config del monitor è spesso rumore: confrontare la pagina/API prima di assumere una rottura
-- `error` ripetuti sulla stessa fonte per SSL/DNS/HTML fragile: valutare demotion a `radar-only`
-- Il monitor non valuta il valore civico della fonte: quella è una decisione umana o di `source-check`
-- Se `di_candidate` è presente nella config della fonte, ispezionarlo sempre prima di decidere
-- Se il segnale non porta quasi mai a una decisione utile, la fonte forse non dovrebbe stare nel monitor
+- `removed` dopo modifiche alla config del monitor puo' essere rumore: verificare prima la pagina o API
+- `error` ripetuti per SSL, DNS o HTML fragile suggeriscono un problema di perimetro del monitor
+- il monitor non valuta il valore civico della fonte: quello resta umano o da `source-check`
+- se `di_candidate` e' presente, ispezionalo sempre prima di decidere
 
----
+## Output minimo atteso
 
-## STOP POINT
+Un run buono di `resource-monitor` lascia:
 
-Fermarsi dopo la sintesi. Non aprire issue, non rilanciare candidate, non modificare
-il set monitorato senza istruzione esplicita.
+- `latest.md` aggiornato
+- segnali classificati per tipo
+- azione suggerita per ogni segnale rilevante
+- nessuna decisione automatica presa al posto del maintainer
 
-Segnali urgenti: marcarli con
-`[ATTENZIONE]` e aspettare istruzioni.
+## Definition of done
 
----
+Il workflow e' chiuso bene quando:
 
-## Vincoli
+- il report e' aggiornato e leggibile
+- ogni segnale rilevante ha un next step umano plausibile
+- i segnali infrastrutturali non sono stati scambiati per cambi del dataset
+- non sono state aperte issue o rilanciati candidate automaticamente
+- se il monitor sembra inutile su una fonte, questo emerge chiaramente nella sintesi
 
-- Niente emoji, niente em dash
-- Non modificare `resource_monitor.sources.yml` senza istruzione esplicita
-- Non spostare fonti in `radar-only` da soli: proporlo a Gabri
-- Non allargare il monitor a nuove fonti solo perché sono interessanti: prima serve una giustificazione forte
+## Stati finali ammessi
 
----
+- `new`
+- `changed`
+- `removed`
+- `error`
 
-## Riferimenti
+## Dove orientarsi
 
-- Script: `source-observatory/scripts/monitor/resource_monitor.py`
-- Config: `source-observatory/scripts/monitor/resource_monitor.sources.yml`
-- Output: `source-observatory/data/monitor/reports/latest.md`
-- Runbook: `source-observatory/docs/runbook.md`
+- [README.md](../README.md)
+- [docs/runbook.md](../docs/runbook.md)
+- [docs/architecture.md](../docs/architecture.md)

--- a/workflows/resource-monitor.md
+++ b/workflows/resource-monitor.md
@@ -1,3 +1,13 @@
+---
+name: resource-monitor
+description: Workflow canonico del Source Observatory per monitorare un insieme ristretto di risorse note e suggerire un next step umano.
+license: MIT
+metadata:
+  version: "1.2"
+  owner: "DataCivicLab"
+  tags: [source-observatory, resource-monitor, monitoring, follow-up]
+---
+
 # Workflow: resource-monitor
 
 Workflow canonico di `source-observatory` per il monitor di un insieme ristretto di risorse note.
@@ -40,9 +50,9 @@ Non usarlo quando:
 - il caso e' meglio descritto da `catalog-watch`
 - il monitor non porta quasi mai a decisioni utili
 
-## Input minimi
+## Preconditions minime
 
-Per partire servono almeno:
+Prima del run dovrebbero esserci almeno:
 
 - config fonti:
   - `source-observatory/scripts/monitor/resource_monitor.sources.yml`
@@ -51,11 +61,6 @@ Per partire servono almeno:
   - `source-observatory/scripts/monitor/resource_monitor.py`
 - output atteso:
   - `source-observatory/data/monitor/reports/latest.md`
-
-## Preconditions minime
-
-Prima del run dovrebbero esserci almeno:
-
 - una fonte Tier 1 o equivalente, gia' giustificata
 - un adapter abbastanza chiaro
 - un next step plausibile se compare un vero segnale
@@ -189,5 +194,6 @@ Il workflow e' chiuso bene quando:
 ## Dove orientarsi
 
 - [README.md](../README.md)
+- [workflows/README.md](./README.md)
 - [docs/runbook.md](../docs/runbook.md)
 - [docs/architecture.md](../docs/architecture.md)

--- a/workflows/resource-monitor.md
+++ b/workflows/resource-monitor.md
@@ -3,7 +3,7 @@ name: resource-monitor
 description: Workflow canonico del Source Observatory per monitorare un insieme ristretto di risorse note e suggerire un next step umano.
 license: MIT
 metadata:
-  version: "1.2"
+  version: "1.3"
   owner: "DataCivicLab"
   tags: [source-observatory, resource-monitor, monitoring, follow-up]
 ---
@@ -11,7 +11,13 @@ metadata:
 # Workflow: resource-monitor
 
 Workflow canonico di `source-observatory` per il monitor di un insieme ristretto di risorse note.
-Versione: 1.2 - 2026-04-08
+Versione: 1.3 - 2026-04-09
+
+Nota di stato:
+
+- `resource-monitor` e' congelato come utility legacy su poche fonti gia' presenti
+- non e' il punto di ingresso per nuove fonti o nuovi candidate
+- i futuri source ping orientati al dataset vivranno preferibilmente in `dataset-incubator`, vicino al candidate
 
 ## Obiettivo di fase
 
@@ -42,6 +48,7 @@ Usalo quando:
 - la fonte e' gia' importante per il Lab
 - esiste un next step plausibile se il segnale cambia
 - il monitor costa meno di uno scouting umano ripetuto
+- la fonte e' gia' una delle poche monitorate, non un nuovo ingresso nel funnel
 
 Non usarlo quando:
 
@@ -49,6 +56,7 @@ Non usarlo quando:
 - il caso e' meglio descritto da `radar-check`
 - il caso e' meglio descritto da `catalog-watch`
 - il monitor non porta quasi mai a decisioni utili
+- stai valutando se aggiungere una nuova fonte: quel gate passa prima da `portal-scout`, `source-check` o DI
 
 ## Preconditions minime
 
@@ -77,6 +85,7 @@ Fermati e non forzare conclusioni quando:
 - il cambio osservato dipende da rumore HTML o da fragilita' dell'adapter
 - non esiste un next step difendibile anche se il segnale fosse vero
 - stai per trattare un `changed` come rerun automatico senza leggere il tipo di cambio
+- stai per usare `resource-monitor` come canale per nuove fonti: il monitor e' congelato e non va esteso
 
 ## Passi canonici
 

--- a/workflows/resource-monitor.md
+++ b/workflows/resource-monitor.md
@@ -10,23 +10,18 @@ metadata:
 
 # Workflow: resource-monitor
 
-Workflow canonico di `source-observatory` per il monitor di un insieme ristretto di risorse note.
-Versione: 1.3 - 2026-04-09
+Workflow canonico di `source-observatory`.
+Versione: 1.3 - 2026-04-10
 
 Nota di stato:
 
-- `resource-monitor` e' congelato come utility legacy su poche fonti gia' presenti
-- non e' il punto di ingresso per nuove fonti o nuovi candidate
+- `resource-monitor` e congelato come utility legacy su poche fonti gia presenti
+- non e il punto di ingresso per nuove fonti o nuovi candidate
 - i futuri source ping orientati al dataset vivranno preferibilmente in `dataset-incubator`, vicino al candidate
 
 ## Obiettivo di fase
 
 Rilevare cambi su un insieme molto ristretto di fonti note e capire se il segnale osservato richiede davvero un next step umano sul dataset.
-
-Questo workflow serve a rispondere a:
-
-- questa fonte nota e' cambiata in modo da richiedere lavoro sul dataset?
-- il segnale osservato e' un vero cambio di risorsa o solo rumore di monitoraggio?
 
 Questo workflow serve a:
 
@@ -43,24 +38,24 @@ Non serve a:
 
 ## Quando usarlo
 
-Usalo quando:
+Usarlo quando:
 
-- la fonte e' gia' importante per il Lab
+- la fonte e gia importante per il Lab
 - esiste un next step plausibile se il segnale cambia
 - il monitor costa meno di uno scouting umano ripetuto
-- la fonte e' gia' una delle poche monitorate, non un nuovo ingresso nel funnel
+- la fonte e gia una delle poche monitorate, non un nuovo ingresso nel funnel
 
 Non usarlo quando:
 
-- la fonte e' ancora solo interessante ma non ancora centrale
-- il caso e' meglio descritto da `radar-check`
-- il caso e' meglio descritto da `catalog-watch`
+- la fonte e ancora solo interessante ma non ancora centrale
+- il caso e meglio descritto da `radar-check`
+- il caso e meglio descritto da `catalog-watch`
 - il monitor non porta quasi mai a decisioni utili
-- stai valutando se aggiungere una nuova fonte: quel gate passa prima da `portal-scout`, `source-check` o DI
+- stai valutando se aggiungere una nuova fonte
 
 ## Preconditions minime
 
-Prima del run dovrebbero esserci almeno:
+Per partire servono:
 
 - config fonti:
   - `source-observatory/scripts/monitor/resource_monitor.sources.yml`
@@ -69,7 +64,7 @@ Prima del run dovrebbero esserci almeno:
   - `source-observatory/scripts/monitor/resource_monitor.py`
 - output atteso:
   - `source-observatory/data/monitor/reports/latest.md`
-- una fonte Tier 1 o equivalente, gia' giustificata
+- una fonte Tier 1 o equivalente, gia giustificata
 - un adapter abbastanza chiaro
 - un next step plausibile se compare un vero segnale
 
@@ -79,13 +74,13 @@ Nel dubbio:
 
 ## Stop rules
 
-Fermati e non forzare conclusioni quando:
+Fermarsi quando:
 
-- il segnale e' chiaramente infrastrutturale e appartiene a `radar-check`
-- il cambio osservato dipende da rumore HTML o da fragilita' dell'adapter
+- il segnale e chiaramente infrastrutturale e appartiene a `radar-check`
+- il cambio osservato dipende da rumore HTML o da fragilita dell'adapter
 - non esiste un next step difendibile anche se il segnale fosse vero
 - stai per trattare un `changed` come rerun automatico senza leggere il tipo di cambio
-- stai per usare `resource-monitor` come canale per nuove fonti: il monitor e' congelato e non va esteso
+- stai per usare `resource-monitor` come canale per nuove fonti
 
 ## Passi canonici
 
@@ -93,10 +88,10 @@ Fermati e non forzare conclusioni quando:
 
 Prima del run, chiediti:
 
-- questa fonte e' davvero un caso da monitor ristretto?
+- questa fonte e davvero un caso da monitor ristretto?
 - esiste un next step plausibile se il segnale cambia?
 
-Se la risposta e' no, il problema puo' essere nel perimetro del monitor, non nel dataset.
+Se la risposta e no, il problema puo essere nel perimetro del monitor, non nel dataset.
 
 ### 2. Esegui il monitor
 
@@ -108,25 +103,23 @@ python source-observatory/scripts/monitor/resource_monitor.py --sources source-o
 
 ### 3. Leggi `latest.md`
 
-Leggi:
+Leggere `source-observatory/data/monitor/reports/latest.md`.
 
-- `source-observatory/data/monitor/reports/latest.md`
-
-Classifica ogni segnale in una di queste classi:
+Classificare ogni segnale in una di queste classi:
 
 | Tipo | Significato |
 |---|---|
 | `new` | risorsa comparsa per la prima volta |
 | `changed` | URL, nome, formato o metadati modificati |
-| `removed` | risorsa presente in precedenza non piu' visibile |
+| `removed` | risorsa presente in precedenza non piu visibile |
 | `error` | problema di adapter o di portale |
 
-### 4. Valuta l'affidabilita' dell'adapter
+### 4. Valuta l'affidabilita dell'adapter
 
 Regola pratica:
 
-- `single_url` o `ckan` = segnale piu' affidabile
-- `html` = piu' sospetto, aspettati piu' falsi positivi
+- `single_url` o `ckan` = segnale piu affidabile
+- `html` = piu sospetto, aspettati piu falsi positivi
 
 Se il segnale viene da un adapter fragile:
 
@@ -145,15 +138,15 @@ Per ogni segnale non nullo, usa questa logica:
 | errore SSL/DNS/timeout | problema da radar, non da dataset |
 | nessun next step difendibile | proporre demotion o rimozione dal monitor |
 
-### 6. Fai una sintesi breve
+### 6. Produci la sintesi
 
-La sintesi dovrebbe lasciare:
+La sintesi deve lasciare:
 
 - conteggio segnali per tipo
 - per ogni segnale rilevante:
   - fonte
   - tipo
-  - affidabilita' dell'adapter
+  - affidabilita dell'adapter
   - azione suggerita
 - fonti senza segnale:
   - `ok, nessuna azione`
@@ -166,14 +159,6 @@ La sintesi dovrebbe lasciare:
 - tenere nel monitor fonti che quasi non producono mai decisioni utili
 - allargare il monitor a nuove fonti solo per entusiasmo
 
-## Regole di interpretazione
-
-- `changed` non implica rerun automatico: dipende dal tipo di cambio
-- `removed` dopo modifiche alla config del monitor puo' essere rumore: verificare prima la pagina o API
-- `error` ripetuti per SSL, DNS o HTML fragile suggeriscono un problema di perimetro del monitor
-- il monitor non valuta il valore civico della fonte: quello resta umano o da `source-check`
-- se `di_candidate` e' presente, ispezionalo sempre prima di decidere
-
 ## Output minimo atteso
 
 Un run buono di `resource-monitor` lascia:
@@ -185,9 +170,9 @@ Un run buono di `resource-monitor` lascia:
 
 ## Definition of done
 
-Il workflow e' chiuso bene quando:
+Il workflow e chiuso bene quando:
 
-- il report e' aggiornato e leggibile
+- il report e aggiornato e leggibile
 - ogni segnale rilevante ha un next step umano plausibile
 - i segnali infrastrutturali non sono stati scambiati per cambi del dataset
 - non sono state aperte issue o rilanciati candidate automaticamente

--- a/workflows/source-check.md
+++ b/workflows/source-check.md
@@ -3,7 +3,7 @@ name: source-check
 description: Workflow canonico del Source Observatory per verificare se una fonte pubblica regge davvero come pista del Lab e merita un passo successivo.
 license: MIT
 metadata:
-  version: "0.2"
+  version: "1.0"
   owner: "DataCivicLab"
   tags: [source-observatory, source-check, scouting, datasets]
 ---
@@ -11,7 +11,7 @@ metadata:
 # Workflow: source-check
 
 Workflow canonico del Source Observatory.
-Versione: 0.2 - 2026-04-08
+Versione: 1.0 - 2026-04-08
 
 ## Obiettivo di fase
 

--- a/workflows/source-check.md
+++ b/workflows/source-check.md
@@ -3,7 +3,7 @@ name: source-check
 description: Workflow canonico del Source Observatory per verificare se una fonte pubblica regge davvero come pista del Lab e merita un passo successivo.
 license: MIT
 metadata:
-  version: "1.0"
+  version: "1.1"
   owner: "DataCivicLab"
   tags: [source-observatory, source-check, scouting, datasets]
 ---
@@ -11,7 +11,7 @@ metadata:
 # Workflow: source-check
 
 Workflow canonico del Source Observatory.
-Versione: 1.0 - 2026-04-08
+Versione: 1.1 - 2026-04-09
 
 ## Obiettivo di fase
 
@@ -58,14 +58,6 @@ Non usarlo quando:
 - sei gia' in intake o pipeline
 - stai facendo solo un health check del portale
 - il lavoro vero e' monitoraggio ricorrente e non valutazione della fonte
-
-## Input minimi
-
-Per partire servono almeno:
-
-- URL, pagina o endpoint reale
-- contesto minimo su che cosa dovrebbe contenere la fonte
-- una ragione concreta per cui potrebbe valere la pena guardarla
 
 ## Preconditions minime
 
@@ -133,6 +125,26 @@ Se il dato e' abbastanza strutturato, prova anche a estrarre:
 - campi principali
 - dimensioni confermate
 - rischio semantico principale
+
+### 3b. Verifica la sufficienza semantica per un v0
+
+Prima di procedere, rispondi in modo esplicito:
+
+1. il dato e' leggibile direttamente?
+2. le variabili chiave sono interpretabili standalone?
+3. esiste un output minimo utile senza join o metadata esterni obbligatori?
+
+Usa queste domande per distinguere tra:
+
+- fonte autosufficiente per un `v0`
+- fonte accessibile ma utile solo con enrichment
+- fonte troppo opaca o troppo scarna per reggere DI
+
+Qualificatore da annotare nella nota locale:
+
+- `self-contained`
+- `usable-with-enrichment`
+- `too-thin-for-v0`
 
 ### 4. Formula la domanda civica
 
@@ -247,6 +259,7 @@ Un source-check buono lascia:
 - domanda civica plausibile
 - perimetro v0 iniziale, se il caso regge
 - un verdict unico e leggibile
+- un qualificatore di sufficienza semantica
 - una nota locale riusabile
 - un next step esplicito
 
@@ -256,6 +269,7 @@ Il workflow e' chiuso bene quando:
 
 - il check non confonde fonte viva e fonte utile
 - il livello di accesso e' dichiarato in modo onesto
+- la sufficienza semantica del `v0` e' resa esplicita
 - il verdetto finale e' unico e coerente
 - esiste un next step plausibile se il verdetto e' positivo
 - esiste una nota locale che permette di riprendere il caso
@@ -268,6 +282,12 @@ Il workflow e' chiuso bene quando:
 - `support dataset`
 - `aggiorna artefatto esistente`
 - `no-go`
+
+Qualificatori ammessi da annotare accanto al verdetto:
+
+- `self-contained`
+- `usable-with-enrichment`
+- `too-thin-for-v0`
 
 ## Dove orientarsi
 

--- a/workflows/source-check.md
+++ b/workflows/source-check.md
@@ -1,41 +1,185 @@
 ---
 name: source-check
-description: Workflow pubblico/light del Source Observatory per verificare se una fonte pubblica regge davvero come pista del Lab. Usare quando serve distinguere una fonte viva da una fonte che merita davvero un passo successivo.
+description: Workflow canonico del Source Observatory per verificare se una fonte pubblica regge davvero come pista del Lab e merita un passo successivo.
 license: MIT
 metadata:
-  version: "0.1"
+  version: "0.2"
   owner: "DataCivicLab"
   tags: [source-observatory, source-check, scouting, datasets]
 ---
 
 # Workflow: source-check
 
-Workflow pubblico/light del Source Observatory.
-Versione: 0.1 - 2026-04-01
-
----
+Workflow canonico del Source Observatory.
+Versione: 0.2 - 2026-04-08
 
 ## Obiettivo di fase
 
-Decidere se una fonte o un dataset pubblico merita un passo successivo del Lab.
+Decidere se una fonte o un dataset pubblico merita davvero un passo successivo del Lab.
 
 Questo workflow serve a rispondere a:
 
 - la fonte e' davvero accessibile?
-- formato e granularita' reggono?
-- la domanda civica e' plausibile?
-- conviene consolidare il caso oppure no?
+- formato, granularita' e copertura reggono?
+- esiste una domanda civica plausibile?
+- il caso merita un passo successivo oppure no?
+
+Questo workflow serve a:
+
+- verificare accesso reale e forma minima della fonte
+- distinguere tra fonte viva e fonte davvero utile
+- chiudere con un verdict unico e leggibile
+- chiarire un perimetro v0 plausibile quando la fonte regge
+- lasciare una nota locale che permetta al filone di muoversi nel funnel del Lab
 
 Non serve a:
 
-- aprire automaticamente issue, PR o discussion
+- aprire automaticamente issue, PR o Discussion
 - fare intake in `dataset-incubator`
 - fare monitoraggio continuo
 - sostituire `radar-check`, `catalog-watch` o `resource-monitor`
 
-## Output minimo atteso
+## Quando usarlo
 
-Una nota o checklist verificata che chiuda con un solo verdict:
+Usalo quando hai gia':
+
+- una fonte nuova che sembra promettente
+- una URL, pagina o dataset reale da verificare
+- un sospetto ragionevole che possa reggere un filone o un support dataset
+
+Usalo anche quando:
+
+- `catalog-watch` o `resource-monitor` segnalano un caso che merita verifica umana
+- un portale e' vivo ma non e' ancora chiaro se il dato valga davvero
+
+Non usarlo quando:
+
+- la fonte e' gia' stata verificata e devi solo lavorare il passo successivo
+- sei gia' in intake o pipeline
+- stai facendo solo un health check del portale
+- il lavoro vero e' monitoraggio ricorrente e non valutazione della fonte
+
+## Input minimi
+
+Per partire servono almeno:
+
+- URL, pagina o endpoint reale
+- contesto minimo su che cosa dovrebbe contenere la fonte
+- una ragione concreta per cui potrebbe valere la pena guardarla
+
+## Preconditions minime
+
+Prima di fare un source-check dovrebbe esserci almeno:
+
+- una fonte o pagina concreta, non solo un tema generico
+- un possibile uso o domanda, anche ancora grezzo
+- un next step plausibile se il caso regge
+
+Nel dubbio:
+
+- se non hai ancora una fonte concreta, non sei in source-check ma ancora in scouting generico
+
+## Stop rules
+
+Fermati e non forzare source-check quando:
+
+- hai solo un tema astratto ma non una fonte reale
+- il caso appartiene ancora a `radar-check` o `catalog-watch`
+- il caso e' gia' abbastanza maturo da richiedere direttamente un workflow successivo
+- stai per aprire automaticamente artifact pubblici senza aver chiuso il verdetto
+- la fonte e' cosi' opaca che non riesci a verificare neppure il minimo accesso reale
+
+## Passi canonici
+
+### 1. Parti dalla fonte reale
+
+Usa come base:
+
+- pagina ufficiale
+- file diretto
+- endpoint
+- catalogo
+
+Non partire da descrizioni di terzi se puoi verificare la fonte primaria.
+
+### 2. Verifica l'accesso reale
+
+Controlla con strumenti reali:
+
+- URL o endpoint raggiungibile
+- file o metadata leggibili davvero
+- redirect, login, JavaScript o WAF, se presenti
+- eventuale opacita' dichiarata in modo esplicito
+
+Distinguere sempre tra:
+
+- `verificato`
+- `inferito`
+
+Se il file non e' accessibile ma il pattern sembra plausibile, dillo chiaramente. Non fingere accesso pieno.
+
+### 3. Verifica la shape minima del dato
+
+Controlla almeno:
+
+- formato
+- granularita'
+- copertura temporale o geografica
+- una riga rappresenta cosa
+- misura o struttura principale
+
+Se il dato e' abbastanza strutturato, prova anche a estrarre:
+
+- campi principali
+- dimensioni confermate
+- rischio semantico principale
+
+### 4. Formula la domanda civica
+
+Scrivi in una riga:
+
+- quale domanda civica la fonte potrebbe sostenere
+- perche' non e' solo descrittiva o inventariale
+
+Se non riesci a formulare una domanda leggibile, e' spesso un segnale che il caso apre male.
+
+### 5. Fissa un perimetro v0 plausibile
+
+Se la fonte regge, indica:
+
+- geografia o universo iniziale consigliato
+- anni o finestra temporale iniziale
+- dimensioni da tenere nel v0
+- dimensioni da lasciare fuori all'inizio
+
+Regola pratica:
+
+- meglio un v0 piu' stretto ma difendibile che una fonte ampia con perimetro confuso
+
+### 6. Controlla se il filone e' gia' vivo
+
+Prima di chiudere il verdetto, verifica se esiste gia' un artefatto rilevante del Lab sullo stesso caso.
+
+Controlla almeno se esiste gia':
+
+- una `Discussion Datasets`
+- una `Discussion Domande`
+- una `Discussion Analisi`
+- un candidate DI chiaramente aperto
+
+Se il filone e' gia' vivo, non aprire un doppione concettuale.
+
+In quel caso il verdetto tipico non e':
+
+- `go Discussion`
+
+ma:
+
+- `aggiorna artefatto esistente`
+
+### 7. Chiudi con un solo verdict
+
+Scegli un solo verdetto finale:
 
 - `go Discussion`
 - `watchlist`
@@ -43,95 +187,91 @@ Una nota o checklist verificata che chiuda con un solo verdict:
 - `aggiorna artefatto esistente`
 - `no-go`
 
-## Quando usarla
+Usa:
 
-Usarla quando:
-
-- una fonte nuova sembra promettente
-- un file o catalogo sembra vivo ma non e' ancora chiaro se valga davvero
-- un update osservato da `catalog-watch` o `resource-monitor` merita verifica umana
-
-Non usarla quando:
-
-- la fonte e' gia stata verificata e devi solo lavorare il passo successivo
-- sei gia in intake o pipeline
-- stai facendo solo un health check del portale
-
-## Workflow minimo
-
-### 1. Verifica l'accesso reale
-
-Controllare con strumenti reali:
-
-- URL o endpoint raggiungibile
-- file o metadata davvero leggibili
-- eventuale opacita' dichiarata esplicitamente
-
-Distinguere sempre tra:
-
-- verificato
-- inferito
-
-### 2. Verifica la shape minima
-
-Controllare almeno:
-
-- formato plausibile
-- granularita' utile
-- copertura temporale o geografica
-- presenza di una misura o struttura leggibile
-
-Se la fonte e' strutturata, estrarre anche:
-
-- indicatore o misura principale
-- dimensioni confermate
-- rischio semantico principale
-
-### 3. Formula la domanda civica
-
-Scrivere in una riga:
-
-- quale domanda civica permette di sostenere
-- perche' non e' solo descrittiva
-
-### 4. Fissa un perimetro v0 plausibile
-
-Se la fonte lo consente, indicare:
-
-- geografia o universo iniziale consigliato
-- anni o finestra temporale iniziale
-- dimensioni da tenere nel v0
-- dimensioni da lasciare fuori all'inizio
-
-### 5. Chiudi con un verdict
-
-Scegliere un solo verdetto:
-
-- `go Discussion` se la fonte regge davvero
+- `go Discussion` se la fonte regge davvero come pista autonoma
 - `watchlist` se e' promettente ma non ancora pronta
 - `support dataset` se serve soprattutto come join o supporto
-- `aggiorna artefatto esistente` se il filone e' gia vivo
+- `aggiorna artefatto esistente` se il filone e' gia' vivo e il passo giusto e' aggiornare, non aprire
 - `no-go` se accesso, formato o valore civico non reggono
 
-## Regole
+### 8. Produci sempre una nota locale
 
-- meglio `watchlist` chiaro che `go Discussion` debole
-- non forzare il funnel completo dentro questo workflow
-- non duplicare un artefatto pubblico gia esistente
-- non confondere fonte viva con fonte utile
+Il source-check non e' chiuso bene se resta solo come giudizio orale o mentale.
 
-## Come si collega al resto del repo
+Lascia sempre una nota locale con almeno:
 
-- `radar-check` dice se la fonte e' viva
-- `catalog-watch` dice se un catalogo segnala qualcosa di nuovo
-- `resource-monitor` dice se una resource Tier 1 e' cambiata
-- `source-check` decide se il caso regge davvero come pista del Lab
+- fonte e link principali
+- cosa e' stato verificato davvero
+- cosa e' solo inferito
+- shape minima del dato
+- domanda civica plausibile
+- perimetro v0 consigliato, se esiste
+- rischio o caveat principale
+- verdetto finale
+- prossimo passo
 
-## Prossimo passo tipico
+### 9. Lascia un next step esplicito
 
-Se il verdetto e' positivo:
+Il workflow si ferma al verdetto, ma il next step va comunque scritto in modo leggibile.
 
-- consolidare il caso in un artefatto pubblico del Lab
-- oppure preparare il passaggio verso il workflow di intake tecnico
+Pattern tipici:
 
-Il passaggio esatto dipende dal repo e dal contesto del filone.
+- `go Discussion`
+  - next step normale: preparare o aprire una `Discussion Datasets`
+- `aggiorna artefatto esistente`
+  - next step normale: aggiornare il filone gia' vivo, non aprirne uno nuovo
+- `watchlist`
+  - next step normale: lasciare un trigger di riapertura
+- `support dataset`
+  - next step normale: tenerlo come supporto, non come filone autonomo
+- `no-go`
+  - next step normale: fermarsi
+
+## Errori tipici
+
+- confondere una fonte viva con una fonte utile
+- fermarsi alla home page senza verificare il file o endpoint reale
+- non distinguere tra accesso verificato e accesso inferito
+- formulare una domanda troppo generica
+- allargare troppo presto il perimetro v0
+- usare `go Discussion` per entusiasmo anche quando sarebbe meglio `watchlist`
+- non controllare se il filone e' gia' vivo prima di dire `go Discussion`
+
+## Output minimo atteso
+
+Un source-check buono lascia:
+
+- fonte reale verificata o limite di accesso dichiarato
+- shape minima del dato
+- domanda civica plausibile
+- perimetro v0 iniziale, se il caso regge
+- un verdict unico e leggibile
+- una nota locale riusabile
+- un next step esplicito
+
+## Definition of done
+
+Il workflow e' chiuso bene quando:
+
+- il check non confonde fonte viva e fonte utile
+- il livello di accesso e' dichiarato in modo onesto
+- il verdetto finale e' unico e coerente
+- esiste un next step plausibile se il verdetto e' positivo
+- esiste una nota locale che permette di riprendere il caso
+- non sono stati aperti automaticamente artifact pubblici o pipeline
+
+## Stati finali ammessi
+
+- `go Discussion`
+- `watchlist`
+- `support dataset`
+- `aggiorna artefatto esistente`
+- `no-go`
+
+## Dove orientarsi
+
+- [README.md](../README.md)
+- [workflows/README.md](./README.md)
+- [docs/usage.md](../docs/usage.md)
+- [docs/architecture.md](../docs/architecture.md)


### PR DESCRIPTION
## Sintesi

Questa PR chiarisce il funnel operativo di `source-observatory` e rafforza i workflow gia' emersi nel lavoro locale.

## Cosa cambia

- chiarisce onboarding portali e differenza tra workflow, registry e inventory
- aggiunge il concetto di semantic sufficiency al workflow `source-check`
- congela `resource-monitor` come utility legacy su poche fonti gia' presenti

## Perche'

Nel repo i pezzi principali c'erano gia', ma mancava una sequenza piu' esplicita tra:

- `portal-scout`
- `catalog-watch`
- `catalog inventory`
- `source-check`
- `resource-monitor`

Questa PR rende quel boundary molto piu' leggibile senza introdurre nuove procedure parallele.

## Note

- PR solo editoriale / di workflow
- nessun cambiamento al builder tecnico o agli script
- il fix tecnico su `catalog inventory` e `INPS` resta in PR separata
