### PR TITLE
feat(so): genera catalog_signals.json automaticamente da CI

### DIFF
--- a/.github/workflows/catalog-inventory.yml
+++ b/.github/workflows/catalog-inventory.yml
@@ -6,7 +6,7 @@ on:
     - cron: "15 3 * * 1"
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   issues: write
 
@@ -128,6 +128,27 @@ jobs:
           gcloud storage cp data/catalog_inventory/generated/catalog_inventory_report.json "$prefix/catalog_inventory_report.json"
           gcloud storage cp data/catalog_inventory/generated/catalog_inventory_latest.parquet "$prefix/snapshots/catalog_inventory_${stamp}.parquet"
           gcloud storage cp data/catalog_inventory/generated/catalog_inventory_report.json "$prefix/snapshots/catalog_inventory_report_${stamp}.json"
+
+      - name: Build catalog signals
+        run: |
+          python scripts/build_catalog_signals.py \
+            --report data/catalog_inventory/generated/catalog_inventory_report.json \
+            --previous previous_report.json \
+            --out data/catalog/catalog_signals.json
+
+      - name: Commit catalog signals
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/catalog/catalog_signals.json
+          if git diff --cached --quiet; then
+            echo "Nessuna variazione nei segnali."
+          else
+            git commit -m "chore(so): aggiorna catalog_signals.json [ci skip]"
+            git push
+          fi
 
       - name: Generate diff and alert
         if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}

--- a/scripts/build_catalog_signals.py
+++ b/scripts/build_catalog_signals.py
@@ -96,9 +96,23 @@ def _classify(
                 "suggested_action": "nessuna",
             }
 
-        # Inventory change
+        # Inventory change — solo se il metodo di conteggio coincide (policy comparabilità)
         if prev_info and prev_info.get("status") == "ok":
             prev_rows = prev_info.get("rows", 0)
+            prev_method = prev_info.get("method")
+            if prev_method and prev_method != method:
+                return {
+                    "source": source_id,
+                    "protocol": protocol,
+                    "signal_type": "missing_data",
+                    "result": "missing_data",
+                    "metric_value": rows,
+                    "detail": (
+                        f"Metodo cambiato: precedente '{prev_method}', attuale '{method}'. "
+                        "Delta non confrontabile con la baseline."
+                    ),
+                    "suggested_action": "verificare causa cambio metodo; non usare delta come segnale",
+                }
             if rows != prev_rows:
                 delta = rows - prev_rows
                 delta_str = f"+{delta}" if delta > 0 else str(delta)

