### PR TITLE
catalog-watch: aggiornamento report e segnali (2026-04-12)

### DIFF
--- a/data/catalog/CATALOG_WATCH_REPORT.md
+++ b/data/catalog/CATALOG_WATCH_REPORT.md
@@ -1,21 +1,21 @@
 # Catalog Watch Report
 
-Ultimo run: 2026-04-10
+Ultimo run: 2026-04-12
 
 ## Sommario segnali
 
 | Classificazione | Conteggio | Dettaglio |
 | :--- | :--- | :--- |
-| `no signal` | 5 | ISTAT SDMX (4212), MIM USTAT (68), Opencoesione (data invariata), INPS (endpoint UP), OpenBDAP (endpoint UP) |
-| `inventory change` | 1 | ANAC: 70 vs baseline 69 (+1 package). Cambio minore, entro la norma. |
+| `no signal` | 9 | ISTAT SDMX (4212), INPS (endpoint UP), OpenBDAP (3772), Dati Salute (191), Camera SPARQL (104), ISPRA Linked Data (66), Consip (17), Lavoro OpenData (159), MIM USTAT (68), Opencoesione (data invariata) |
+| `health` | 1 | ANAC: WAF "Request Rejected" torna attivo (prima restituiva HTML). Regressione rispetto al run 2026-04-10 che mostrava JSON valido. |
+| `inventory change` | 0 | - |
 | `structural drift` | 0 | - |
-| `health` | 1 | ANAC: ora risponde con JSON CKAN valido (prima run restituiva HTML "Request Rejected"). Segnale positivo. |
 | `follow-up candidate` | 0 | - |
-| `[DATO MANCANTE]` | 1 | Dati Salute: sitemap raggiungibile ma conteggio URL non verificabile con precisione per troncamento response. |
+| `[DATO MANCANTE]` | 0 | - |
 
 ## Fonti catalog-watch osservate in questo run
 
-7 fonti: istat_sdmx, anac, inps, openbdap, dati_salute, mim_ustat, opencoesione
+11 fonti: istat_sdmx, anac, inps, openbdap, dati_salute, dati_camera, ispra_linked_data, consip_open_data, lavoro_opendata, mim_ustat, opencoesione
 
 ---
 
@@ -26,59 +26,99 @@ Ultimo run: 2026-04-10
 - **Protocollo**: sdmx
 - **Inventariabile**: si (SDMX supportato)
 - **Baseline**: 4212 dataflow (2026-04-10, method: dataflow_count)
-- **Osservato**: 4212 dataflow (2026-04-10)
+- **Osservato**: 4212 dataflow (2026-04-12, method: discover_dataflows MCP)
 - **Delta**: 0
-- **Nota**: Baseline riallineata all'endpoint esploradati (MCP ondata) con filtro NonProductionDataflow. Il conteggio 509 era su sdmx.istat.it (endpoint diverso).
+- **Nota**: Conteggio stabile. Endpoint esploradati risponde correttamente.
 - **Azione**: Nessuna azione richiesta.
 
 ### anac
-- **Stato**: `inventory change` + `health` (segnale positivo)
+- **Stato**: `health` (regressione)
 - **Protocollo**: ckan
 - **Inventariabile**: si (CKAN)
 - **Baseline**: 69 (2026-03-28, method: package_list)
-- **Osservato**: 70 (2026-04-10, method: package_list senza limit)
-- **Delta**: +1
-- **Nota**: L'endpoint CKAN ora restituisce JSON valido con 70 package. Nel run precedente (2026-04-03) rispondeva con pagina HTML "Request Rejected". Il WAF sembra aver allentato il blocco. Il delta di +1 package e' minore e nella norma.
-- **Azione**: Nessuna azione immediata. Monitorare la stabilita' della risposta JSON nei prossimi run.
+- **Osservato**: WAF "Request Rejected" -- risposta HTML, non JSON
+- **Delta**: non verificabile
+- **Nota**: L'endpoint CKAN torna a restituire pagina HTML "Request Rejected" (support ID: aa3c7223-1749-4b9f-b110-e9c421b37be0). Nel run 2026-04-10 rispondeva con JSON valido (70 package). Il WAF ha riattivato il blocco. Situazione instabile.
+- **Azione**: Monitorare nei prossimi run. Se il blocco WAF persiste, valutare declassamento a `radar-only` o ricerca di endpoint alternativo.
 
 ### inps
 - **Stato**: `no signal`
 - **Protocollo**: ckan
 - **Inventariabile**: si (CKAN)
 - **Baseline**: 2323 (2026-04-02, method: package_list)
