### PR TITLE
feat: catalog inventory diff e alert automatico su variazioni

### DIFF
--- a/.github/workflows/catalog-inventory.yml
+++ b/.github/workflows/catalog-inventory.yml
@@ -135,10 +135,25 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          python scripts/catalog_diff.py previous_report.json data/catalog_inventory/generated/catalog_inventory_report.json --output diff.md
+          # Skip diff on first run (no baseline yet — previous_report.json is empty {})
+          if python -c "import json,sys; d=json.load(open('previous_report.json')); sys.exit(0 if d.get('sources') else 1)"; then
+            python scripts/catalog_diff.py previous_report.json data/catalog_inventory/generated/catalog_inventory_report.json --output diff.md
+          else
+            echo "Nessun baseline precedente — skip diff (primo run)."
+            exit 0
+          fi
+
           if [ -s diff.md ]; then
-            echo "Diff rilevato. Apro issue."
-            gh issue create --title "[Catalog] Rilevate variazioni nell'inventario" --body-file diff.md --label "catalog-alert"
+            echo "Diff rilevato."
+            ISSUE_TITLE="[Catalog] Variazioni rilevate nell'inventario"
+            EXISTING=$(gh issue list --label "catalog-alert" --state open --json number,title --jq ".[] | select(.title==\"$ISSUE_TITLE\") | .number" | head -1)
+            if [ -n "$EXISTING" ]; then
+              echo "Aggiorno issue #$EXISTING esistente."
+              gh issue comment "$EXISTING" --body-file diff.md
+            else
+              echo "Apro nuova issue."
+              gh issue create --title "$ISSUE_TITLE" --body-file diff.md --label "catalog-alert"
+            fi
           else
             echo "Nessuna variazione rilevata."
           fi

--- a/.github/workflows/catalog-inventory.yml
+++ b/.github/workflows/catalog-inventory.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -103,6 +104,14 @@ jobs:
         if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
         uses: google-github-actions/setup-gcloud@v3
 
+      - name: Download previous report
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
+        continue-on-error: true
+        run: |
+          prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
+          prefix="${prefix%/}"
+          gcloud storage cp "$prefix/catalog_inventory_report.json" previous_report.json || echo "{}" > previous_report.json
+
       - name: Upload snapshot to GCS
         if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
         run: |
@@ -120,3 +129,16 @@ jobs:
           gcloud storage cp data/catalog_inventory/generated/catalog_inventory_report.json "$prefix/catalog_inventory_report.json"
           gcloud storage cp data/catalog_inventory/generated/catalog_inventory_latest.parquet "$prefix/snapshots/catalog_inventory_${stamp}.parquet"
           gcloud storage cp data/catalog_inventory/generated/catalog_inventory_report.json "$prefix/snapshots/catalog_inventory_report_${stamp}.json"
