### PR TITLE
Aggiungi issue template per scouting SO

### DIFF
--- a/.github/ISSUE_TEMPLATE/catalog-inventory-scout.yml
+++ b/.github/ISSUE_TEMPLATE/catalog-inventory-scout.yml
@@ -1,0 +1,59 @@
+name: Catalog inventory scout
+description: Triage di un catalog inventory esistente per produrre una shortlist.
+title: "catalog-scout: <catalogo>"
+labels: ["catalog-scout", "scouting"]
+body:
+  - type: input
+    id: catalog_name
+    attributes:
+      label: Catalogo / fonte
+      placeholder: "ISTAT SDMX - catalog inventory"
+    validations:
+      required: true
+  - type: input
+    id: inventory_path
+    attributes:
+      label: Inventory path / riferimento
+      placeholder: "source-observatory/data/catalog_inventory/generated/catalog_inventory_latest.parquet"
+    validations:
+      required: true
+  - type: textarea
+    id: criteria
+    attributes:
+      label: Criteri di triage
+      description: "Cosa rende un item degno di source-check."
+      placeholder: "rilevanza civica, granularita comunale, assenza overlap"
+    validations:
+      required: true
+  - type: textarea
+    id: shortlist
+    attributes:
+      label: Shortlist proposta
+      description: "Elenco corto di item con motivazione e verdict."
+      placeholder: "- 47_940: servizi sociali comuni -> source-check (alta)"
+    validations:
+      required: true
+  - type: textarea
+    id: watchlist
+    attributes:
+      label: Watchlist / backlog
+      description: "Item interessanti ma non prioritari."
+    validations:
+      required: false
+  - type: textarea
+    id: caveats
+    attributes:
+      label: Caveat tecnici
+      description: "Limiti dell'inventory o del catalogo (metadata poveri, protocollo non supportato)."
+    validations:
+      required: false
+  - type: dropdown
+    id: verdict
+    attributes:
+      label: Esito
+      options:
+        - shortlist pronta per source-check
+        - serve inventory enriched
+        - not now
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/portal-scout.yml
+++ b/.github/ISSUE_TEMPLATE/portal-scout.yml
@@ -1,0 +1,73 @@
+name: Portal scout
+description: Classifica un portale e decide il prossimo passo del funnel SO.
+title: "portal-scout: <portale>"
+labels: ["portal-scout", "scouting"]
+body:
+  - type: input
+    id: portal_name
+    attributes:
+      label: Portale / fonte
+      placeholder: "OpenCoesione"
+    validations:
+      required: true
+  - type: input
+    id: portal_url
+    attributes:
+      label: URL principale
+      placeholder: "https://opencoesione.gov.it"
+    validations:
+      required: true
+  - type: dropdown
+    id: protocol
+    attributes:
+      label: Superficie osservabile principale
+      options:
+        - CKAN
+        - SDMX
+        - HTML (sitemap/listing)
+        - API custom
+        - SPARQL
+        - Altro
+    validations:
+      required: true
+  - type: textarea
+    id: surfaces
+    attributes:
+      label: Superfici osservabili
+      description: "Elenca le superfici rilevanti (catalogo, API, sitemap, download)."
+      placeholder: "- catalogo JSON\n- sitemap dataset"
+    validations:
+      required: true
+  - type: textarea
+    id: inventory_feasibility
+    attributes:
+      label: Inventariabile?
+      description: "Sì/no e con quale metodo."
+      placeholder: "Si, via sitemap dataset; no crawler generale."
+    validations:
+      required: true
+  - type: textarea
+    id: overlap
+    attributes:
+      label: Overlap con filoni esistenti
+      description: "Se esistono filoni simili, indicare."
+    validations:
+      required: false
+  - type: dropdown
+    id: verdict
+    attributes:
+      label: Verdict
+      options:
+        - go catalog-watch
+        - go source-check item-based
+        - radar-only
+        - not now
+    validations:
+      required: true
+  - type: textarea
+    id: next_step
+    attributes:
+      label: Next step consigliato
+      placeholder: "Aprire catalog-watch o fare 1-2 source-check mirati"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/source-check.yml
+++ b/.github/ISSUE_TEMPLATE/source-check.yml
@@ -1,0 +1,93 @@
+name: Source-check
+description: Verifica una fonte con accesso reale, shape, sufficienza semantica e verdict.
+title: "source-check: <fonte>"
+labels: ["source-check", "scouting"]
+body:
+  - type: input
+    id: source_name
+    attributes:
+      label: Fonte / nome breve
+      placeholder: "ISTAT 47_940 - Servizi sociali dei Comuni"
+    validations:
+      required: true
+  - type: input
+    id: source_url
+    attributes:
+      label: URL / endpoint principale
+      placeholder: "https://esploradati.istat.it/SDMXWS/rest/data/47_940"
+    validations:
+      required: true
+  - type: dropdown
+    id: protocol
+    attributes:
+      label: Protocollo / formato
+      options:
+        - SDMX
+        - CKAN
+        - CSV/Excel
+        - HTML
+        - RDF
+        - Altro
+    validations:
+      required: true
+  - type: textarea
+    id: access_probe
+    attributes:
+      label: Accesso reale (probe)
+      description: "Link o comando usato per verificare l'accesso reale."
+      placeholder: "GET ...?format=csv&detail=full"
+    validations:
+      required: true
+  - type: textarea
+    id: shape
+    attributes:
+      label: Shape / dimensioni chiave
+      description: "Dimensioni principali, granularita territoriale e temporale."
+      placeholder: "- REF_AREA: comuni\n- TIME_PERIOD: 2001-2024\n- DATA_TYPE: incidenti, morti, feriti"
+    validations:
+      required: true
+  - type: textarea
+    id: v0_scope
+    attributes:
+      label: Perimetro v0 proposto
+      description: "Quale v0 minimale sarebbe difendibile."
+      placeholder: "Comuni + ultimi 3-5 anni + misure base"
+    validations:
+      required: true
+  - type: dropdown
+    id: semantic_sufficiency
+    attributes:
+      label: Sufficienza semantica del v0
+      options:
+        - self-contained
+        - usable-with-enrichment
+        - too-thin-for-v0
+    validations:
+      required: true
+  - type: textarea
+    id: overlap
+    attributes:
+      label: Overlap con filoni esistenti
+      description: "Se esiste un filone simile, indicarlo."
+      placeholder: "MIT incidenti 2001-2018"
+    validations:
+      required: false
+  - type: dropdown
+    id: verdict
+    attributes:
+      label: Verdict
+      options:
+        - go Discussion
+        - watchlist
+        - support dataset
+        - aggiorna artefatto esistente
+        - not now
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Note finali
+      description: "Rischi, caveat, trigger per riaprire."
+    validations:
+      required: false


### PR DESCRIPTION
## Sintesi

Aggiunge issue template per rendere piu' disciplinati source-check, catalog-inventory-scout e portal-scout in source-observatory.

## Cosa cambia

- template source-check
- template catalog-inventory-scout
- template portal-scout

## Perche'

Riduce task locali e rende il funnel SO piu' tracciabile direttamente su GitHub.

## Note

- solo template, nessun cambio ai workflow o al builder