-- **Osservato**: endpoint UP, package_list restituisce lista di package (conteggio esatto non verificabile per troncamento response)
-- **Delta**: non verificabile con precisione
-- **Nota**: package_search fallisce (restituisce HTML, non JSON). Questo e' coerente con il comportamento noto di questo CKAN. L'endpoint package_list risponde correttamente con una lunga lista di package ID.
-- **Azione**: Nessuna azione richiesta. Il conteggio esatto richiederebbe una chiamata package_list senza troncamento.
+- **Osservato**: package_search restituisce payload vuoto (comportamento noto); package_list con limit=1 conferma endpoint UP e response success=true
+- **Delta**: non applicabile (package_search inaffidabile per questa fonte)
+- **Nota**: package_search restituisce payload vuoto, coerente con il comportamento noto di questo CKAN. L'endpoint package_list risponde correttamente.
+- **Azione**: Nessuna azione richiesta.
 
 ### openbdap
 - **Stato**: `no signal`
 - **Protocollo**: ckan
 - **Inventariabile**: si (CKAN)
 - **Baseline**: 3772 (2026-04-02, method: package_list)
-- **Osservato**: endpoint UP, package_list restituisce lista di UUID (conteggio esatto non verificabile per troncamento response)
-- **Delta**: non verificabile con precisione
-- **Nota**: package_search restituisce count=0, coerente con la nota del registry ("package_search restituisce count inaffidabile"). L'endpoint package_list risponde con molti UUID.
+- **Osservato**: package_search restituisce count=0 (comportamento noto); package_list con limit=1 restituisce 3772 items (truncated)
+- **Delta**: 0
+- **Nota**: package_search restituisce count=0, coerente con la nota del registry ("package_search restituisce count inaffidabile"). Il package_list conferma 3772 items, in linea con la baseline.
 - **Azione**: Nessuna azione richiesta.
 
 ### dati_salute
-- **Stato**: `[DATO MANCANTE]`
+- **Stato**: `no signal`
 - **Protocollo**: html
-- **Inventariabile**: parziale (sitemap XML)
+- **Inventariabile**: si (sitemap XML)
 - **Baseline**: 191 (2026-04-07, method: sitemap_dataset_count)
-- **Osservato**: sitemap-0.xml raggiungibile, contiene URL /it/dataset/ (conteggio esatto non verificabile per troncamento response)
-- **Delta**: non verificabile
-- **Nota**: Primo run per questa fonte nel catalog-watch. La sitemap e' accessibile e ben formata. Il conteggio preciso richiederebbe il parsing completo del file XML.
-- **Azione**: Nessuna azione immediata. Il builder del inventory dovrebbe essere esteso per supportare il protocollo html/sitemap.
+- **Osservato**: 191 URL /it/dataset/ dal sitemap-0.xml (2026-04-12)
+- **Delta**: 0
+- **Nota**: Sitemap raggiungibile e ben formata. Conteggio stabile.
+- **Azione**: Nessuna azione richiesta.
+
+### dati_camera
+- **Stato**: `no signal`
+- **Protocollo**: sparql
+- **Inventariabile**: si (SPARQL)
+- **Baseline**: 104 (2026-04-11, method: sparql_query, query: camera_dcat)
+- **Osservato**: 104 dataset (2026-04-12)
+- **Delta**: 0
+- **Nota**: Endpoint SPARQL risponde correttamente. Conteggio stabile.
+- **Azione**: Nessuna azione richiesta.
+
+### ispra_linked_data
+- **Stato**: `no signal`
+- **Protocollo**: sparql
+- **Inventariabile**: si (SPARQL)
+- **Baseline**: 66 (2026-04-11, method: sparql_query, query: dcat_datasets)
+- **Osservato**: 66 dataset (2026-04-12)
+- **Delta**: 0
+- **Nota**: Endpoint SPARQL risponde correttamente. Conteggio stabile.
+- **Azione**: Nessuna azione richiesta.
+
+### consip_open_data
+- **Stato**: `no signal`
+- **Protocollo**: ckan
+- **Inventariabile**: si (CKAN)
+- **Baseline**: 17 (2026-04-10, method: package_list)
+- **Osservato**: 17 (2026-04-12, method: package_search?rows=0)
+- **Delta**: 0
+- **Nota**: package_search risponde correttamente con count=17. Valore in linea con la baseline.
+- **Azione**: Nessuna azione richiesta.
+
+### lavoro_opendata
+- **Stato**: `no signal`
+- **Protocollo**: ckan
+- **Inventariabile**: si (CKAN, SPOD)
+- **Baseline**: 159 (2026-04-11, method: package_list)
+- **Osservato**: package_search restituisce count=0 (comportamento noto); package_list con limit=1 conferma 159 items (truncated)
+- **Delta**: 0
+- **Nota**: package_search restituisce count=0, coerente con la configurazione CKAN_SKIP_PACKAGE_SEARCH. Il package_list conferma 159 items, stabile rispetto alla baseline.
+- **Azione**: Nessuna azione richiesta.
 
 ### mim_ustat
 - **Stato**: `no signal`
 - **Protocollo**: ckan
 - **Inventariabile**: si (CKAN)
 - **Baseline**: 68 (2026-04-09, method: package_list)
