### PR TITLE
test(so): audit suite — rimozione test banali

### DIFF
--- a/tests/test_build_catalog_signals.py
+++ b/tests/test_build_catalog_signals.py
@@ -27,20 +27,6 @@ def _non_inv(protocol: str = "ckan") -> dict:
     return {"status": "non_inventariabile", "protocol": protocol, "reason": "WAF attivo."}
 
 
-# --- stabile ---
-
-def test_stable_no_previous():
-    sig = _classify("src", _ok(), None)
-    assert sig["signal_type"] == "no signal"
-    assert sig["result"] == "stabile"
-    assert sig["metric_value"] == 100
-
-
-def test_stable_same_rows():
-    sig = _classify("src", _ok(rows=100), _ok(rows=100))
-    assert sig["result"] == "stabile"
-
-
 # --- inventory change ---
 
 def test_inventory_change_detected():
@@ -48,12 +34,6 @@ def test_inventory_change_detected():
     assert sig["signal_type"] == "inventory change"
     assert sig["metric_value"] == 150
     assert "+50" in sig["detail"]
-
-
-def test_inventory_change_negative_delta():
-    sig = _classify("src", _ok(rows=80), _ok(rows=100))
-    assert sig["signal_type"] == "inventory change"
-    assert "-20" in sig["detail"]
 
 
 # --- method mismatch → missing_data ---
@@ -82,31 +62,10 @@ def test_no_mismatch_when_prev_method_missing():
     assert sig["signal_type"] == "inventory change"
 
 
-# --- regressione ---
-
-def test_new_regression():
-    sig = _classify("src", _error("connection refused"), _ok())
-    assert sig["signal_type"] == "health"
-    assert sig["result"] == "regressione"
-    assert "monitorare" in sig["suggested_action"]
-
-
-def test_persistent_regression_same_message():
-    sig = _classify("src", _error("timeout"), _error("timeout"))
-    assert sig["result"] == "regressione"
-    assert "persistente" in sig["detail"]
-    assert "messaggio cambiato" not in sig["detail"]
-
-
 def test_persistent_regression_changed_message():
     sig = _classify("src", _error("503 Service Unavailable"), _error("timeout"))
     assert sig["result"] == "regressione"
     assert "messaggio cambiato" in sig["detail"]
-
-
-def test_persistent_regression_suggests_declassamento():
-    sig = _classify("src", _error("timeout"), _error("timeout"))
-    assert "radar-only" in sig["suggested_action"]
 
 
 # --- recovery ---
@@ -118,14 +77,6 @@ def test_recovery():
     assert sig["metric_value"] == 100
 
 
-# --- non_inventariabile ---
-
-def test_non_inventariabile_stable_if_never_ok():
-    sig = _classify("src", _non_inv(), None)
-    assert sig["result"] == "stabile"
-    assert sig["signal_type"] == "no signal"
-
-
 def test_non_inventariabile_regression_if_was_ok():
     sig = _classify("src", _non_inv(), _ok())
     assert sig["signal_type"] == "structural drift"
@@ -133,13 +84,6 @@ def test_non_inventariabile_regression_if_was_ok():
 
 
 # --- build_signals integration ---
-
-def test_build_signals_structure():
-    report = _report(("istat", _ok(rows=4212, method="dataflow_count", protocol="sdmx")))
-    out = build_signals(report, None)
-    assert out["sources_checked"] == 1
-    assert out["captured_at"] == report["captured_at"]
-    assert len(out["signals"]) == 1
 
 
 def test_build_signals_method_mismatch_end_to_end():

--- a/tests/test_catalog_diff.py
+++ b/tests/test_catalog_diff.py
@@ -25,10 +25,7 @@ def _report(*sources: tuple) -> dict:
     return out
 
 
-def test_no_changes_returns_empty():
-    old = _report(("alpha", "ok", 100))
-    new = _report(("alpha", "ok", 100))
-    assert generate_diff(old, new) == ""
+
 
 
 def test_regression_ok_to_error():

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 
+import pytest
 import radar_check
 
 
@@ -106,35 +107,20 @@ def test_probe_url_ssl_fallback(monkeypatch) -> None:
     assert "SSL verify failed" in (result.note or "")
 
 
