### PR TITLE
feat: catalog inventory improvements - registry-driven config, openbdap fix, parallelizzazione

### DIFF
--- a/data/catalog_inventory/README.md
+++ b/data/catalog_inventory/README.md
@@ -61,8 +61,7 @@ Colonne chiave:
 
 Nota operativa:
 - per cataloghi CKAN il builder prova in ordine `package_search`, `current_package_list_with_resources`, `package_list`
-- `current_package_list_with_resources` è disabilitato per `inps` in ambiente locale Windows per instabilita SSL/GIL (fall-back diretto a `package_list` con warning esplicito)
-- la logica di enrichment resta attiva per altri cataloghi CKAN futuri
+- il comportamento per fonte (skip di `package_search`, skip di `current_package_list_with_resources`, enrich via `package_show` sample) è configurato nel blocco `inventory:` del registry, non hardcoded nello script
 - per cataloghi SPARQL il builder usa solo query dichiarate nel registry o template espliciti; il pilot iniziale è `dcat_datasets`
 - il template SPARQL generico enumera dataset e metadati DCAT leggeri; non popola `distribution_url`, `distribution_count` o `format`
 - per SPARQL `tags` resta vuoto e i temi DCAT stanno nel campo opzionale `theme`; query custom possono aggiungere campi opzionali come `distribution_url`, `distribution_count` e `format`
@@ -70,7 +69,7 @@ Nota operativa:
 ## Workflow
 
 Workflow GitHub Actions disponibile:
-- `.github/workflows/catalog-inventory-manual.yml`
+- `.github/workflows/catalog-inventory.yml`
 
 Comando locale equivalente:
 
@@ -78,9 +77,14 @@ Comando locale equivalente:
 python scripts/build_catalog_inventory.py
 ```
 
+Con raccolta parallela (sperimentale, usare con cautela su endpoint fragili):
+
+```bash
+python scripts/build_catalog_inventory.py --workers 3
+```
+
 ## Caveat
 
 - il perimetro segue solo le fonti `catalog-watch` del registry
-- l'inventory può essere intenzionalmente parziale se una fonte e' osservabile ma non inventariabile in modo stabile
+- l'inventory può essere intenzionalmente parziale se una fonte è osservabile ma non inventariabile in modo stabile
 - il README locale resta in `_local/data/catalog_inventory/README.md`
-- `istat_sdmx` oggi viene enumerato in modo riproducibile tramite `https://sdmx.istat.it/SDMXWS/rest/dataflow/IT1`, coerente con la baseline aggiornata a `509`

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -25,6 +25,9 @@ anac:
   protocol: ckan
   observation_mode: catalog-watch
   base_url: https://dati.anticorruzione.it/opendata/api/3/action/package_list?limit=1
+  inventory:
+    non_inventoriable: true
+    reason: "Fonte osservata in source-observatory, ma non inventariabile con client HTTP standard per via di una risposta WAF 'Request Rejected'."
   last_probed: '2026-04-12'
   catalog_baseline:
     captured_at: '2026-03-28'
@@ -41,6 +44,10 @@ inps:
   protocol: ckan
   observation_mode: catalog-watch
   base_url: https://serviziweb2.inps.it/odapi/package_list?limit=1
+  inventory:
+    skip_current_list: true
+    package_show_sample: true
+    sample_size: 25
   last_probed: '2026-04-12'
   catalog_baseline:
     captured_at: '2026-04-02'
@@ -59,6 +66,8 @@ openbdap:
   protocol: ckan
   observation_mode: catalog-watch
   base_url: https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
+  inventory:
+    skip_package_search: true
   last_probed: '2026-04-12'
   catalog_baseline:
     captured_at: '2026-04-02'
@@ -195,6 +204,9 @@ lavoro_opendata:
   protocol: ckan
   observation_mode: catalog-watch
   base_url: https://dati.lavoro.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
+  inventory:
+    skip_package_search: true
+    skip_current_list: true
   last_probed: '2026-04-12'
   catalog_baseline:
     captured_at: '2026-04-11'

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -68,6 +68,7 @@ openbdap:
   base_url: https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
   inventory:
     skip_package_search: true
+    skip_package_search_reason: "timeout sistematico a 60s"
   last_probed: '2026-04-12'
   catalog_baseline:
     captured_at: '2026-04-02'
@@ -206,6 +207,7 @@ lavoro_opendata:
   base_url: https://dati.lavoro.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
   inventory:
     skip_package_search: true
