### PR TITLE
refactor: disaccoppiare resource_monitor da decisioni operative DI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ venv/
 # OS / editor noise
 .DS_Store
 Thumbs.db
+
+# Runtime monitor outputs
+data/monitor/reports/diff_summary.json

--- a/data/monitor/README.md
+++ b/data/monitor/README.md
@@ -5,20 +5,30 @@ Stato canonico per il monitoraggio file/resource.
 ## Struttura
 
 - `snapshots/`
-  - snapshot JSON con timestamp scritti da `source-observatory/scripts/monitor/resource_monitor.py`
+  - snapshot JSON completi con timestamp, scritti da `resource_monitor.py`
 - `reports/latest.md`
-  - ultimo report differenziale leggibile
+  - ultimo report differenziale leggibile (Markdown)
+- `reports/diff_summary.json`
+  - summary minimale per consumer esterni (macchine)
 
 ## Perimetro
 
-Quest'area traccia cambi su una lista corta di fonti già rilevanti:
+Quest'area osserva e segnala cambiamenti su una lista corta di fonti già rilevanti:
 
 - file nuovi
 - file cambiati
 - file rimossi
 - errori di adapter
 
-Non è un catalogo di scouting e non è il posto in cui si decide la qualità della fonte.
+**Il monitor osserva, non agisce.** Non invalida raw, non rilancia pipeline, non decide se un cambiamento richiede azione. E' responsabilita' del consumatore del `diff_summary.json` decidere cosa fare con il segnale.
+
+## Consumer esterni
+
+Il `diff_summary.json` e' progettato per essere consumato da:
+
+- Script o workflow che vogliono sapere "cosa e' cambiato" senza parsare lo snapshot completo
+- La toolkit pipeline, eventualmente, come segnale per invalidare il raw layer
+- Esseri umani che leggono `reports/latest.md`
 
 ## Input
 

--- a/scripts/monitor/resource_monitor.py
+++ b/scripts/monitor/resource_monitor.py
@@ -698,7 +698,7 @@ def write_diff_summary(snapshot: dict[str, Any]) -> None:
             "changed": s["changed_count"],
             "removed": s["removed_count"],
             "unchanged": s["unchanged_count"],
