### PR TITLE
Catalog-watch: Ministero Lavoro (SPOD CKAN)

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -145,6 +145,22 @@ consip_open_data:
     hanno confermato che il catalogo contiene almeno due target primari e un support
     dataset utile per il filone Consip acquisti PA.
   datasets_in_use: []
+lavoro_opendata:
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://dati.lavoro.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
+  last_probed: '2026-04-11'
+  catalog_baseline:
+    captured_at: '2026-04-11'
+    metric: package_count
+    value: 159
+    method: package_list
+    reliability: medium
+    note: Baseline iniziale su SPOD CKAN (package_list). Package_search count inaffidabile.
+  verdict: go
+  note: Portale Ministero del Lavoro (SPOD CKAN) con API stabile e catalogo ~159 dataset.
+  datasets_in_use: []
 mim_ustat:
   source_kind: catalog
   protocol: ckan


### PR DESCRIPTION
## Sintesi
Aggiunge il portale Open Data Ministero del Lavoro (SPOD CKAN) al registry come catalog-watch.

## Dettagli
- Entry: `lavoro_opendata`
- Protocollo: `ckan`
- Base URL: `/SpodCkanApi/api/3/action/package_list?limit=1`
- Baseline iniziale: `package_count = 159` (package_list)

## Note operative
- `package_search` count inaffidabile sul portale, quindi baseline basata su `package_list`.

## Riferimenti
Closes #60