+    skip_package_search_reason: "count inaffidabile"
     skip_current_list: true
   last_probed: '2026-04-12'
   catalog_baseline:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -50,6 +50,7 @@ Modello v0:
 
 ```bash
 python scripts/build_catalog_inventory.py
+python scripts/build_catalog_inventory.py --workers 3  # parallelo, sperimentale
 ```
 
 Usa `catalog inventory` quando la domanda è:

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -32,7 +32,7 @@ CKAN_ACTION_NAMES = {
     "current_package_list_with_resources",
 }
 # Sources where package_search is unreliable (bad counts or timeouts).
-CKAN_SKIP_PACKAGE_SEARCH = {"lavoro_opendata"}
+CKAN_SKIP_PACKAGE_SEARCH = {"lavoro_opendata", "openbdap"}
 # Sources where current_package_list_with_resources is unreliable (SSL/GIL crash on Windows).
 # These skip the enrichment step and fall straight to package_list.
 CKAN_SKIP_CURRENT_LIST = {"inps", "lavoro_opendata"}

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -57,7 +57,10 @@ LIMIT {limit}
 
 def _inventory_cfg(source_cfg: dict[str, Any]) -> dict[str, Any]:
     """Legge il blocco `inventory:` dalla config della fonte nel registry."""
-    return source_cfg.get("inventory") or {}
+    inv = source_cfg.get("inventory")
+    if isinstance(inv, dict):
+        return inv
+    return {}
 
 
 def supported_protocols() -> set[str]:
@@ -425,7 +428,7 @@ def collect_ckan_inventory(
             search_exc = exc
     else:
         search_exc = ValueError(
-            f"CKAN package_search disabled for {source_id} (unreliable counts)."
+            f"CKAN package_search disabled for {source_id} ({inv.get('skip_package_search_reason', 'disabled by registry config')})."
         )
 
     package_list_rows = collect_ckan_inventory_via_package_list(
@@ -836,6 +839,8 @@ def parse_args() -> argparse.Namespace:
         "--workers",
         type=int,
         default=1,
+        choices=range(1, 9),
+        metavar="N (1-8)",
         help="Thread per la raccolta parallela (default: 1 = seriale).",
     )
     return parser.parse_args()

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import time
 import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -795,24 +796,30 @@ def load_registry() -> dict[str, Any]:
 
 def collect_inventory(
     source_id: str, source_cfg: dict[str, Any], captured_at: str
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None, dict[str, Any] | None]:
+    """Raccoglie l'inventory per una fonte. Ritorna (rows, warning, summary) senza side-effect."""
     protocol = source_cfg.get("protocol")
     if protocol == "ckan":
         rows, warning = collect_ckan_inventory(source_id, source_cfg, captured_at)
-        if warning:
-            source_cfg["_inventory_warning"] = warning
-        return rows
+        return rows, warning, None
     if protocol == "sdmx":
         rows, warning = collect_sdmx_inventory(source_id, source_cfg, captured_at)
-        if warning:
-            source_cfg["_inventory_warning"] = warning
-        return rows
+        return rows, warning, None
     if protocol == "sparql":
         rows, summary = collect_sparql_inventory(source_id, source_cfg, captured_at)
-        if summary:
-            source_cfg["_inventory_summary"] = summary
-        return rows
+        return rows, None, summary
     raise ValueError(f"Unsupported protocol for catalog inventory: {protocol}")
+
+
+def _collect_source(
+    source_id: str, source_cfg: dict[str, Any], captured_at: str
+) -> tuple[str, list[dict[str, Any]], dict[str, Any] | None, dict[str, Any] | None, Exception | None]:
+    """Worker per ThreadPoolExecutor: raccoglie una fonte e cattura eccezioni."""
+    try:
+        rows, warning, summary = collect_inventory(source_id, source_cfg, captured_at)
+        return source_id, rows, warning, summary, None
+    except Exception as exc:
+        return source_id, [], None, None, exc
 
 
 def parse_args() -> argparse.Namespace:
@@ -824,6 +831,12 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=DEFAULT_OUT_DIR,
         help="Directory di output per parquet e report JSON.",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="Thread per la raccolta parallela (default: 1 = seriale).",
     )
     return parser.parse_args()
 
@@ -845,6 +858,8 @@ def main() -> None:
         "sources": {},
     }
 