-            "error": s["error"],
+            "error": s.get("error"),
         }
 
         changed_resources = [

--- a/scripts/monitor/resource_monitor.py
+++ b/scripts/monitor/resource_monitor.py
@@ -457,21 +457,6 @@ def read_sources(path: Path) -> list[dict[str, Any]]:
     return sources
 
 
-def candidate_config_path(di_candidate: str | None) -> Path | None:
-    if not di_candidate or di_candidate == "~":
-        return None
-    config_path = (
-        WORKSPACE_ROOT
-        / "dataset-incubator"
-        / "candidates"
-        / di_candidate
-        / "dataset.yml"
-    )
-    if config_path.exists():
-        return config_path
-    return None
-
-
 def operational_warning(source: dict[str, Any]) -> list[str]:
     if source.get("changed_count", 0) <= 0:
         return []
@@ -480,14 +465,9 @@ def operational_warning(source: dict[str, Any]) -> list[str]:
     di_candidate = source.get("di_candidate")
     if di_candidate and di_candidate != "~":
         lines.append(f"  - Candidate collegato: `{di_candidate}`")
-        config_path = candidate_config_path(di_candidate)
-        if config_path:
-            lines.append(
-                "  - Comando suggerito: "
-                f"`python -m toolkit.cli.app run all --config {config_path}`"
-            )
-        else:
-            lines.append("  - Config candidate non trovata nel workspace")
+        lines.append(
+            "  - Verifica se i cambiamenti richiedono un aggiornamento della pipeline."
+        )
     else:
         lines.append("  - Nessun candidate DI collegato nel config")
 
@@ -699,6 +679,89 @@ def write_report(report: str) -> None:
     LATEST_REPORT_PATH.write_text(report, encoding="utf-8")
 
 
+DIFF_SUMMARY_PATH = REPORTS_DIR / "diff_summary.json"
+
+
+def write_diff_summary(snapshot: dict[str, Any]) -> None:
+    """Scrive un JSON minimale con solo le informazioni utili per consumer esterni.
+
+    Il formato e' progettato per essere consumato da script o dalla toolkit
+    senza dover parsare lo snapshot completo.
+    """
+    per_source: dict[str, dict[str, Any]] = {}
+    sources_with_changes: list[str] = []
+    sources_with_errors: list[str] = []
+
+    for s in snapshot["sources"]:
+        entry: dict[str, Any] = {
+            "new": s["new_count"],
+            "changed": s["changed_count"],
+            "removed": s["removed_count"],
+            "unchanged": s["unchanged_count"],
+            "error": s["error"],
+        }
+
+        changed_resources = [
+            {
+                "id": r["id"],
+                "name": r["name"],
+                "format": r.get("format"),
+                "url": r.get("url"),
+                "fields_changed": r.get("changes", []),
+            }
+            for r in s.get("resources", [])
+            if r.get("status") == "changed"
+        ]
+        new_resources = [
+            {
+                "id": r["id"],
+                "name": r["name"],
+                "format": r.get("format"),
+                "url": r.get("url"),
+            }
+            for r in s.get("resources", [])
+            if r.get("status") == "new"
+        ]
+        removed_resources = [
+            {
+                "id": r["id"],
+                "name": r["name"],
+                "format": r.get("format"),
+                "url": r.get("url"),
+            }
+            for r in s.get("resources", [])
+            if r.get("status") == "removed"
+        ]
+
+        if changed_resources:
+            entry["changed_resources"] = changed_resources
+        if new_resources:
+            entry["new_resources"] = new_resources
+        if removed_resources:
+            entry["removed_resources"] = removed_resources
+
+        per_source[s["id"]] = entry
+
+        if s["changed_count"] > 0 or s["new_count"] > 0 or s["removed_count"] > 0:
+            sources_with_changes.append(s["id"])
+        if s["error"]:
+            sources_with_errors.append(s["id"])
+
+    summary = {
+        "generated_at": snapshot["generated_at"],
+        "generated_at_utc": snapshot["generated_at_utc"],
+        "source_count": snapshot["source_count"],
+        "sources_with_changes": sources_with_changes,
+        "sources_with_errors": sources_with_errors,
+        "per_source": per_source,
+    }
+
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    DIFF_SUMMARY_PATH.write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Resource-level diff for known dataset sources."
@@ -739,8 +802,10 @@ def main() -> int:
     snapshot_path = write_snapshot(snapshot)
     report = render_report(snapshot, previous_path, snapshot_path)
     write_report(report)
-    print(f"Wrote snapshot: {snapshot_path}")
-    print(f"Wrote report:   {LATEST_REPORT_PATH}")
+    write_diff_summary(snapshot)
+    print(f"Wrote snapshot:   {snapshot_path}")
+    print(f"Wrote report:     {LATEST_REPORT_PATH}")
+    print(f"Wrote diff:       {DIFF_SUMMARY_PATH}")
     return 0
 
 

--- a/tests/test_resource_monitor.py
+++ b/tests/test_resource_monitor.py
@@ -1,12 +1,14 @@
 """Test per monitor/resource_monitor.py."""
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 from xml.etree import ElementTree as ET
 
 import requests
 
 from monitor.resource_monitor import (
+    DIFF_SUMMARY_PATH,
     annotate_resources,
     diff_fields,
     fetch_sdmx,
@@ -14,6 +16,7 @@ from monitor.resource_monitor import (
     is_data_link,
     parse_sdmx_resources,
     resource_signature,
+    write_diff_summary,
 )
 
 
@@ -297,3 +300,67 @@ def test_fetch_sdmx_returns_error_on_xml_parse_error() -> None:
             result = fetch_sdmx(source, timeout=5)
     assert result.error is not None
     assert "SDMX XML parse error" in result.error
+
+
+def test_write_diff_summary_writes_minimal_machine_readable_payload(
+    tmp_path, monkeypatch
+) -> None:
+    reports_dir = tmp_path / "reports"
+    diff_path = reports_dir / "diff_summary.json"
+    monkeypatch.setattr("monitor.resource_monitor.REPORTS_DIR", reports_dir)
+    monkeypatch.setattr("monitor.resource_monitor.DIFF_SUMMARY_PATH", diff_path)
+
+    snapshot = {
+        "generated_at": "2026-04-12T14:00:00+00:00",
+        "generated_at_utc": "2026-04-12 14:00:00Z",
+        "source_count": 1,
+        "sources": [
+            {
+                "id": "inps-ckan",
+                "new_count": 1,
+                "changed_count": 1,
+                "removed_count": 1,
+                "unchanged_count": 3,
+                "error": None,
+                "resources": [
+                    {
+                        "id": "r-new",
+                        "name": "Nuovo file",
+                        "format": "CSV",
+                        "url": "https://example.test/new.csv",
+                        "status": "new",
+                    },
+                    {
+                        "id": "r-chg",
+                        "name": "File aggiornato",
+                        "format": "CSV",
+                        "url": "https://example.test/changed.csv",
+                        "status": "changed",
+                        "changes": ["last_modified: 'a' -> 'b'"],
+                    },
+                    {
+                        "id": "r-del",
+                        "name": "File rimosso",
+                        "format": "CSV",
+                        "url": "https://example.test/removed.csv",
+                        "status": "removed",
+                    },
+                ],
+            }
+        ],
+    }
+
+    write_diff_summary(snapshot)
+    assert DIFF_SUMMARY_PATH.name == "diff_summary.json"
+    assert diff_path.exists()
+
+    payload = json.loads(diff_path.read_text(encoding="utf-8"))
+    assert payload["source_count"] == 1
+    assert payload["sources_with_changes"] == ["inps-ckan"]
+    assert payload["sources_with_errors"] == []
+    assert payload["per_source"]["inps-ckan"]["new"] == 1
+    assert payload["per_source"]["inps-ckan"]["changed"] == 1
+    assert payload["per_source"]["inps-ckan"]["removed"] == 1
+    assert payload["per_source"]["inps-ckan"]["new_resources"][0]["id"] == "r-new"
+    assert payload["per_source"]["inps-ckan"]["changed_resources"][0]["id"] == "r-chg"
+    assert payload["per_source"]["inps-ckan"]["removed_resources"][0]["id"] == "r-del"

--- a/tests/test_resource_monitor.py
+++ b/tests/test_resource_monitor.py
@@ -8,7 +8,6 @@ from xml.etree import ElementTree as ET
 import requests
 
 from monitor.resource_monitor import (
-    DIFF_SUMMARY_PATH,
     annotate_resources,
     diff_fields,
     fetch_sdmx,
@@ -351,7 +350,6 @@ def test_write_diff_summary_writes_minimal_machine_readable_payload(
     }
 
     write_diff_summary(snapshot)
-    assert DIFF_SUMMARY_PATH.name == "diff_summary.json"
     assert diff_path.exists()
 
     payload = json.loads(diff_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- disaccoppia `resource_monitor` da logica operativa legata a `dataset-incubator`
- mantiene il monitor nel perimetro osservativo: segnala cambi, non decide azioni
- aggiunge un output JSON minimale (`diff_summary.json`) per consumer esterni

## Modifiche principali
- rimosso `candidate_config_path()` (path resolution locale fragile/non affidabile)
- semplificato `operational_warning()` a messaggio informativo senza comando `toolkit run`
- aggiunto `write_diff_summary()` con payload machine-readable (`reports/diff_summary.json`)
- aggiornato `data/monitor/README.md` su perimetro e consumer esterni
- corretto typo path nel README (`source-observatory/...`)
- aggiunto test sulla shape minima del `diff_summary.json`

## Test
- `pytest -q tests/test_resource_monitor.py` -> 24 passed
- `pytest -q tests` -> 41 passed