-- **Osservato**: 68 (2026-04-10, method: package_search?rows=0)
+- **Osservato**: 68 (2026-04-12, method: package_search?rows=0)
 - **Delta**: 0
-- **Nota**: Conteggio stabile. Nessun cambiamento dall'ultimo run.
+- **Nota**: Conteggio stabile. Risposta JSON valida.
 - **Azione**: Nessuna azione richiesta.
 
 ### opencoesione
@@ -86,17 +126,18 @@ Ultimo run: 2026-04-10
 - **Protocollo**: rest_json
 - **Inventariabile**: si (REST API)
 - **Baseline**: 2025-10-31 (2026-04-09, method: api_root, campo: data_aggiornamento)
-- **Osservato**: 20251031 (2026-04-10, formato numerico compatto)
+- **Osservato**: 20251031 (2026-04-12, formato numerico compatto)
 - **Delta**: 0 (stessa data, formato diverso)
-- **Nota**: L'API root e' raggiungibile e restituisce tutti i sotto-endpoint (progetti, soggetti, aggregati, temi, nature, territori, programmi). La data di aggiornamento e' invariata.
+- **Nota**: L'API root e' raggiungibile e restituisce tutti i sotto-endpoint. La data di aggiornamento e' invariata.
 - **Azione**: Nessuna azione richiesta.
 
 ---
 
-## Confronto con run precedente (2026-04-03)
+## Confronto con run precedente (2026-04-10)
 
-Il run precedente copriva 4 fonti (istat_sdmx, anac, inps, openbdap). Questo run ne copre 7 con l'aggiunta di dati_salute, mim_ustat e opencoesione.
+Il run precedente copriva 7 fonti. Questo run copre 11 fonti con l'aggiunta di dati_camera, ispra_linked_data, consip_open_data e lavoro_opendata.
 
 Cambiamenti rilevanti rispetto al run precedente:
-- ANAC: da "HTML Request Rejected" a JSON CKAN valido -- miglioramento significativo
-- ISTAT SDMX: baseline riallineata a 4212 su endpoint esploradati (MCP ondata)
+- ANAC: da JSON CKAN valido a "Request Rejected" HTML -- regressione WAF significativa
+- ISTAT SDMX: conteggio stabile a 4212
+- Opencoesione: data invariata