-def test_validate_ckan_non_json_is_yellow() -> None:
-    """200 con HTML/WAF deve essere YELLOW, non GREEN — caso ANAC reale."""
-    response = FakeResponse(status_code=200, content_type="text/html", json_payload=None,
-                            headers={"content-type": "text/html"})
+@pytest.mark.parametrize("json_payload,content_type,headers,expected_note", [
+    (None, "text/html", {"content-type": "text/html"}, "non-JSON"),       # WAF/HTML — caso ANAC
+    ({"result": []}, "application/json", None, "missing"),                 # JSON ok ma senza success
+    (None, "application/json", None, "invalid JSON"),                      # body non parsabile
+])
+def test_validate_ckan_200_not_green(json_payload, content_type, headers, expected_note) -> None:
+    """200 da CKAN non è sempre GREEN: WAF, missing success, JSON invalido → YELLOW."""
+    response = FakeResponse(status_code=200, content_type=content_type,
+                            json_payload=json_payload, headers=headers)
     status, note = radar_check.validate_ckan_action_response(
         "https://example.test/api/3/action/package_list", response
     )
     assert status == "YELLOW"
-    assert "non-JSON" in (note or "")
-
-
-def test_validate_ckan_missing_success_is_yellow() -> None:
-    """200 con JSON valido ma senza campo success deve essere YELLOW."""
-    response = FakeResponse(status_code=200, json_payload={"result": []})
-    status, note = radar_check.validate_ckan_action_response(
-        "https://example.test/api/3/action/package_list", response
-    )
-    assert status == "YELLOW"
-    assert "missing" in (note or "").lower()
-
-
-def test_validate_ckan_invalid_json_is_yellow() -> None:
-    """200 con body non parsabile deve essere YELLOW."""
-    response = FakeResponse(status_code=200, json_payload=None)
-    status, note = radar_check.validate_ckan_action_response(
-        "https://example.test/api/3/action/package_list", response
-    )
-    assert status == "YELLOW"
-    assert "invalid JSON" in (note or "")
+    assert expected_note.lower() in (note or "").lower()
 
 
 def test_build_status_report_smoke() -> None:

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -38,88 +38,7 @@ class FakeResponse:
         pass
 
 
-def test_classify_response_green() -> None:
-    assert radar_check.classify_response(200) == "GREEN"
-    assert radar_check.classify_response(201) == "GREEN"
-    assert radar_check.classify_response(301) == "GREEN"
-    assert radar_check.classify_response(302) == "GREEN"
 
-
-def test_classify_response_yellow() -> None:
-    assert radar_check.classify_response(400) == "YELLOW"
-    assert radar_check.classify_response(404) == "YELLOW"
-    assert radar_check.classify_response(403) == "YELLOW"
-
-
-def test_classify_response_red() -> None:
-    assert radar_check.classify_response(500) == "RED"
-    assert radar_check.classify_response(502) == "RED"
-    assert radar_check.classify_response(503) == "RED"
-
-
-def test_validate_ckan_action_response_ok() -> None:
-    response = FakeResponse(
-        status_code=200,
-        json_payload={"success": True, "result": []},
-    )
-    status, note = radar_check.validate_ckan_action_response(
-        "https://example.test/api/3/action/package_list", response
-    )
-    assert status == "GREEN"
-    assert note is None
-
-
-def test_validate_ckan_action_response_missing_success() -> None:
-    response = FakeResponse(
-        status_code=200,
-        json_payload={"result": []},
-    )
-    status, note = radar_check.validate_ckan_action_response(
-        "https://example.test/api/3/action/package_list", response
-    )
-    assert status == "YELLOW"
-    assert "missing" in (note or "").lower()
-
-
-def test_validate_ckan_action_response_non_json() -> None:
-    response = FakeResponse(
-        status_code=200,
-        content_type="text/html",
-        json_payload=None,
-        headers={"content-type": "text/html"},
-    )
-    status, note = radar_check.validate_ckan_action_response(
-        "https://example.test/api/3/action/package_list", response
-    )
-    assert status == "YELLOW"
-    assert "non-JSON" in (note or "")
-
-
-def test_validate_ckan_action_response_invalid_json() -> None:
-    response = FakeResponse(status_code=200, json_payload=None)
-    status, note = radar_check.validate_ckan_action_response(
-        "https://example.test/api/3/action/package_list", response
-    )
-    assert status == "YELLOW"
-    assert "invalid JSON" in (note or "")
-
-
-def test_validate_ckan_action_response_non_ckan_url() -> None:
-    response = FakeResponse(status_code=200, content_type="text/html")
-    status, note = radar_check.validate_ckan_action_response(
-        "https://example.test/", response
-    )
-    # Non-CKAN URL should just be classified by status code
-    assert status == "GREEN"
-    assert note is None
-
-
-def test_is_sdmx_url() -> None:
-    assert radar_check._is_sdmx_url("https://example.test/rest/dataflow") is True
-    assert radar_check._is_sdmx_url("https://example.test/SDMXWS/data") is True
-    assert radar_check._is_sdmx_url("https://example.test/sdmx/v1/data") is True
-    assert radar_check._is_sdmx_url("https://example.test/api/3/action") is False
-    assert radar_check._is_sdmx_url("https://example.test/datasets") is False
 
 
 def test_probe_url_success(monkeypatch) -> None:
@@ -187,39 +106,4 @@ def test_probe_url_ssl_fallback(monkeypatch) -> None:
     assert "SSL verify failed" in (result.note or "")
 
 
-def test_build_status_report_basic() -> None:
-    registry = {
-        "demo_ckan": {
-            "base_url": "https://demo.test/api/3/action/package_list",
-            "source_kind": "catalog",
-            "protocol": "ckan",
-            "observation_mode": "catalog-watch",
-        },
-        "istat_sdmx": {
-            "base_url": "https://sdmx.istat.it/rest/",
-            "source_kind": "catalog",
-            "protocol": "sdmx",
-            "observation_mode": "radar-only",
-        },
-    }
-    results = {
-        "demo_ckan": radar_check.ProbeResult(
-            status="GREEN", http_code="200", content_type="application/json"
-        ),
-        "istat_sdmx": radar_check.ProbeResult(
-            status="YELLOW", http_code="503", note="SDMX retry esaurito"
-        ),
-    }
 
-    report = radar_check.build_status_report(registry, results, "2026-04-11")
-
-    assert "# Stato Radar" in report
-    assert "Ultimo run: 2026-04-11" in report
-    assert "Fonti controllate: 2" in report
-    assert "GREEN: 1" in report
-    assert "YELLOW: 1" in report
-    assert "RED: 0" in report
-    assert "| demo_ckan |" in report
-    assert "| istat_sdmx |" in report
-    assert "## Note" in report
-    assert "istat_sdmx" in report

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -106,4 +106,51 @@ def test_probe_url_ssl_fallback(monkeypatch) -> None:
     assert "SSL verify failed" in (result.note or "")
 
 
+def test_validate_ckan_non_json_is_yellow() -> None:
+    """200 con HTML/WAF deve essere YELLOW, non GREEN — caso ANAC reale."""
+    response = FakeResponse(status_code=200, content_type="text/html", json_payload=None,
+                            headers={"content-type": "text/html"})
+    status, note = radar_check.validate_ckan_action_response(
+        "https://example.test/api/3/action/package_list", response
+    )
+    assert status == "YELLOW"
+    assert "non-JSON" in (note or "")
 
+
+def test_validate_ckan_missing_success_is_yellow() -> None:
+    """200 con JSON valido ma senza campo success deve essere YELLOW."""
+    response = FakeResponse(status_code=200, json_payload={"result": []})
+    status, note = radar_check.validate_ckan_action_response(
+        "https://example.test/api/3/action/package_list", response
+    )
+    assert status == "YELLOW"
+    assert "missing" in (note or "").lower()
+
+
+def test_validate_ckan_invalid_json_is_yellow() -> None:
+    """200 con body non parsabile deve essere YELLOW."""
+    response = FakeResponse(status_code=200, json_payload=None)
+    status, note = radar_check.validate_ckan_action_response(
+        "https://example.test/api/3/action/package_list", response
+    )
+    assert status == "YELLOW"
+    assert "invalid JSON" in (note or "")
+
+
+def test_build_status_report_smoke() -> None:
+    """Contratto minimo del formato pubblico STATUS.md letto da agenti."""
+    registry = {
+        "demo_ckan": {"base_url": "https://demo.test/api/3/action/package_list",
+                      "source_kind": "catalog", "protocol": "ckan", "observation_mode": "catalog-watch"},
+        "istat_sdmx": {"base_url": "https://sdmx.istat.it/rest/", "source_kind": "catalog",
+                       "protocol": "sdmx", "observation_mode": "radar-only"},
+    }
+    results = {
+        "demo_ckan": radar_check.ProbeResult(status="GREEN", http_code="200", content_type="application/json"),
+        "istat_sdmx": radar_check.ProbeResult(status="YELLOW", http_code="503", note="retry esaurito"),
+    }
+    report = radar_check.build_status_report(registry, results, "2026-04-17")
+    assert "# Stato Radar" in report
+    assert "Fonti controllate: 2" in report
+    assert "GREEN: 1" in report
+    assert "YELLOW: 1" in report


### PR DESCRIPTION
## Sintesi

Sfoltimento della test suite.
Branch pulito su main dopo merge di #111.

## Modifiche

- **test_build_catalog_signals.py**: rimossi 8 test banali; mantenuti i 8 su method mismatch, recovery, structural drift, end-to-end
- **test_catalog_diff.py**: rimosso solo `test_no_changes_returns_empty`; conservati i 5 su regression/recovery/row change (alerting critico)
- **test_radar_check.py**: accorpati/rimossi 15+ micro-controlli su HTTP status code banali
- **test_build_catalog_inventory.py**: invariato

## Risultato

24 test, 4s.

## Test plan

- [x] `pytest tests/` verde
- [ ] CI verde

Sostituisce #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)