--- a/scripts/build_catalog_signals.py
+++ b/scripts/build_catalog_signals.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Genera catalog_signals.json da catalog_inventory_report.json.
+
+Confronta con il report precedente (se disponibile) per rilevare
+regressioni, recovery e variazioni di inventory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REPORT = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_report.json"
+DEFAULT_OUT = REPO_ROOT / "data" / "catalog" / "catalog_signals.json"
+
+
+def _classify(
+    source_id: str,
+    info: dict,
+    prev_info: dict | None,
+) -> dict:
+    status = info.get("status")
+    protocol = info.get("protocol", "n/d")
+
+    # Non inventariabile: includi solo se era ok prima (regressione strutturale)
+    if status in ("non_inventariabile", "protocol_not_supported"):
+        prev_status = prev_info.get("status") if prev_info else None
+        if prev_status == "ok":
+            return {
+                "source": source_id,
+                "protocol": protocol,
+                "signal_type": "structural drift",
+                "result": "regressione",
+                "metric_value": None,
+                "detail": info.get("reason", "Fonte non più inventariabile."),
+                "suggested_action": "verificare causa — fonte precedentemente ok",
+            }
+        return {
+            "source": source_id,
+            "protocol": protocol,
+            "signal_type": "no signal",
+            "result": "stabile",
+            "metric_value": None,
+            "detail": info.get("reason", "Fonte non inventariabile."),
+            "suggested_action": "nessuna",
+        }
+
+    # Errore
+    if status == "error":
+        error_msg = info.get("error", "errore sconosciuto")
+        prev_status = prev_info.get("status") if prev_info else None
+        if prev_status == "error":
+            prev_error = prev_info.get("error", "")
+            changed = prev_error != error_msg
+            detail = f"Errore persistente: {error_msg}"
+            if changed:
+                detail += " (messaggio cambiato rispetto al run precedente)"
+            return {
+                "source": source_id,
+                "protocol": protocol,
+                "signal_type": "health",
+                "result": "regressione",
+                "metric_value": None,
+                "detail": detail,
+                "suggested_action": "valutare declassamento a radar-only se persiste",
+            }
+        # Nuova regressione
+        return {
+            "source": source_id,
+            "protocol": protocol,
+            "signal_type": "health",
+            "result": "regressione",
+            "metric_value": None,
+            "detail": f"Errore: {error_msg}",
+            "suggested_action": "monitorare nei prossimi run",
+        }
+
+    # Ok
+    if status == "ok":
+        rows = info.get("rows", 0)
+        method = info.get("method", "n/d")
+        prev_status = prev_info.get("status") if prev_info else None
+
+        # Recovery
+        if prev_status == "error":
+            return {
+                "source": source_id,
+                "protocol": protocol,
+                "signal_type": "health",
+                "result": "recovery",
+                "metric_value": rows,
+                "detail": f"Tornato ok. {rows} item ({method}).",
+                "suggested_action": "nessuna",
+            }
+
+        # Inventory change
+        if prev_info and prev_info.get("status") == "ok":
+            prev_rows = prev_info.get("rows", 0)
+            if rows != prev_rows:
+                delta = rows - prev_rows
+                delta_str = f"+{delta}" if delta > 0 else str(delta)
+                return {
+                    "source": source_id,
+                    "protocol": protocol,
+                    "signal_type": "inventory change",
+                    "result": "inventory change",
+                    "metric_value": rows,
+                    "detail": f"{rows} item ({method}), delta {delta_str} rispetto al run precedente ({prev_rows}).",
+                    "suggested_action": "verificare se variazione attesa; avviare catalog-inventory-scout se nuovi dataset",
+                }
+
+        # Stabile
+        return {
+            "source": source_id,
+            "protocol": protocol,
+            "signal_type": "no signal",
+            "result": "stabile",
+            "metric_value": rows,
+            "detail": f"{rows} item ({method}), in linea con la baseline.",
+            "suggested_action": "nessuna",
+        }
+
+    # Fallback
+    return {
+        "source": source_id,
+        "protocol": protocol,
+        "signal_type": "no signal",
+        "result": "stabile",
+        "metric_value": None,
+        "detail": f"Status non gestito: {status}",
+        "suggested_action": "nessuna",
+    }
+
+
+def build_signals(report: dict, prev_report: dict | None) -> dict:
+    sources = report.get("sources", {})
+    prev_sources = (prev_report or {}).get("sources", {})
+
+    signals = []
+    for source_id, info in sources.items():
+        prev_info = prev_sources.get(source_id)
+        signals.append(_classify(source_id, info, prev_info))
+
+    # Rimuovi metric_value None per pulizia (campi opzionali)
+    for s in signals:
+        if s.get("metric_value") is None:
+            del s["metric_value"]
+
+    return {
+        "captured_at": report.get("captured_at", ""),
+        "sources_checked": len(sources),
+        "signals": signals,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Genera catalog_signals.json da catalog_inventory_report.json."
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=DEFAULT_REPORT,
+        help="Path al report inventory attuale.",
+    )
+    parser.add_argument(
+        "--previous",
+        type=Path,
+        default=None,
+        help="Path al report inventory precedente (opzionale, per rilevare regressioni).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help="Path di output per catalog_signals.json.",
+    )
+    args = parser.parse_args()
+
+    report = json.loads(args.report.read_text(encoding="utf-8"))
+    prev_report = None
+    if args.previous and args.previous.exists():
+        prev_report = json.loads(args.previous.read_text(encoding="utf-8"))
+        if not prev_report.get("sources"):
+            prev_report = None  # primo run
+
+    signals = build_signals(report, prev_report)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(signals, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Wrote {len(signals['signals'])} signals to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_catalog_signals.py
+++ b/scripts/build_catalog_signals.py
@@ -52,7 +52,7 @@ def _classify(
     if status == "error":
         error_msg = info.get("error", "errore sconosciuto")
         prev_status = prev_info.get("status") if prev_info else None
-        if prev_status == "error":
+        if prev_status == "error" and prev_info is not None:
             prev_error = prev_info.get("error", "")
             changed = prev_error != error_msg
             detail = f"Errore persistente: {error_msg}"

--- a/tests/test_build_catalog_signals.py
+++ b/tests/test_build_catalog_signals.py
@@ -1,0 +1,149 @@
+"""Tests for build_catalog_signals.py."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from build_catalog_signals import build_signals, _classify
+
+
+def _report(*sources: tuple) -> dict:
+    return {
+        "captured_at": "2026-04-17T10:00:00+00:00",
+        "sources": {sid: info for sid, info in sources},
+    }
+
+
+def _ok(rows: int = 100, method: str = "package_list", protocol: str = "ckan") -> dict:
+    return {"status": "ok", "protocol": protocol, "rows": rows, "method": method}
+
+
+def _error(msg: str = "timeout", protocol: str = "ckan") -> dict:
+    return {"status": "error", "protocol": protocol, "error": msg}
+
+
+def _non_inv(protocol: str = "ckan") -> dict:
+    return {"status": "non_inventariabile", "protocol": protocol, "reason": "WAF attivo."}
+
+
+# --- stabile ---
+
+def test_stable_no_previous():
+    sig = _classify("src", _ok(), None)
+    assert sig["signal_type"] == "no signal"
+    assert sig["result"] == "stabile"
+    assert sig["metric_value"] == 100
+
+
+def test_stable_same_rows():
+    sig = _classify("src", _ok(rows=100), _ok(rows=100))
+    assert sig["result"] == "stabile"
+
+
+# --- inventory change ---
+
+def test_inventory_change_detected():
+    sig = _classify("src", _ok(rows=150), _ok(rows=100))
+    assert sig["signal_type"] == "inventory change"
+    assert sig["metric_value"] == 150
+    assert "+50" in sig["detail"]
+
+
+def test_inventory_change_negative_delta():
+    sig = _classify("src", _ok(rows=80), _ok(rows=100))
+    assert sig["signal_type"] == "inventory change"
+    assert "-20" in sig["detail"]
+
+
+# --- method mismatch → missing_data ---
+
+def test_method_mismatch_emits_missing_data():
+    current = _ok(rows=200, method="package_list")
+    prev = _ok(rows=100, method="package_search")
+    sig = _classify("src", current, prev)
+    assert sig["signal_type"] == "missing_data"
+    assert sig["result"] == "missing_data"
+    assert "package_search" in sig["detail"]
+    assert "package_list" in sig["detail"]
+
+
+def test_method_mismatch_even_if_rows_same():
+    current = _ok(rows=100, method="package_list")
+    prev = _ok(rows=100, method="package_search")
+    sig = _classify("src", current, prev)
+    assert sig["signal_type"] == "missing_data"
+
+
+def test_no_mismatch_when_prev_method_missing():
+    """Se il report precedente non ha method, non bloccare su mismatch."""
+    prev = {"status": "ok", "protocol": "ckan", "rows": 100}  # no method field
+    sig = _classify("src", _ok(rows=150, method="package_list"), prev)
+    assert sig["signal_type"] == "inventory change"
+
+
+# --- regressione ---
+
+def test_new_regression():
+    sig = _classify("src", _error("connection refused"), _ok())
+    assert sig["signal_type"] == "health"
+    assert sig["result"] == "regressione"
+    assert "monitorare" in sig["suggested_action"]
+
+
+def test_persistent_regression_same_message():
+    sig = _classify("src", _error("timeout"), _error("timeout"))
+    assert sig["result"] == "regressione"
+    assert "persistente" in sig["detail"]
+    assert "messaggio cambiato" not in sig["detail"]
+
+
+def test_persistent_regression_changed_message():
+    sig = _classify("src", _error("503 Service Unavailable"), _error("timeout"))
+    assert sig["result"] == "regressione"
+    assert "messaggio cambiato" in sig["detail"]
+
+
+def test_persistent_regression_suggests_declassamento():
+    sig = _classify("src", _error("timeout"), _error("timeout"))
+    assert "radar-only" in sig["suggested_action"]
+
+
+# --- recovery ---
+
+def test_recovery():
+    sig = _classify("src", _ok(rows=100), _error("timeout"))
+    assert sig["signal_type"] == "health"
+    assert sig["result"] == "recovery"
+    assert sig["metric_value"] == 100
+
+
+# --- non_inventariabile ---
+
+def test_non_inventariabile_stable_if_never_ok():
+    sig = _classify("src", _non_inv(), None)
+    assert sig["result"] == "stabile"
+    assert sig["signal_type"] == "no signal"
+
+
+def test_non_inventariabile_regression_if_was_ok():
+    sig = _classify("src", _non_inv(), _ok())
+    assert sig["signal_type"] == "structural drift"
+    assert sig["result"] == "regressione"
+
+
+# --- build_signals integration ---
+
+def test_build_signals_structure():
+    report = _report(("istat", _ok(rows=4212, method="dataflow_count", protocol="sdmx")))
+    out = build_signals(report, None)
+    assert out["sources_checked"] == 1
+    assert out["captured_at"] == report["captured_at"]
+    assert len(out["signals"]) == 1
+
+
+def test_build_signals_method_mismatch_end_to_end():
+    current = _report(("anac", _ok(rows=200, method="package_list")))
+    previous = _report(("anac", _ok(rows=100, method="package_search")))
+    out = build_signals(current, previous)
+    assert out["signals"][0]["signal_type"] == "missing_data"


### PR DESCRIPTION
## Summary

- Aggiunge `scripts/build_catalog_signals.py`: trasforma `catalog_inventory_report.json` in `catalog_signals.json` in modo deterministico, senza LLM
- Classifica ogni fonte: `stabile`, `regressione`, `recovery`, `inventory change`, `structural drift`
- Aggiunge campo `metric_value` numerico (dove applicabile) per consumo programmatico da ACB
- Aggiorna `catalog-inventory.yml`: due nuovi step dopo il run settimanale — build signals + commit automatico (`[ci skip]`)
- Permessi workflow aggiornati a `contents: write` per abilitare il commit

## Motivazione

`catalog_signals.json` era aggiornato manualmente dall'agente durante catalog-watch. Ora è generato automaticamente ogni lunedì insieme all'inventario, quindi ACB legge sempre segnali freschi.

## Test plan

- [ ] Script testato localmente su report reale (11 fonti, tutti stabile)
- [ ] Testato con mock previous report: inventory change, structural drift (ANAC ok→non_inventariabile), recovery — tutti classificati correttamente
- [ ] Verificare primo run CI: `catalog_signals.json` committato senza errori
- [ ] Verificare run successivo con variazione: segnale `inventory change` atteso

🤖 Generated with [Claude Code](https://claude.com/claude-code)