### PR TITLE
feat: add SPARQL catalog inventory adapter

### DIFF
--- a/data/catalog_inventory/README.md
+++ b/data/catalog_inventory/README.md
@@ -18,6 +18,7 @@ Sorgenti oggi inventariate in modo riproducibile:
 - `istat_sdmx`
 - `inps`
 - `openbdap`
+- `ispra_linked_data`
 
 Sorgenti osservate ma non inventariate automaticamente:
 - `anac`
@@ -46,8 +47,8 @@ Colonne chiave:
 - `captured_at`: timestamp UTC del run inventory
 - `source_id`: id della fonte nel registry (`istat_sdmx`, `inps`, `openbdap`, ...)
 - `source_kind`: oggi atteso `catalog`
-- `protocol`: protocollo della fonte (`ckan`, `sdmx`)
-- `inventory_method`: metodo usato per l'enumerazione (`package_search`, `package_list`, `dataflow_count`)
+- `protocol`: protocollo della fonte (`ckan`, `sdmx`, `sparql`)
+- `inventory_method`: metodo usato per l'enumerazione (`package_search`, `package_list`, `dataflow_count`, `sparql_query`)
 - `item_kind`: tipo di item (`dataset` o `dataflow`)
 - `item_id`: identificativo tecnico dell'item
 - `item_name`: nome macchina o slug quando disponibile
@@ -62,6 +63,8 @@ Nota operativa:
 - per cataloghi CKAN il builder prova in ordine `package_search`, `current_package_list_with_resources`, `package_list`
 - `current_package_list_with_resources` e' disabilitato per `inps` in ambiente locale Windows per instabilita SSL/GIL (fall-back diretto a `package_list` con warning esplicito)
 - la logica di enrichment resta attiva per altri cataloghi CKAN futuri
+- per cataloghi SPARQL il builder usa solo query dichiarate nel registry o template espliciti; il pilot iniziale è `dcat_datasets`
+- il template SPARQL generico enumera dataset e metadati DCAT leggeri; query custom possono aggiungere campi opzionali come `distribution_url`, `distribution_count` e `format`
 
 ## Workflow
 

--- a/data/catalog_inventory/README.md
+++ b/data/catalog_inventory/README.md
@@ -64,7 +64,8 @@ Nota operativa:
 - `current_package_list_with_resources` e' disabilitato per `inps` in ambiente locale Windows per instabilita SSL/GIL (fall-back diretto a `package_list` con warning esplicito)
 - la logica di enrichment resta attiva per altri cataloghi CKAN futuri
 - per cataloghi SPARQL il builder usa solo query dichiarate nel registry o template espliciti; il pilot iniziale è `dcat_datasets`
-- il template SPARQL generico enumera dataset e metadati DCAT leggeri; query custom possono aggiungere campi opzionali come `distribution_url`, `distribution_count` e `format`
+- il template SPARQL generico enumera dataset e metadati DCAT leggeri; non popola `distribution_url`, `distribution_count` o `format`
+- per SPARQL `tags` resta vuoto e i temi DCAT stanno nel campo opzionale `theme`; query custom possono aggiungere campi opzionali come `distribution_url`, `distribution_count` e `format`
 
 ## Workflow
 

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -125,6 +125,29 @@ dati_camera:
   note: Aggiunto endpoint SPARQL come radar-only per monitoraggio infrastrutturale
     di base.
   datasets_in_use: []