+    # Fase 1: filtra fonti inventariabili (in ordine del registry)
+    inventoriable: list[tuple[str, dict[str, Any]]] = []
     for source_id, source_cfg in registry.items():
         if source_cfg.get("source_kind") != "catalog":
             continue
@@ -871,29 +886,42 @@ def main() -> None:
             }
             continue
 
-        try:
-            rows = collect_inventory(source_id, source_cfg, captured_at)
-            all_rows.extend(rows)
-            source_report = {
-                "status": "ok",
-                "protocol": source_cfg.get("protocol"),
-                "rows": len(rows),
-                "method": source_cfg.get("catalog_baseline", {}).get("method"),
-            }
-            warning = source_cfg.pop("_inventory_warning", None)
-            if warning:
-                source_report["warning"] = warning
-            summary = source_cfg.pop("_inventory_summary", None)
-            if summary:
-                source_report["summary"] = summary
-            report["sources"][source_id] = source_report
-        except Exception as exc:
+        inventoriable.append((source_id, source_cfg))
+
+    # Fase 2: raccolta (seriale con workers=1, parallela con workers>1)
+    collected: dict[str, tuple[list[dict[str, Any]], dict[str, Any] | None, dict[str, Any] | None, Exception | None]] = {}
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        future_to_id = {
+            executor.submit(_collect_source, source_id, source_cfg, captured_at): source_id
+            for source_id, source_cfg in inventoriable
+        }
+        for future in as_completed(future_to_id):
+            sid, rows, warning, summary, exc = future.result()
+            collected[sid] = (rows, warning, summary, exc)
+
+    # Fase 3: assembla report in ordine del registry
+    for source_id, source_cfg in inventoriable:
+        rows, warning, summary, exc = collected[source_id]
+        if exc is not None:
             report["sources"][source_id] = {
                 "status": "error",
                 "protocol": source_cfg.get("protocol"),
                 "error": str(exc),
                 "method": source_cfg.get("catalog_baseline", {}).get("method"),
             }
+            continue
+        all_rows.extend(rows)
+        source_report: dict[str, Any] = {
+            "status": "ok",
+            "protocol": source_cfg.get("protocol"),
+            "rows": len(rows),
+            "method": source_cfg.get("catalog_baseline", {}).get("method"),
+        }
+        if warning:
+            source_report["warning"] = warning
+        if summary:
+            source_report["summary"] = summary
+        report["sources"][source_id] = source_report
 
     if not all_rows:
         raise RuntimeError("No catalog inventory rows collected.")

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -22,24 +22,12 @@ REGISTRY_PATH = REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
 DEFAULT_OUT_DIR = REPO_ROOT / "data" / "catalog_inventory" / "generated"
 DEFAULT_OUT_PARQUET = "catalog_inventory_latest.parquet"
 DEFAULT_OUT_REPORT = "catalog_inventory_report.json"
-NON_INVENTORIABLE_SOURCES = {
-    "anac": "Fonte osservata in source-observatory, ma non inventariabile con client HTTP standard per via di una risposta WAF 'Request Rejected'.",
-}
 CKAN_ACTION_NAMES = {
     "package_list",
     "package_search",
     "package_show",
     "current_package_list_with_resources",
 }
-# Sources where package_search is unreliable (bad counts or timeouts).
-CKAN_SKIP_PACKAGE_SEARCH = {"lavoro_opendata", "openbdap"}
-# Sources where current_package_list_with_resources is unreliable (SSL/GIL crash on Windows).
-# These skip the enrichment step and fall straight to package_list.
-CKAN_SKIP_CURRENT_LIST = {"inps", "lavoro_opendata"}
-# Sources where package_list rows (often numeric IDs) should be sampled and enriched
-# via package_show when current_package_list_with_resources is skipped.
-CKAN_PACKAGE_SHOW_SAMPLE_SOURCES = {"inps"}
-CKAN_PACKAGE_SHOW_SAMPLE_SIZE = 25
 SPARQL_QUERY_TEMPLATES = {
     "dcat_datasets": """
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
@@ -64,6 +52,11 @@ ORDER BY ?dataset
 LIMIT {limit}
 """.strip()
 }
+
+
+def _inventory_cfg(source_cfg: dict[str, Any]) -> dict[str, Any]:
+    """Legge il blocco `inventory:` dalla config della fonte nel registry."""
+    return source_cfg.get("inventory") or {}
 
 
 def supported_protocols() -> set[str]:
@@ -368,7 +361,7 @@ def collect_ckan_inventory_via_package_show_sample(
     source_cfg: dict[str, Any],
     captured_at: str,
     package_list_rows: list[dict[str, Any]],
-    sample_size: int = CKAN_PACKAGE_SHOW_SAMPLE_SIZE,
+    sample_size: int = 25,
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
     endpoint = ckan_action_endpoint(source_cfg["base_url"], "package_show")
     sampled_idx = _sample_indexes(len(package_list_rows), sample_size)
@@ -420,8 +413,9 @@ def collect_ckan_inventory_via_package_show_sample(
 def collect_ckan_inventory(
     source_id: str, source_cfg: dict[str, Any], captured_at: str
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    inv = _inventory_cfg(source_cfg)
     search_exc: Exception | None = None
-    if source_id not in CKAN_SKIP_PACKAGE_SEARCH:
+    if not inv.get("skip_package_search"):
         try:
             return collect_ckan_inventory_via_search(
                 source_id, source_cfg, captured_at
@@ -436,13 +430,14 @@ def collect_ckan_inventory(
     package_list_rows = collect_ckan_inventory_via_package_list(
         source_id, source_cfg, captured_at
     )
-    if source_id in CKAN_SKIP_CURRENT_LIST:
-        if source_id in CKAN_PACKAGE_SHOW_SAMPLE_SOURCES:
+    if inv.get("skip_current_list"):
+        if inv.get("package_show_sample"):
             enriched_rows, sample_warning = collect_ckan_inventory_via_package_show_sample(
                 source_id=source_id,
                 source_cfg=source_cfg,
                 captured_at=captured_at,
                 package_list_rows=package_list_rows,
+                sample_size=inv.get("sample_size", 25),
             )
             enriched_by_id = {row["item_id"]: row for row in enriched_rows}
             merged_rows: list[dict[str, Any]] = []
@@ -856,12 +851,13 @@ def main() -> None:
         if source_cfg.get("observation_mode") != "catalog-watch":
             continue
 
-        if source_id in NON_INVENTORIABLE_SOURCES:
+        inv = _inventory_cfg(source_cfg)
+        if inv.get("non_inventoriable"):
             report["sources"][source_id] = {
                 "status": "non_inventariabile",
                 "protocol": source_cfg.get("protocol"),
                 "method": source_cfg.get("catalog_baseline", {}).get("method"),
-                "reason": NON_INVENTORIABLE_SOURCES[source_id],
+                "reason": inv.get("reason", "Fonte non inventariabile."),
             }
             continue
 

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -122,6 +122,7 @@ def test_collect_ckan_inventory_skips_current_list_for_inps(monkeypatch) -> None
         "source_kind": "catalog",
         "protocol": "ckan",
         "catalog_baseline": {"method": "package_list"},
+        "inventory": {"skip_current_list": True, "package_show_sample": True, "sample_size": 25},
     }
 
     def fake_search(*_args, **_kwargs):
@@ -190,6 +191,7 @@ def test_collect_ckan_inventory_inps_enriches_with_package_show_sample(monkeypat
         "source_kind": "catalog",
         "protocol": "ckan",
         "catalog_baseline": {"method": "package_list"},
+        "inventory": {"skip_current_list": True, "package_show_sample": True, "sample_size": 25},
     }
 
     def fake_search(*_args, **_kwargs):


### PR DESCRIPTION
## Summary

- Fix: skip `package_search` per openbdap (timeout sistematico a 60s, fallback immediato a `package_list`)
- Refactor: comportamento inventory per-fonte spostato dal codice al registry (`inventory:` block) - rimossi 5 set hardcoded dallo script
- Feat: raccolta parallela con `--workers` (default 1 = seriale, comportamento invariato); `collect_inventory()` ora puro senza side-effect su `source_cfg`
- Docs: aggiornati `data/catalog_inventory/README.md` e `docs/runbook.md`

## Dettaglio

**Registry-driven config** - ogni fonte ora dichiara il proprio comportamento inventory in `sources_registry.yaml`:
- `anac`: `non_inventoriable: true`
- `inps`: `skip_current_list`, `package_show_sample`, `sample_size`
- `openbdap`: `skip_package_search`
- `lavoro_opendata`: `skip_package_search`, `skip_current_list`

**Parallelizzazione** - con `--workers 3` le fonti vengono raccolte in parallelo; l'ordine del report resta quello del registry.

## Test plan

- [x] `pytest tests/test_build_catalog_inventory.py tests/test_radar_check.py -q` - 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)