### PR TITLE
chore: dev tooling hardening and mypy fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Lint with ruff
+        run: ruff check scripts/ tests/
+
+      - name: Type check with mypy
+        run: mypy scripts/
 
       - name: Run tests
         run: pytest tests/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ Thumbs.db
 
 # Runtime monitor outputs
 data/monitor/reports/diff_summary.json
+
+# Local artifacts (parquet, reports)
+data/catalog_inventory/generated/
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+-r requirements.txt
+pytest>=7.0,<10.0
+ruff>=0.1.0,<1.0.0
+mypy>=1.0.0,<2.0.0
+types-requests
+types-PyYAML
+pandas-stubs

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ requests>=2.31,<3.0
 PyYAML>=6.0,<7.0
 duckdb>=1.0,<2.0
 pandas>=2.1,<4.0
-pytest>=7.0,<10.0

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -472,17 +472,17 @@ def collect_ckan_inventory(
             source_id, source_cfg, captured_at
         )
         enriched_by_id = {row["item_id"]: row for row in current_rows}
-        merged_rows: list[dict[str, Any]] = []
+        fallback_merged_rows: list[dict[str, Any]] = []
         missing_metadata = 0
         for row in package_list_rows:
             enriched = enriched_by_id.get(row["item_id"])
             if enriched is None:
                 missing_metadata += 1
-                merged_rows.append(row)
+                fallback_merged_rows.append(row)
             else:
-                merged_rows.append({**row, **enriched, "ordinal": row["ordinal"]})
+                fallback_merged_rows.append({**row, **enriched, "ordinal": row["ordinal"]})
 
-        warning: dict[str, Any] = {
+        fallback_warning: dict[str, Any] = {
             "type": "fallback_current_package_list_with_resources",
             "message": "Fallback da package_search a current_package_list_with_resources.",
             "package_search_error": str(search_exc)
@@ -492,8 +492,8 @@ def collect_ckan_inventory(
             "rows_missing_metadata": missing_metadata,
         }
         if current_warning:
-            warning["current_list_warning"] = current_warning
-        return merged_rows, warning
+            fallback_warning["current_list_warning"] = current_warning
+        return fallback_merged_rows, fallback_warning
     except Exception as current_list_exc:
         return package_list_rows, {
             "type": "fallback_package_list",


### PR DESCRIPTION
Miglioramenti infrastruttura dev tooling:
- Separati file dipendenze: `requirements.txt` (runtime puro) e `requirements-dev.txt` (test, mypy, lint).
- Rimossi errori mypy bloccanti (falsi positivi da ri-dichiarazione limitando scope) in `build_catalog_inventory.py`.
- Aggiornata la GitHub Actions CI (`ci.yml`) per eseguire in sequenza (fail-fast): installazione via `requirements-dev.txt`, `ruff check`, `mypy`, `pytest`.
- Esclusa folder interna `generated` ignorandone git-tracking per evitare PR sporche con artefatti locali.