+ispra_linked_data:
+  source_kind: catalog
+  protocol: sparql
+  observation_mode: catalog-watch
+  base_url: https://dati.isprambiente.it/sparql
+  last_probed: '2026-04-11'
+  catalog_baseline:
+    captured_at: '2026-04-11'
+    metric: dataset_count
+    value: 66
+    method: sparql_query
+    query_name: dcat_datasets
+    reliability: medium
+    note: Baseline fissata con query DCAT dichiarata su dataset distinti.
+  sparql:
+    endpoint_url: https://dati.isprambiente.it/sparql
+    query_name: dcat_datasets
+    limit: 5000
+  verdict: go
+  note: Catalogo linked-data ISPRA con metadati DCAT interrogabili via SPARQL.
+    Pilot per inventory SPARQL; non sostituisce le fonti operative ISPRA già usate
+    per pipeline tabellari.
+  datasets_in_use: []
 consip_open_data:
   source_kind: catalog
   protocol: ckan

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -528,7 +528,7 @@ def collect_sparql_inventory(
                 "item_name": compact_uri_name(dataset_uri),
                 "title": row_state["title"],
                 "organization": row_state["publisher"],
-                "tags": ", ".join(themes) if themes else None,
+                "tags": None,
                 "notes_excerpt": description[:300] if description else None,
                 "source_url": endpoint,
                 "ordinal": idx,
@@ -657,9 +657,9 @@ def collect_inventory(
             source_cfg["_inventory_warning"] = warning
         return rows
     if protocol == "sparql":
-        rows, warning = collect_sparql_inventory(source_id, source_cfg, captured_at)
-        if warning:
-            source_cfg["_inventory_warning"] = warning
+        rows, summary = collect_sparql_inventory(source_id, source_cfg, captured_at)
+        if summary:
+            source_cfg["_inventory_summary"] = summary
         return rows
     raise ValueError(f"Unsupported protocol for catalog inventory: {protocol}")
 
@@ -731,6 +731,9 @@ def main() -> None:
             warning = source_cfg.pop("_inventory_warning", None)
             if warning:
                 source_report["warning"] = warning
+            summary = source_cfg.pop("_inventory_summary", None)
+            if summary:
+                source_report["summary"] = summary
             report["sources"][source_id] = source_report
         except Exception as exc:
             report["sources"][source_id] = {

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -36,10 +36,34 @@ CKAN_SKIP_PACKAGE_SEARCH = {"lavoro_opendata"}
 CKAN_SKIP_CURRENT_LIST = {"inps", "lavoro_opendata"}
 SDMX_RETRYABLE_STATUS_CODES = {500, 502, 503, 504}
 SDMX_RETRY_DELAYS_SECONDS = (2, 5)
+SPARQL_QUERY_TEMPLATES = {
+    "dcat_datasets": """
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+SELECT DISTINCT ?dataset ?title ?description ?publisherName ?issued ?modified ?landingPage ?theme
+WHERE {
+  ?dataset a dcat:Dataset .
+  OPTIONAL { ?dataset dct:title ?title . }
+  OPTIONAL { ?dataset dct:description ?description . }
+  OPTIONAL {
+    ?dataset dct:publisher ?publisher .
+    OPTIONAL { ?publisher foaf:name ?publisherName . }
+  }
+  OPTIONAL { ?dataset dct:issued ?issued . }
+  OPTIONAL { ?dataset dct:modified ?modified . }
+  OPTIONAL { ?dataset dcat:landingPage ?landingPage . }
+  OPTIONAL { ?dataset dcat:theme ?theme . }
+}
+ORDER BY ?dataset
+LIMIT {limit}
+""".strip()
+}
 
 
 def supported_protocols() -> set[str]:
-    return {"ckan", "sdmx"}
+    return {"ckan", "sdmx", "sparql"}
 
 
 def now_utc_iso() -> str:
@@ -358,6 +382,182 @@ def parse_sdmx_name(name_elem: ET.Element | None) -> str | None:
     return text or None
 
 
+def sparql_binding_value(binding: dict[str, Any], name: str) -> str | None:
+    value = (binding.get(name) or {}).get("value")
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def compact_uri_name(uri: str | None) -> str | None:
+    if not uri:
+        return None
+    value = uri.rstrip("/")
+    if "#" in value:
+        return value.rsplit("#", 1)[-1] or value
+    return value.rsplit("/", 1)[-1] or value
+
+
+def append_unique(values: list[str], value: str | None) -> None:
+    if value and value not in values:
+        values.append(value)
+
+
+def parse_int(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def build_sparql_query(source_cfg: dict[str, Any]) -> tuple[str, str]:
+    sparql_cfg = source_cfg.get("sparql") or {}
+    query_name = sparql_cfg.get("query_name") or source_cfg.get(
+        "catalog_baseline", {}
+    ).get("query_name")
+    query_text = sparql_cfg.get("query")
+    if not query_text:
+        query_name = query_name or "dcat_datasets"
+        query_text = SPARQL_QUERY_TEMPLATES.get(query_name)
+    if not query_text:
+        raise ValueError(f"SPARQL query template not found: {query_name}")
+    limit = int(sparql_cfg.get("limit", 5000))
+    if "{limit}" in query_text:
+        query_text = query_text.replace("{limit}", str(limit))
+    return query_text, query_name or "custom"
+
+
+def collect_sparql_inventory(
+    source_id: str, source_cfg: dict[str, Any], captured_at: str
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    sparql_cfg = source_cfg.get("sparql") or {}
+    endpoint = sparql_cfg.get("endpoint_url") or source_cfg["base_url"]
+    query_text, query_name = build_sparql_query(source_cfg)
+    response = requests.get(
+        endpoint,
+        params={"query": query_text, "format": "application/sparql-results+json"},
+        headers={
+            "Accept": "application/sparql-results+json",
+            "User-Agent": "DataCivicLab Source Observatory",
+        },
+        timeout=int(sparql_cfg.get("timeout_seconds", 60)),
+    )
+    response.raise_for_status()
+    payload = response.json()
+    bindings = ((payload.get("results") or {}).get("bindings")) or []
+    if not isinstance(bindings, list):
+        raise ValueError(
+            f"Unexpected SPARQL payload for {source_id}: bindings is not a list"
+        )
+
+    by_dataset: dict[str, dict[str, Any]] = {}
+    for binding in bindings:
+        dataset_uri = sparql_binding_value(binding, "dataset")
+        if not dataset_uri:
+            continue
+        row_state = by_dataset.setdefault(
+            dataset_uri,
+            {
+                "title": None,
+                "description": None,
+                "publisher": None,
+                "issued": None,
+                "modified": None,
+                "landing_page": None,
+                "distribution_count": None,
+                "distribution_urls": [],
+                "formats": [],
+                "themes": [],
+            },
+        )
+        row_state["title"] = row_state["title"] or sparql_binding_value(
+            binding, "title"
+        )
+        row_state["description"] = row_state["description"] or sparql_binding_value(
+            binding, "description"
+        )
+        row_state["publisher"] = row_state["publisher"] or sparql_binding_value(
+            binding, "publisherName"
+        )
+        row_state["issued"] = row_state["issued"] or sparql_binding_value(
+            binding, "issued"
+        )
+        row_state["modified"] = row_state["modified"] or sparql_binding_value(
+            binding, "modified"
+        )
+        row_state["landing_page"] = row_state["landing_page"] or sparql_binding_value(
+            binding, "landingPage"
+        )
+        row_state["distribution_count"] = row_state["distribution_count"] or parse_int(
+            sparql_binding_value(binding, "distributionCount")
+        )
+        append_unique(
+            row_state["distribution_urls"],
+            sparql_binding_value(binding, "distributionURL")
+            or sparql_binding_value(binding, "distributionUrl")
+            or sparql_binding_value(binding, "distribution_url")
+            or sparql_binding_value(binding, "downloadURL")
+            or sparql_binding_value(binding, "accessURL")
+            or sparql_binding_value(binding, "distribution"),
+        )
+        append_unique(row_state["formats"], sparql_binding_value(binding, "format"))
+        append_unique(row_state["themes"], sparql_binding_value(binding, "theme"))
+
+    rows: list[dict[str, Any]] = []
+    inventory_method = source_cfg.get("catalog_baseline", {}).get(
+        "method", "sparql_query"
+    )
+    for idx, (dataset_uri, row_state) in enumerate(by_dataset.items(), start=1):
+        description = row_state["description"]
+        distribution_urls = row_state["distribution_urls"]
+        distribution_count = row_state["distribution_count"]
+        formats = row_state["formats"]
+        themes = row_state["themes"]
+        rows.append(
+            {
+                "captured_at": captured_at,
+                "source_id": source_id,
+                "source_kind": source_cfg.get("source_kind"),
+                "protocol": source_cfg.get("protocol"),
+                "inventory_method": inventory_method,
+                "item_kind": "dataset",
+                "item_id": dataset_uri,
+                "item_name": compact_uri_name(dataset_uri),
+                "title": row_state["title"],
+                "organization": row_state["publisher"],
+                "tags": ", ".join(themes) if themes else None,
+                "notes_excerpt": description[:300] if description else None,
+                "source_url": endpoint,
+                "ordinal": idx,
+                "issued": row_state["issued"],
+                "modified": row_state["modified"],
+                "landing_page": row_state["landing_page"],
+                "distribution_url": distribution_urls[0]
+                if distribution_urls
+                else None,
+                "distribution_count": distribution_count
+                if distribution_count is not None
+                else (len(distribution_urls) if distribution_urls else None),
+                "format": ", ".join(formats) if formats else None,
+                "theme": ", ".join(themes) if themes else None,
+            }
+        )
+
+    if not rows:
+        raise ValueError(f"SPARQL query returned no inventory rows for {source_id}")
+
+    return rows, {
+        "type": "sparql_query_template",
+        "message": "Inventory raccolto via query SPARQL dichiarata.",
+        "query_name": query_name,
+        "bindings": len(bindings),
+        "datasets": len(rows),
+    }
+
+
 def collect_sdmx_inventory(
     source_id: str, source_cfg: dict[str, Any], captured_at: str
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
@@ -453,6 +653,11 @@ def collect_inventory(
         return rows
     if protocol == "sdmx":
         rows, warning = collect_sdmx_inventory(source_id, source_cfg, captured_at)
+        if warning:
+            source_cfg["_inventory_warning"] = warning
+        return rows
+    if protocol == "sparql":
+        rows, warning = collect_sparql_inventory(source_id, source_cfg, captured_at)
         if warning:
             source_cfg["_inventory_warning"] = warning
         return rows

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -271,7 +271,8 @@ def test_collect_sparql_inventory_groups_distribution_bindings(monkeypatch) -> N
     assert rows[0]["distribution_url"] == "https://example.test/download/alpha.csv"
     assert rows[0]["distribution_count"] == 2
     assert rows[0]["format"] == "CSV, RDF_TURTLE"
-    assert rows[0]["tags"] == "ENVI"
+    assert rows[0]["tags"] is None
+    assert rows[0]["theme"] == "ENVI"
     assert rows[1]["item_name"] == "beta"
 
     assert warning is not None

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -14,6 +14,17 @@ build_catalog_inventory = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(build_catalog_inventory)
 
 
+class FakeJsonResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
 def test_collect_ckan_inventory_merges_current_list_metadata(monkeypatch) -> None:
     source_cfg = {
         "base_url": "https://example.test/api/3/action/package_search",
@@ -174,3 +185,97 @@ def test_collect_ckan_inventory_skips_current_list_for_inps(monkeypatch) -> None
     assert warning is not None
     assert warning["type"] == "skip_current_package_list"
 
+
+def test_collect_sparql_inventory_groups_distribution_bindings(monkeypatch) -> None:
+    source_cfg = {
+        "base_url": "https://example.test/sparql",
+        "source_kind": "catalog",
+        "protocol": "sparql",
+        "catalog_baseline": {
+            "method": "sparql_query",
+            "query_name": "dcat_datasets",
+        },
+        "sparql": {
+            "endpoint_url": "https://example.test/sparql",
+            "query_name": "dcat_datasets",
+            "limit": 10,
+        },
+    }
+    payload = {
+        "results": {
+            "bindings": [
+                {
+                    "dataset": {
+                        "type": "uri",
+                        "value": "https://example.test/dataset/alpha",
+                    },
+                    "title": {"type": "literal", "value": "Dataset Alpha"},
+                    "description": {
+                        "type": "literal",
+                        "value": "Descrizione dataset alpha",
+                    },
+                    "publisherName": {
+                        "type": "literal",
+                        "value": "Ente demo",
+                    },
+                    "modified": {"type": "literal", "value": "2026-04-10"},
+                    "downloadURL": {
+                        "type": "uri",
+                        "value": "https://example.test/download/alpha.csv",
+                    },
+                    "format": {"type": "uri", "value": "CSV"},
+                    "theme": {"type": "uri", "value": "ENVI"},
+                },
+                {
+                    "dataset": {
+                        "type": "uri",
+                        "value": "https://example.test/dataset/alpha",
+                    },
+                    "downloadURL": {
+                        "type": "uri",
+                        "value": "https://example.test/download/alpha.ttl",
+                    },
+                    "format": {"type": "uri", "value": "RDF_TURTLE"},
+                    "theme": {"type": "uri", "value": "ENVI"},
+                },
+                {
+                    "dataset": {
+                        "type": "uri",
+                        "value": "https://example.test/dataset/beta",
+                    },
+                    "title": {"type": "literal", "value": "Dataset Beta"},
+                },
+            ]
+        }
+    }
+
+    def fake_get(url, **kwargs):
+        assert url == "https://example.test/sparql"
+        assert kwargs["headers"]["Accept"] == "application/sparql-results+json"
+        assert kwargs["params"]["format"] == "application/sparql-results+json"
+        assert "LIMIT 10" in kwargs["params"]["query"]
+        return FakeJsonResponse(payload)
+
+    monkeypatch.setattr(build_catalog_inventory.requests, "get", fake_get)
+
+    rows, warning = build_catalog_inventory.collect_sparql_inventory(
+        "demo_sparql", source_cfg, "2026-04-11T12:00:00+00:00"
+    )
+
+    assert len(rows) == 2
+    assert rows[0]["item_id"] == "https://example.test/dataset/alpha"
+    assert rows[0]["item_name"] == "alpha"
+    assert rows[0]["title"] == "Dataset Alpha"
+    assert rows[0]["organization"] == "Ente demo"
+    assert rows[0]["modified"] == "2026-04-10"
+    assert rows[0]["distribution_url"] == "https://example.test/download/alpha.csv"
+    assert rows[0]["distribution_count"] == 2
+    assert rows[0]["format"] == "CSV, RDF_TURTLE"
+    assert rows[0]["tags"] == "ENVI"
+    assert rows[1]["item_name"] == "beta"
+
+    assert warning is not None
+    assert warning["type"] == "sparql_query_template"
+    assert warning["query_name"] == "dcat_datasets"
+    assert warning["bindings"] == 3
+    assert warning["datasets"] == 2


### PR DESCRIPTION
## Cosa cambia

- Aggiunge un adapter SPARQL minimale al builder del catalog inventory.
- Introduce il template dichiarato `dcat_datasets` per inventariare dataset/metadati DCAT leggeri.
- Aggiunge `ispra_linked_data` al registry come pilot `catalog-watch` SPARQL con baseline `66` dataset.
- Aggiorna la documentazione del catalog inventory e aggiunge test unitario sul parsing delle risposte SPARQL JSON.

## Perché

Il Source Observatory riconosce già superfici SPARQL, ma il catalog inventory supportava solo CKAN e SDMX. Questo PR abilita un primo percorso riproducibile per cataloghi RDF/DCAT senza introdurre un connettore SPARQL nel toolkit.

## Verifiche

- `/home/gabry/dev/dataciviclab-workspace/toolkit/.venv/bin/python -m pytest -q tests/test_build_catalog_inventory.py` -> `3 passed`
- `git diff --check` -> ok
- Probe mirato su ISPRA Linked Data via `collect_sparql_inventory(...)` -> `66` dataset da `1604` binding

## Note

Il template generico resta volutamente leggero: enumera dataset e metadati DCAT, senza forzare discovery delle distribuzioni su endpoint che possono diventare lenti. Query custom potranno aggiungere `distribution_url`, `distribution_count` e `format` dove la superficie lo regge.
