### PR TITLE
feat: INPS CKAN package_show sample enricher per fallback package_list

### DIFF
--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -36,6 +36,10 @@ CKAN_SKIP_PACKAGE_SEARCH = {"lavoro_opendata"}
 # Sources where current_package_list_with_resources is unreliable (SSL/GIL crash on Windows).
 # These skip the enrichment step and fall straight to package_list.
 CKAN_SKIP_CURRENT_LIST = {"inps", "lavoro_opendata"}
+# Sources where package_list rows (often numeric IDs) should be sampled and enriched
+# via package_show when current_package_list_with_resources is skipped.
+CKAN_PACKAGE_SHOW_SAMPLE_SOURCES = {"inps"}
+CKAN_PACKAGE_SHOW_SAMPLE_SIZE = 25
 SPARQL_QUERY_TEMPLATES = {
     "dcat_datasets": """
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
@@ -312,6 +316,75 @@ def collect_ckan_inventory_via_package_list(
     return rows
 
 
+def _sample_indexes(total: int, sample_size: int) -> list[int]:
+    if total <= 0 or sample_size <= 0:
+        return []
+    if total <= sample_size:
+        return list(range(total))
+
+    indexes: set[int] = {0, total - 1}
+    step = max(total // sample_size, 1)
+    for idx in range(0, total, step):
+        indexes.add(idx)
+        if len(indexes) >= sample_size:
+            break
+    return sorted(indexes)
+
+
+def collect_ckan_inventory_via_package_show_sample(
+    source_id: str,
+    source_cfg: dict[str, Any],
+    captured_at: str,
+    package_list_rows: list[dict[str, Any]],
+    sample_size: int = CKAN_PACKAGE_SHOW_SAMPLE_SIZE,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    endpoint = ckan_action_endpoint(source_cfg["base_url"], "package_show")
+    sampled_idx = _sample_indexes(len(package_list_rows), sample_size)
+    if not sampled_idx:
+        return [], None
+
+    enriched_rows: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for idx in sampled_idx:
+        base_row = package_list_rows[idx]
+        package_id = str(base_row["item_id"])
+        try:
+            payload = ckan_get_json(endpoint, params={"id": package_id}, timeout=30)
+            if not payload.get("success"):
+                errors.append(f"{package_id}: package_show success=false")
+                continue
+            item = payload.get("result")
+            if not isinstance(item, dict):
+                errors.append(f"{package_id}: package_show result non-dict")
+                continue
+            enriched = extract_ckan_inventory_row(
+                source_id=source_id,
+                source_cfg=source_cfg,
+                captured_at=captured_at,
+                item=item,
+                endpoint=endpoint,
+                ordinal=base_row["ordinal"],
+                inventory_method="package_show_sample",
+            )
+            # Keep package_list key for deterministic merge against base rows.
+            enriched["item_id"] = package_id
+            enriched_rows.append(enriched)
+        except Exception as exc:
+            errors.append(f"{package_id}: {exc}")
+
+    warning: dict[str, Any] | None = None
+    if errors:
+        warning = {
+            "type": "package_show_sample_partial",
+            "message": "Arricchimento sample via package_show completato con errori parziali.",
+            "sample_size": len(sampled_idx),
+            "rows_enriched": len(enriched_rows),
+            "errors_preview": errors[:10],
+        }
+    return enriched_rows, warning
+
+
 def collect_ckan_inventory(
     source_id: str, source_cfg: dict[str, Any], captured_at: str
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
@@ -332,6 +405,32 @@ def collect_ckan_inventory(
         source_id, source_cfg, captured_at
     )
     if source_id in CKAN_SKIP_CURRENT_LIST:
+        if source_id in CKAN_PACKAGE_SHOW_SAMPLE_SOURCES:
+            enriched_rows, sample_warning = collect_ckan_inventory_via_package_show_sample(
+                source_id=source_id,
+                source_cfg=source_cfg,
+                captured_at=captured_at,
+                package_list_rows=package_list_rows,
+            )
+            enriched_by_id = {row["item_id"]: row for row in enriched_rows}
+            merged_rows: list[dict[str, Any]] = []
+            missing_metadata = 0
+            for row in package_list_rows:
+                enriched = enriched_by_id.get(row["item_id"])
+                if enriched is None:
+                    missing_metadata += 1
+                    merged_rows.append(row)
+                else:
+                    merged_rows.append({**row, **enriched, "ordinal": row["ordinal"]})
+            warning: dict[str, Any] = {
+                "type": "skip_current_package_list_with_package_show_sample",
+                "message": f"current_package_list_with_resources disabilitato per {source_id}; applicato enrich sample via package_show.",
+                "rows_enriched": len(enriched_by_id),
+                "rows_missing_metadata": missing_metadata,
+            }
+            if sample_warning:
+                warning["package_show_sample_warning"] = sample_warning
+            return merged_rows, warning
         return package_list_rows, {
             "type": "skip_current_package_list",
             "message": f"Enrichment current_package_list_with_resources disabilitato per {source_id} (instabilita SSL/GIL in ambiente locale).",

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -150,6 +150,9 @@ def test_collect_ckan_inventory_skips_current_list_for_inps(monkeypatch) -> None
     def fail_if_called(*_args, **_kwargs):
         raise AssertionError("current list non dovrebbe essere chiamato per INPS")
 
+    def fake_package_show_sample(*_args, **_kwargs):
+        return ([], None)
+
     monkeypatch.setattr(
         build_catalog_inventory, "collect_ckan_inventory_via_search", fake_search
     )
@@ -163,6 +166,11 @@ def test_collect_ckan_inventory_skips_current_list_for_inps(monkeypatch) -> None
         "collect_ckan_inventory_via_current_list",
         fail_if_called,
     )
+    monkeypatch.setattr(
+        build_catalog_inventory,
+        "collect_ckan_inventory_via_package_show_sample",
+        fake_package_show_sample,
+    )
 
     rows, warning = build_catalog_inventory.collect_ckan_inventory(
         "inps", source_cfg, "2026-04-09T12:00:00+00:00"
@@ -172,7 +180,110 @@ def test_collect_ckan_inventory_skips_current_list_for_inps(monkeypatch) -> None
     assert rows[0]["item_id"] == "544"
     assert rows[0]["title"] is None
     assert warning is not None
-    assert warning["type"] == "skip_current_package_list"
+    assert warning["type"] == "skip_current_package_list_with_package_show_sample"
+    assert warning["rows_enriched"] == 0
+
+
+def test_collect_ckan_inventory_inps_enriches_with_package_show_sample(monkeypatch) -> None:
+    source_cfg = {
+        "base_url": "https://www.inps.it/odapi/api/3/action/package_search",
+        "source_kind": "catalog",
+        "protocol": "ckan",
+        "catalog_baseline": {"method": "package_list"},
+    }
+
+    def fake_search(*_args, **_kwargs):
+        raise ValueError("package_search rotto")
+
+    def fake_package_list(source_id, source_cfg, captured_at):
+        return [
+            {
+                "captured_at": captured_at,
+                "source_id": source_id,
+                "source_kind": source_cfg.get("source_kind"),
+                "protocol": source_cfg.get("protocol"),
+                "inventory_method": "package_list",
+                "item_kind": "dataset",
+                "item_id": "544",
+                "item_name": "544",
+                "title": None,
+                "organization": None,
+                "tags": None,
+                "notes_excerpt": None,
+                "source_url": "https://www.inps.it/odapi/api/3/action/package_list",
+                "ordinal": 1,
+            },
+            {
+                "captured_at": captured_at,
+                "source_id": source_id,
+                "source_kind": source_cfg.get("source_kind"),
+                "protocol": source_cfg.get("protocol"),
+                "inventory_method": "package_list",
+                "item_kind": "dataset",
+                "item_id": "545",
+                "item_name": "545",
+                "title": None,
+                "organization": None,
+                "tags": None,
+                "notes_excerpt": None,
+                "source_url": "https://www.inps.it/odapi/api/3/action/package_list",
+                "ordinal": 2,
+            },
+        ]
+
+    def fake_package_show_sample(*_args, **_kwargs):
+        return (
+            [
+                {
+                    "item_id": "544",
+                    "item_name": "rdc-statistiche",
+                    "title": "Reddito di cittadinanza - statistiche",
+                    "organization": "INPS",
+                    "tags": "welfare",
+                    "notes_excerpt": "descrizione",
+                    "source_url": "https://www.inps.it/odapi/api/3/action/package_show",
+                    "inventory_method": "package_show_sample",
+                    "ordinal": 99,
+                }
+            ],
+            None,
+        )
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("current list non dovrebbe essere chiamato per INPS")
+
+    monkeypatch.setattr(
+        build_catalog_inventory, "collect_ckan_inventory_via_search", fake_search
+    )
+    monkeypatch.setattr(
+        build_catalog_inventory,
+        "collect_ckan_inventory_via_package_list",
+        fake_package_list,
+    )
+    monkeypatch.setattr(
+        build_catalog_inventory,
+        "collect_ckan_inventory_via_package_show_sample",
+        fake_package_show_sample,
+    )
+    monkeypatch.setattr(
+        build_catalog_inventory,
+        "collect_ckan_inventory_via_current_list",
+        fail_if_called,
+    )
+
+    rows, warning = build_catalog_inventory.collect_ckan_inventory(
+        "inps", source_cfg, "2026-04-09T12:00:00+00:00"
+    )
+
+    assert len(rows) == 2
+    assert rows[0]["item_id"] == "544"
+    assert rows[0]["title"] == "Reddito di cittadinanza - statistiche"
+    assert rows[1]["item_id"] == "545"
+    assert rows[1]["title"] is None
+    assert warning is not None
+    assert warning["type"] == "skip_current_package_list_with_package_show_sample"
+    assert warning["rows_enriched"] == 1
+    assert warning["rows_missing_metadata"] == 1
 
 
 def test_collect_sparql_inventory_groups_distribution_bindings(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- aggiunge un percorso di enrich metadata per CKAN `package_list` basato su sample `package_show`
- abilita il nuovo enrich per `inps`, dove `current_package_list_with_resources` e' skip
- integra merge metadata per `item_id` mantenendo ordinamento e fallback robusto

## Modifiche
- `scripts/build_catalog_inventory.py`
  - nuova costante `CKAN_PACKAGE_SHOW_SAMPLE_SOURCES = {"inps"}`
  - nuova costante `CKAN_PACKAGE_SHOW_SAMPLE_SIZE = 25`
  - helper `_sample_indexes(...)` per campionamento stratificato
  - nuova funzione `collect_ckan_inventory_via_package_show_sample(...)`
  - integrazione in `collect_ckan_inventory(...)` nel ramo skip-current
- `tests/test_build_catalog_inventory.py`
  - aggiornato test INPS skip-current al nuovo comportamento
  - aggiunto test dedicato al merge metadata via sample `package_show`

## Validazione
- `pytest -q tests/test_build_catalog_inventory.py` -> 4 passed
- `pytest -q tests` -> 42 passed

Closes #83