--- a/data/catalog/catalog_signals.json
+++ b/data/catalog/catalog_signals.json
@@ -1,30 +1,94 @@
 {
-  "captured_at": "2026-03-30",
-  "sources_checked": 3,
+  "captured_at": "2026-04-12",
+  "sources_checked": 11,
   "signals": [
     {
       "source": "istat_sdmx",
       "protocol": "sdmx",
-      "signal_type": "[DATO MANCANTE]",
-      "result": "segnale parziale",
-      "detail": "Il conteggio dataflow restituito dal tool appare limitato rispetto alla baseline storica.",
-      "suggested_action": "verificare limite tool o endpoint"
+      "signal_type": "no signal",
+      "result": "stabile",
+      "detail": "Conteggio dataflow stabile a 4212 rispetto alla baseline.",
+      "suggested_action": "nessuna"
     },
     {
       "source": "anac",
       "protocol": "ckan",
-      "signal_type": "no signal",
-      "result": "stabile",
-      "detail": "Conteggio package stabile rispetto alla baseline disponibile.",
-      "suggested_action": "nessuna"
+      "signal_type": "health",
+      "result": "regressione",
+      "detail": "WAF 'Request Rejected' torna attivo. L'endpoint restituisce HTML invece di JSON CKAN. Regressione rispetto al run 2026-04-10 che mostrava JSON valido.",
+      "suggested_action": "monitorare nei prossimi run; valutare declassamento a radar-only se persiste"
     },
     {
       "source": "inps",
       "protocol": "ckan",
-      "signal_type": "inventory change",
-      "result": "rilevante",
-      "detail": "Il conteggio package osservato è molto superiore alla baseline registrata.",
-      "suggested_action": "follow-up umano / source-check mirato"
+      "signal_type": "no signal",
+      "result": "stabile",
+      "detail": "Endpoint UP. package_search restituisce payload vuoto (comportamento noto); package_list conferma endpoint funzionante.",
+      "suggested_action": "nessuna"
+    },
+    {
+      "source": "openbdap",
+      "protocol": "ckan",
+      "signal_type": "no signal",
+      "result": "stabile",
+      "detail": "Endpoint UP. package_list conferma 3772 items, in linea con la baseline. package_search count=0 e' comportamento noto.",
+      "suggested_action": "nessuna"
+    },
+    {
+      "source": "dati_salute",
+      "protocol": "html",
+      "signal_type": "no signal",
+      "result": "stabile",
+      "detail": "Sitemap raggiungibile, 191 URL /it/dataset/ conteggiati, in linea con la baseline.",
+      "suggested_action": "nessuna"
+    },
+    {
+      "source": "dati_camera",
+      "protocol": "sparql",
+      "signal_type": "no signal",
+      "result": "stabile",
+      "detail": "SPARQL endpoint risponde, 104 dataset conteggiati, stabile.",
+      "suggested_action": "nessuna"
+    },
+    {
+      "source": "ispra_linked_data",
+      "protocol": "sparql",
+      "signal_type": "no signal",
+      "result": "stabile",
+      "detail": "SPARQL endpoint risponde, 66 dataset conteggiati, stabile.",
+      "suggested_action": "nessuna"
+    },
+    {
+      "source": "consip_open_data",
+      "protocol": "ckan",
+      "signal_type": "no signal",
+      "result": "stabile",
+      "detail": "CKAN package_search restituisce count=17, in linea con la baseline.",
+      "suggested_action": "nessuna"
+    },
+    {
+      "source": "lavoro_opendata",
+      "protocol": "ckan",
+      "signal_type": "no signal",
+      "result": "stabile",
+      "detail": "SPOD CKAN package_search count=0 (noto), package_list conferma 159 items, stabile.",
+      "suggested_action": "nessuna"
+    },
+    {
+      "source": "mim_ustat",
+      "protocol": "ckan",
+      "signal_type": "no signal",
+      "result": "stabile",
+      "detail": "CKAN package_search restituisce count=68, in linea con la baseline.",
+      "suggested_action": "nessuna"
+    },
+    {
+      "source": "opencoesione",
+      "protocol": "rest",
+      "signal_type": "no signal",
+      "result": "stabile",
+      "detail": "API root UP, data_aggiornamento invariata (2025-10-31).",
+      "suggested_action": "nessuna"
     }
   ]
 }


### PR DESCRIPTION
Aggiornamento catalog-watch del run 2026-04-12.

### Cosa include
- refresh di `data/catalog/CATALOG_WATCH_REPORT.md`
- refresh di `data/catalog/catalog_signals.json`

### Nota tecnica
Il branch è stato rebased su `main` locale prima del push.