+
+      - name: Generate diff and alert
+        if: ${{ hashFiles('previous_report.json') != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/catalog_diff.py previous_report.json data/catalog_inventory/generated/catalog_inventory_report.json --output diff.md
+          if [ -s diff.md ]; then
+            echo "Diff rilevato. Apro issue."
+            gh issue create --title "[Catalog] Rilevate variazioni nell'inventario" --body-file diff.md --label "catalog-alert"
+          else
+            echo "Nessuna variazione rilevata."
+          fi

--- a/.github/workflows/catalog-inventory.yml
+++ b/.github/workflows/catalog-inventory.yml
@@ -106,7 +106,6 @@ jobs:
 
       - name: Download previous report
         if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
-        continue-on-error: true
         run: |
           prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
           prefix="${prefix%/}"
@@ -131,7 +130,7 @@ jobs:
           gcloud storage cp data/catalog_inventory/generated/catalog_inventory_report.json "$prefix/snapshots/catalog_inventory_report_${stamp}.json"
 
       - name: Generate diff and alert
-        if: ${{ hashFiles('previous_report.json') != '' }}
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/scripts/catalog_diff.py
+++ b/scripts/catalog_diff.py
@@ -2,15 +2,17 @@
 """
 Compara due report di catalog inventory e genera un sommario markdown delle divergenze.
 """
+
 from __future__ import annotations
 import json
 import argparse
 import sys
-from pathlib import Path
+
 
 def load_report(path: str) -> dict:
-    with open(path, 'r', encoding='utf-8') as f:
+    with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
+
 
 def is_baseline_empty(report: dict) -> bool:
     """True if the report has no sources — signals a missing baseline (first run)."""
@@ -60,13 +62,17 @@ def generate_diff(old_report: dict, new_report: dict) -> str:
     if regressions:
         lines.append("#### Regressioni (ok → errore)")
         for key, val in regressions:
-            lines.append(f"- `{key}` ({val.get('protocol', 'n/d')}): {val.get('status')} — {val.get('error') or val.get('reason', 'n/d')}")
+            lines.append(
+                f"- `{key}` ({val.get('protocol', 'n/d')}): {val.get('status')} — {val.get('error') or val.get('reason', 'n/d')}"
+            )
         lines.append("")
 
     if added:
         lines.append("#### Nuove fonti rilevate")
         for key, val in added:
-            lines.append(f"- `{key}`: {val.get('rows', 0)} item ({val.get('protocol', 'n/d')})")
+            lines.append(
+                f"- `{key}`: {val.get('rows', 0)} item ({val.get('protocol', 'n/d')})"
+            )
         lines.append("")
 
     if removed:
@@ -88,27 +94,29 @@ def generate_diff(old_report: dict, new_report: dict) -> str:
     lines.append(f"Calcolato il: {new_report.get('captured_at', 'n/d')}")
     return "\n".join(lines)
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("old_report", help="Path al report JSON precedente")
     parser.add_argument("new_report", help="Path al report JSON attuale")
     parser.add_argument("--output", help="Path al file markdown di output (opzionale)")
     args = parser.parse_args()
-    
+
     try:
         old_data = load_report(args.old_report)
         new_data = load_report(args.new_report)
     except Exception as e:
         print(f"Errore caricamento report: {e}", file=sys.stderr)
         sys.exit(1)
-        
+
     markdown = generate_diff(old_data, new_data)
-    
+
     if args.output:
-        with open(args.output, 'w', encoding='utf-8') as f:
+        with open(args.output, "w", encoding="utf-8") as f:
             f.write(markdown)
     else:
         print(markdown)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/catalog_diff.py
+++ b/scripts/catalog_diff.py
@@ -12,49 +12,71 @@ def load_report(path: str) -> dict:
     with open(path, 'r', encoding='utf-8') as f:
         return json.load(f)
 
+def is_baseline_empty(report: dict) -> bool:
+    """True if the report has no sources — signals a missing baseline (first run)."""
+    return not report.get("sources")
+
+
 def generate_diff(old_report: dict, new_report: dict) -> str:
     old_sources = old_report.get("sources", {})
     new_sources = new_report.get("sources", {})
-    
+
     all_keys = sorted(set(old_sources.keys()) | set(new_sources.keys()))
-    
+
     added = []
     removed = []
     changed = []
-    
+    regressions = []
+
     for key in all_keys:
         old_val = old_sources.get(key)
         new_val = new_sources.get(key)
-        
+
         if old_val is None:
             added.append((key, new_val))
         elif new_val is None:
             removed.append((key, old_val))
         else:
-            old_rows = old_val.get("rows", 0)
-            new_rows = new_val.get("rows", 0)
-            if old_rows != new_rows:
+            old_status = old_val.get("status", "ok")
+            new_status = new_val.get("status", "ok")
+            if old_status == "ok" and new_status != "ok":
+                regressions.append((key, new_val))
+            elif old_status != "ok" and new_status == "ok":
+                # recovery — treat as changed (positive)
+                old_rows = old_val.get("rows", 0)
+                new_rows = new_val.get("rows", 0)
                 changed.append((key, old_rows, new_rows))
-    
-    if not added and not removed and not changed:
+            elif old_status == "ok" and new_status == "ok":
+                old_rows = old_val.get("rows", 0)
+                new_rows = new_val.get("rows", 0)
+                if old_rows != new_rows:
+                    changed.append((key, old_rows, new_rows))
+
+    if not added and not removed and not changed and not regressions:
         return ""
 
-    lines = ["### 📊 Variazioni nel Catalogo", ""]
-    
+    lines = ["### Variazioni nel Catalogo", ""]
+
+    if regressions:
+        lines.append("#### Regressioni (ok → errore)")
+        for key, val in regressions:
+            lines.append(f"- `{key}` ({val.get('protocol', 'n/d')}): {val.get('status')} — {val.get('error') or val.get('reason', 'n/d')}")
+        lines.append("")
+
     if added:
-        lines.append("#### ✨ Nuove fonti rilevate")
+        lines.append("#### Nuove fonti rilevate")
         for key, val in added:
             lines.append(f"- `{key}`: {val.get('rows', 0)} item ({val.get('protocol', 'n/d')})")
         lines.append("")
 
     if removed:
-        lines.append("#### 🗑️ Fonti rimosse o non più raggiungibili")
+        lines.append("#### Fonti rimosse o non più raggiungibili")
         for key, val in removed:
             lines.append(f"- `{key}` (precedentemente {val.get('rows', 0)} item)")
         lines.append("")
 
     if changed:
-        lines.append("#### 📉 Variazione numero item")
+        lines.append("#### Variazione numero item")
         lines.append("| Fonte | Precedente | Attuale | Delta |")
         lines.append("| :--- | :---: | :---: | :---: |")
         for key, old_r, new_r in changed:
@@ -62,7 +84,7 @@ def generate_diff(old_report: dict, new_report: dict) -> str:
             delta_str = f"+{delta}" if delta > 0 else str(delta)
             lines.append(f"| `{key}` | {old_r} | {new_r} | **{delta_str}** |")
         lines.append("")
-        
+
     lines.append(f"Calcolato il: {new_report.get('captured_at', 'n/d')}")
     return "\n".join(lines)
 

--- a/scripts/catalog_diff.py
+++ b/scripts/catalog_diff.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Compara due report di catalog inventory e genera un sommario markdown delle divergenze.
+"""
+from __future__ import annotations
+import json
+import argparse
+import sys
+from pathlib import Path
+
+def load_report(path: str) -> dict:
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+def generate_diff(old_report: dict, new_report: dict) -> str:
+    old_sources = old_report.get("sources", {})
+    new_sources = new_report.get("sources", {})
+    
+    all_keys = sorted(set(old_sources.keys()) | set(new_sources.keys()))
+    
+    added = []
+    removed = []
+    changed = []
+    
+    for key in all_keys:
+        old_val = old_sources.get(key)
+        new_val = new_sources.get(key)
+        
+        if old_val is None:
+            added.append((key, new_val))
+        elif new_val is None:
+            removed.append((key, old_val))
+        else:
+            old_rows = old_val.get("rows", 0)
+            new_rows = new_val.get("rows", 0)
+            if old_rows != new_rows:
+                changed.append((key, old_rows, new_rows))
+    
+    if not added and not removed and not changed:
+        return ""
+
+    lines = ["### 📊 Variazioni nel Catalogo", ""]
+    
+    if added:
+        lines.append("#### ✨ Nuove fonti rilevate")
+        for key, val in added:
+            lines.append(f"- `{key}`: {val.get('rows', 0)} item ({val.get('protocol', 'n/d')})")
+        lines.append("")
+
+    if removed:
+        lines.append("#### 🗑️ Fonti rimosse o non più raggiungibili")
+        for key, val in removed:
+            lines.append(f"- `{key}` (precedentemente {val.get('rows', 0)} item)")
+        lines.append("")
+
+    if changed:
+        lines.append("#### 📉 Variazione numero item")
+        lines.append("| Fonte | Precedente | Attuale | Delta |")
+        lines.append("| :--- | :---: | :---: | :---: |")
+        for key, old_r, new_r in changed:
+            delta = new_r - old_r
+            delta_str = f"+{delta}" if delta > 0 else str(delta)
+            lines.append(f"| `{key}` | {old_r} | {new_r} | **{delta_str}** |")
+        lines.append("")
+        
+    lines.append(f"Calcolato il: {new_report.get('captured_at', 'n/d')}")
+    return "\n".join(lines)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("old_report", help="Path al report JSON precedente")
+    parser.add_argument("new_report", help="Path al report JSON attuale")
+    parser.add_argument("--output", help="Path al file markdown di output (opzionale)")
+    args = parser.parse_args()
+    
+    try:
+        old_data = load_report(args.old_report)
+        new_data = load_report(args.new_report)
+    except Exception as e:
+        print(f"Errore caricamento report: {e}", file=sys.stderr)
+        sys.exit(1)
+        
+    markdown = generate_diff(old_data, new_data)
+    
+    if args.output:
+        with open(args.output, 'w', encoding='utf-8') as f:
+            f.write(markdown)
+    else:
+        print(markdown)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/catalog_diff.py
+++ b/scripts/catalog_diff.py
@@ -29,6 +29,8 @@ def generate_diff(old_report: dict, new_report: dict) -> str:
     removed = []
     changed = []
     regressions = []
+    recoveries = []
+    persistent_errors = []
 
     for key in all_keys:
         old_val = old_sources.get(key)
@@ -41,20 +43,24 @@ def generate_diff(old_report: dict, new_report: dict) -> str:
         else:
             old_status = old_val.get("status", "ok")
             new_status = new_val.get("status", "ok")
-            if old_status == "ok" and new_status != "ok":
+            old_ok = old_status == "ok"
+            new_ok = new_status == "ok"
+            if old_ok and not new_ok:
                 regressions.append((key, new_val))
-            elif old_status != "ok" and new_status == "ok":
-                # recovery — treat as changed (positive)
-                old_rows = old_val.get("rows", 0)
-                new_rows = new_val.get("rows", 0)
-                changed.append((key, old_rows, new_rows))
-            elif old_status == "ok" and new_status == "ok":
+            elif not old_ok and new_ok:
+                recoveries.append((key, new_val))
+            elif not old_ok and not new_ok:
+                # errore → errore: segnala se il messaggio cambia o sempre
+                old_err = old_val.get("error") or old_val.get("reason", "")
+                new_err = new_val.get("error") or new_val.get("reason", "")
+                persistent_errors.append((key, new_val, old_err != new_err))
+            else:
                 old_rows = old_val.get("rows", 0)
                 new_rows = new_val.get("rows", 0)
                 if old_rows != new_rows:
                     changed.append((key, old_rows, new_rows))
 
-    if not added and not removed and not changed and not regressions:
+    if not added and not removed and not changed and not regressions and not recoveries and not persistent_errors:
         return ""
 
     lines = ["### Variazioni nel Catalogo", ""]
@@ -64,6 +70,23 @@ def generate_diff(old_report: dict, new_report: dict) -> str:
         for key, val in regressions:
             lines.append(
                 f"- `{key}` ({val.get('protocol', 'n/d')}): {val.get('status')} — {val.get('error') or val.get('reason', 'n/d')}"
+            )
+        lines.append("")
+
+    if persistent_errors:
+        lines.append("#### Errori persistenti (errore → errore)")
+        for key, val, changed_msg in persistent_errors:
+            suffix = " *(messaggio cambiato)*" if changed_msg else ""
+            lines.append(
+                f"- `{key}` ({val.get('protocol', 'n/d')}): {val.get('error') or val.get('reason', 'n/d')}{suffix}"
+            )
+        lines.append("")
+
+    if recoveries:
+        lines.append("#### Recovery (errore → ok)")
+        for key, val in recoveries:
+            lines.append(
+                f"- `{key}` ({val.get('protocol', 'n/d')}): tornato ok — {val.get('rows', 0)} item"
             )
         lines.append("")
 

--- a/tests/test_catalog_diff.py
+++ b/tests/test_catalog_diff.py
@@ -1,0 +1,90 @@
+"""Tests for catalog_diff.py — generate_diff."""
+from __future__ import annotations
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from catalog_diff import generate_diff
+
+
+def _report(*sources: tuple) -> dict:
+    """Build a minimal report dict from (id, status, rows?, error?) tuples."""
+    out: dict = {"captured_at": "2026-04-16T00:00:00+00:00", "sources": {}}
+    for item in sources:
+        sid, status = item[0], item[1]
+        rows = item[2] if len(item) > 2 else None
+        err = item[3] if len(item) > 3 else None
+        entry: dict = {"status": status, "protocol": "ckan"}
+        if rows is not None:
+            entry["rows"] = rows
+        if err:
+            entry["error"] = err
+        out["sources"][sid] = entry
+    return out
+
+
+def test_no_changes_returns_empty():
+    old = _report(("alpha", "ok", 100))
+    new = _report(("alpha", "ok", 100))
+    assert generate_diff(old, new) == ""
+
+
+def test_regression_ok_to_error():
+    old = _report(("alpha", "ok", 100))
+    new = _report(("alpha", "error", 0, "timeout"))
+    diff = generate_diff(old, new)
+    assert "Regressioni" in diff
+    assert "alpha" in diff
+    assert "timeout" in diff
+
+
+def test_recovery_error_to_ok():
+    old = _report(("alpha", "error", 0, "WAF"))
+    new = _report(("alpha", "ok", 50))
+    diff = generate_diff(old, new)
+    assert "Recovery" in diff
+    assert "alpha" in diff
+    assert "Regressioni" not in diff
+
+
+def test_persistent_error_always_reported():
+    old = _report(("alpha", "error", 0, "timeout"))
+    new = _report(("alpha", "error", 0, "timeout"))
+    diff = generate_diff(old, new)
+    assert "Errori persistenti" in diff
+    assert "alpha" in diff
+
+
+def test_persistent_error_changed_message_flagged():
+    old = _report(("alpha", "error", 0, "timeout"))
+    new = _report(("alpha", "error", 0, "WAF 403"))
+    diff = generate_diff(old, new)
+    assert "messaggio cambiato" in diff
+
+
+def test_added_and_removed():
+    old = _report(("alpha", "ok", 100))
+    new = _report(("beta", "ok", 50))
+    diff = generate_diff(old, new)
+    assert "Nuove fonti" in diff
+    assert "beta" in diff
+    assert "rimosse" in diff
+    assert "alpha" in diff
+
+
+def test_row_count_change():
+    old = _report(("alpha", "ok", 100))
+    new = _report(("alpha", "ok", 120))
+    diff = generate_diff(old, new)
+    assert "Variazione numero item" in diff
+    assert "+20" in diff
+
+
+def test_recovery_not_in_changed_table():
+    """Recovery must not appear in 'Variazione numero item'."""
+    old = _report(("alpha", "error", 0, "WAF"))
+    new = _report(("alpha", "ok", 50))
+    diff = generate_diff(old, new)
+    assert "Variazione numero item" not in diff


### PR DESCRIPTION
## Summary

- Aggiunge `scripts/catalog_diff.py`: compara due snapshot `catalog_inventory_report.json` e produce un markdown con variazioni (nuove fonti, rimosse, cambio row count, regressioni ok→errore)
- Integra il diff nel workflow `catalog-inventory.yml`: scarica il report precedente da GCS, genera il diff, apre o aggiorna un'issue con label `catalog-alert` se ci sono variazioni

## Comportamento

- **Anti-flood**: se esiste già un'issue aperta con titolo `[Catalog] Variazioni rilevate nell'inventario`, aggiunge un commento invece di aprirne una nuova
- **First-run safe**: se non c'è ancora un baseline su GCS (`previous_report.json` è `{}`), il diff viene saltato con log esplicito
- **Regressioni di status**: transizioni `ok → errore` appaiono in sezione dedicata con messaggio di errore, non solo variazioni di row count

## Test plan

- [ ] Verificare che il workflow giri senza errori su `workflow_dispatch`
- [ ] Verificare che al primo run (nessun baseline GCS) il diff step venga saltato
- [ ] Verificare che al secondo run venga aperta una issue se ci sono variazioni
- [ ] Verificare che run successivi con stessa variazione aggiungano un commento, non una nuova issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)