### PR TITLE
feat(so): bulk source-check — enrichment, scoring, upsert incrementale

### DIFF
--- a/.github/workflows/source-check.yml
+++ b/.github/workflows/source-check.yml
@@ -1,0 +1,128 @@
+name: source-check
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 2"  # martedì mattina, dopo il build inventory del lunedì
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  source-check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      CATALOG_INVENTORY_GCS_PREFIX: ${{ secrets.CATALOG_INVENTORY_GCS_PREFIX }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Authenticate to Google Cloud
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Download catalog inventory from GCS
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
+        run: |
+          prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
+          prefix="${prefix%/}"
+          mkdir -p data/catalog_inventory/generated
+          gcloud storage cp "$prefix/catalog_inventory_latest.parquet" \
+            data/catalog_inventory/generated/catalog_inventory_latest.parquet
+
+      - name: Build catalog inventory (fallback se GCS non disponibile)
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER == '' || env.GCP_SERVICE_ACCOUNT == '' || env.CATALOG_INVENTORY_GCS_PREFIX == '' }}
+        run: |
+          python scripts/build_catalog_inventory.py \
+            --out-dir data/catalog_inventory/generated \
+            --workers 4
+
+      - name: Download previous source-check results from GCS
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
+        run: |
+          prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
+          prefix="${prefix%/}"
+          gcloud storage cp "$prefix/source-check/source_check_results.parquet" \
+            data/catalog_inventory/generated/source_check_results.parquet || true
+
+      - name: Run bulk source-check
+        run: |
+          python scripts/bulk_source_check.py \
+            --only-with-title \
+            --include-no-url \
+            --max-age-days 7 \
+            --workers 8
+
+      - name: Upload source-check results to GCS
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
+        run: |
+          stamp=$(python -c "from datetime import datetime, timezone; print(datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S'))")
+          prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
+          prefix="${prefix%/}"
+          gcloud storage cp data/catalog_inventory/generated/source_check_results.parquet \
+            "$prefix/source-check/source_check_results.parquet"
+          gcloud storage cp data/catalog_inventory/generated/source_check_results.parquet \
+            "$prefix/source-check/snapshots/source_check_${stamp}.parquet"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: source-check-results
+          path: data/catalog_inventory/generated/source_check_results.parquet
+
+      - name: Publish summary
+        run: |
+          python - <<'PY'
+          import pandas as pd
+          from pathlib import Path
+
+          df = pd.read_parquet("data/catalog_inventory/generated/source_check_results.parquet")
+          candidates = int(df["intake_candidate"].sum()) if "intake_candidate" in df.columns else 0
+          reachable = int(df["reachable"].sum()) if "reachable" in df.columns else 0
+          total = len(df)
+          avg_score = df["intake_score"].mean() if "intake_score" in df.columns else 0
+
+          lines = [
+              "## Source check results", "",
+              f"- Item controllati: {total}",
+              f"- Raggiungibili: {reachable} ({reachable/total*100:.0f}%)" if total else "- Raggiungibili: n/d",
+              f"- Intake candidates (score ≥ 40): {candidates}",
+              f"- Score medio: {avg_score:.0f}",
+              "",
+          ]
+
+          if "granularity" in df.columns:
+              lines.append("**Granularità:**")
+              for gran, n in df["granularity"].value_counts().items():
+                  lines.append(f"- {gran}: {n}")
+
+          Path("source_check_summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+          cat source_check_summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/source-check.yml
+++ b/.github/workflows/source-check.yml
@@ -55,10 +55,10 @@ jobs:
           prefix="${prefix%/}"
           mkdir -p data/catalog_inventory/generated
           gcloud storage cp "$prefix/catalog_inventory_latest.parquet" \
-            data/catalog_inventory/generated/catalog_inventory_latest.parquet
+            data/catalog_inventory/generated/catalog_inventory_latest.parquet || true
 
-      - name: Build catalog inventory (fallback se GCS non disponibile)
-        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER == '' || env.GCP_SERVICE_ACCOUNT == '' || env.CATALOG_INVENTORY_GCS_PREFIX == '' }}
+      - name: Build catalog inventory (fallback se parquet non disponibile)
+        if: ${{ hashFiles('data/catalog_inventory/generated/catalog_inventory_latest.parquet') == '' }}
         run: |
           python scripts/build_catalog_inventory.py \
             --out-dir data/catalog_inventory/generated \

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -75,7 +75,7 @@ openbdap:
     skip_package_search_reason: timeout sistematico a 60s
     skip_current_list: true
     package_show_sample: true
-    sample_size: 50
+    sample_size: 200
   last_probed: '2026-04-18'
   catalog_baseline:
     captured_at: '2026-04-02'
@@ -219,7 +219,7 @@ lavoro_opendata:
     skip_package_search_reason: count inaffidabile
     skip_current_list: true
     package_show_sample: true
-    sample_size: 50
+    sample_size: 100
   last_probed: '2026-04-18'
   catalog_baseline:
     captured_at: '2026-04-11'

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -29,6 +29,8 @@ anac:
     non_inventoriable: true
     reason: WAF strutturale - restituisce HTML 'Request Rejected' su qualsiasi client
       HTTP non browser. Confermato 2026-04-16.
+    scraping_blocked: true
+    scraping_blocked_reason: "reCAPTCHA / WAF blocca richieste HTTP non-browser"
   last_probed: '2026-04-18'
   catalog_baseline:
     captured_at: '2026-03-28'
@@ -49,7 +51,7 @@ inps:
   inventory:
     skip_current_list: true
     package_show_sample: true
-    sample_size: 100
+    sample_size: 500
   last_probed: '2026-04-18'
   catalog_baseline:
     captured_at: '2026-04-02'
@@ -136,6 +138,8 @@ dati_camera:
   protocol: sparql
   observation_mode: catalog-watch
   base_url: https://dati.camera.it/sparql
+  scraping_blocked: true
+  scraping_blocked_reason: "reCAPTCHA / WAF blocca richieste HTTP non-browser"
   last_probed: '2026-04-18'
   catalog_baseline:
     captured_at: '2026-04-11'

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,61 +1,164 @@
-# Architettura
+# Source Observatory — Guida Architettura
 
-`source-observatory` è l'intelligence layer leggero del Lab: osserva poche fonti pubbliche ricche e decide se un segnale merita lavoro umano.
+## Struttura scripts/
 
-Non è:
+```
+scripts/
+  collectors/          # package: logica di inventory per protocollo
+    base.py            # utility condivise: observatory_get, CollectorResult, strip_query
+    ckan.py            # collector CKAN
+    sdmx.py            # collector SDMX
+    sparql.py          # collector SPARQL
+  build_catalog_inventory.py   # entry point: enumera fonti → parquet
+  build_catalog_signals.py     # entry point: segnali di cambiamento
+  bulk_source_check.py         # entry point: enrichment e scoring per intake
+  _constants.py                # costanti condivise tra script
+```
 
-- una pipeline dataset
-- un sistema di intake automatico
-- monitoraggio diffuso del web
+## Regola fondamentale: riusa collectors/base.py
 
-## Responsabilità
+Tutti gli script che fanno chiamate HTTP **devono** usare `observatory_get()` da `collectors/base.py`, non `requests.get()` diretto. Motivo: User-Agent coerente, session management, timeout standard.
 
-- `radar_check.py`: health check della fonte o del catalogo.
-- `catalog-watch`: cambi inventariali o strutturali di cataloghi noti.
-- `catalog inventory`: snapshot tabulare degli item enumerabili.
-- `source-check`: valutazione umana di una fonte o dataset.
+```python
+# ✗ non fare
+import requests
+r = requests.get(url, timeout=15)
 
-Il confine con `toolkit` è netto: `source-observatory` trova e qualifica segnali; `toolkit` costruisce pipeline riproducibili.
+# ✓ fare
+from collectors.base import observatory_get
+r = observatory_get(url, timeout=15)
+```
 
-## Stato Canonico
+Per importare `collectors` da uno script in `scripts/`, usa:
+```python
+from collectors.base import observatory_get
+from collectors.ckan import ckan_get_json
+```
 
-- Registry: `data/radar/sources_registry.yaml`
-- Radar: `data/radar/STATUS.md`
-- Catalog-watch: `data/catalog/CATALOG_WATCH_REPORT.md`
-- Signals: `data/catalog/catalog_signals.json`
-- Inventory generated: `data/catalog_inventory/generated/`
+`build_catalog_inventory.py` importa direttamente da `collectors` (è un modulo di pari livello).
 
-## Perimetro
+## Struttura di un nuovo script entry point
 
-Una fonte entra nel registry solo se produce segnali chiari e difendibili.
+```python
+#!/usr/bin/env python3
+"""Docstring breve: cosa fa, input, output."""
 
-Stati operativi:
+from __future__ import annotations
 
-- `radar-only`: fonte utile da tenere viva, ma non inventariabile.
-- `catalog-watch`: catalogo osservabile a livello inventario.
-- `source-check item-based`: valore in pochi item specifici, non nel catalogo.
+# stdlib
+# terze parti
+# collectors (importazione diretta)
 
-## Tassonomia Segnali
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
-Usare pochi tipi:
+# costanti e configurazione
 
-- `health`
-- `inventory_change`
-- `structural_drift`
-- `follow_up_candidate`
-- `missing_data`
+# funzioni private _*  (logica, no I/O)
 
-Il segnale osservato non va confuso con il next step. Prima si classifica il segnale, poi si decide se aprire source-check, rerun candidate, watchlist o nessuna azione.
+# funzione pubblica principale (orchestrazione)
 
-## Guardrail
+# CLI parse_args() + main()
 
-- Tenere piccolo l'universo monitorato.
-- Non trasformare delta numerici non comparabili in novità.
-- Non automatizzare issue o intake finché il rumore non resta basso.
-- Usare `catalog-watch` solo con metodo di misura dichiarato e confrontabile.
+if __name__ == "__main__":
+    main()
+```
 
-## Documenti Collegati
+## Regole
 
-- [runbook.md](runbook.md): comandi e operatività.
-- [catalog_watch_measurement_policy.md](catalog_watch_measurement_policy.md): regole di comparabilità dei delta.
-- [workflows/](../workflows/): procedure per scout, watch e source-check.
+- **Un file = una responsabilità.** Entry point (`build_*`, `bulk_*`) contengono solo CLI + orchestrazione. Logica riusabile va in `collectors/` o in un modulo dedicato.
+- **Funzioni private `_*`** non hanno docstring. Funzioni pubbliche hanno una riga.
+- **Nessuna eccezione silenziata senza motivo.** Se catturi `Exception`, logga o restituisci un valore sentinel esplicito (es. `None`, `enrich_method: "error"`).
+- **Tipi espliciti** sulle firme delle funzioni pubbliche.
+- **No dipendenze nuove** senza discussione — il progetto usa `requests`, `pandas`, `pyyaml`, `duckdb`. Per parsing XML usa `xml.etree.ElementTree` stdlib.
+
+## Aggiungere un nuovo enricher a bulk_source_check
+
+1. Scrivi `_fetch_X()` e `_parse_X()` — restituiscono sempre il dict shape di `_EMPTY_ENRICH`
+2. Aggiungi un branch in `_enrich()` con la condizione sul protocollo
+3. Aggiungi la costante stringa `ENRICH_X = "x_method"` vicino a `_EMPTY_ENRICH`
+4. Usa `observatory_get()` invece di `requests.get()`
+
+## Pattern: dict shape degli enricher
+
+Ogni enricher restituisce esattamente queste chiavi (valore `None` se non disponibile):
+
+```python
+{
+    "enriched_title": str | None,
+    "enriched_tags": str | None,
+    "enriched_notes": str | None,
+    "resource_url": str | None,
+    "resource_format": str | None,
+    "granularity": str | None,
+    "year_min": int | None,
+    "year_max": int | None,
+    "enrich_method": str,   # mai None
+}
+```
+
+`_EMPTY_ENRICH` in `bulk_source_check.py` è la definizione canonica di questo shape.
+
+## Utility da collectors/base.py
+
+### Funzioni HTTP
+- `observatory_get(url, *, timeout=60, headers=None, **kwargs)` — GET con User-Agent coerente
+- `get_observatory_session()` → `requests.Session` con header predefiniti
+
+### Tipi
+- `CollectorResult(rows, warning=None, summary=None)` — risultato di una collezione
+- `now_utc_iso() → str` — timestamp UTC ISO per logging
+
+### Parsing
+- `strip_query(url: str) -> str` — rimuove query string
+- `parse_int(value: str | None) -> int | None` — parsing sicuro
+- `sparql_binding_value(binding, name) -> str | None` — estrae valore da SPARQL binding
+- `compact_uri_name(uri: str | None) -> str | None` — estrae nome da URI compresso
+- `append_unique(values: list[str], value: str | None)` — append non duplicato
+- `inventory_cfg(source_cfg: dict) -> dict` — legge il blocco `inventory:` da config sorgente
+
+## Schema colonne: catalog-inventory vs source-check
+
+### Layer 1 — catalog-inventory (`catalog_inventory_latest.parquet`)
+Contiene tutto ciò che è derivabile staticamente dall'inventory, senza chiamate attive alla fonte.
+
+| Colonna | Fonte | Note |
+|---|---|---|
+| `source_id`, `source_kind`, `protocol` | registry | identificatori della fonte |
+| `item_id`, `item_name`, `item_slug` | collector | `item_slug` = nome testuale CKAN per package_show |
+| `title`, `organization`, `tags`, `notes_excerpt` | collector | metadati base dell'item |
+| `issued`, `modified` | collector | date come stringhe ISO |
+| `landing_page`, `distribution_url`, `format` | collector | URL e formato dichiarato |
+| `api_base_url` | collector | endpoint API pre-calcolato (CKAN o SDMX root) |
+| `source_url` | collector | URL endpoint di inventory |
+| `captured_at` | build script | timestamp del run di inventory |
+
+### Layer 2 — source-check (`source_check_results.parquet`)
+Contiene tutto ciò che richiede chiamate attive alla fonte o inferenza sui metadati arricchiti.
+
+| Colonna | Come si ottiene |
+|---|---|
+| `check_timestamp` | runtime al momento del check |
+| `http_status`, `reachable`, `check_notes` | HTTP HEAD sull'URL risorsa |
+| `enriched_title`, `enriched_tags`, `enriched_notes` | package_show (CKAN) / dataflow annotations (SDMX) |
+| `resource_url`, `resource_format` | package_show resources / HTML scraping |
+| `granularity` | inferenza regex su testo arricchito |
+| `year_min`, `year_max` | extras DCAT-AP / TIME_PERIOD SDMX / regex su testo |
+| `enrich_method` | stringa che identifica il metodo usato |
+| `intake_score` | scoring 0-100 su granularità, anni, reachable, formato |
+| `intake_candidate` | `score ≥ 40` AND `needs_review = False` |
+| `needs_review` | granularità o anni non determinabili |
+
+**Linea di confine:** se è derivabile dall'inventory senza chiamate esterne → layer 1. Se richiede una chiamata attiva alla fonte → layer 2.
+
+## Fonti con scraping bloccato
+
+Alcune fonti bloccano le richieste HTTP non-browser (reCAPTCHA, WAF). Sono marcate nel registry con `scraping_blocked: true`. Il source-check le salta automaticamente senza tentare HTML scraping.
+
+Fonti attualmente bloccate: `dati_camera`, `anac`.
+
+Per aggiungere una nuova fonte bloccata, aggiungi nel registry:
+```yaml
+source_id:
+  scraping_blocked: true
+  scraping_blocked_reason: "descrizione del blocco"
+```

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -85,6 +85,12 @@ def parse_args() -> argparse.Namespace:
         metavar="N (1-8)",
         help="Thread per la raccolta parallela (default: 1 = seriale).",
     )
+    parser.add_argument(
+        "--source-ids",
+        nargs="+",
+        metavar="SOURCE_ID",
+        help="Limita il build a queste source_id (spazio-separato).",
+    )
     return parser.parse_args()
 
 
@@ -105,8 +111,12 @@ def main() -> None:
         "sources": {},
     }
 
+    source_id_filter = set(args.source_ids) if args.source_ids else None
+
     inventoriable: list[tuple[str, dict[str, Any]]] = []
     for source_id, source_cfg in registry.items():
+        if source_id_filter and source_id not in source_id_filter:
+            continue
         if source_cfg.get("source_kind") != "catalog":
             continue
         if source_cfg.get("observation_mode") != "catalog-watch":
@@ -172,6 +182,20 @@ def main() -> None:
         raise RuntimeError("No catalog inventory rows collected.")
 
     df = pd.DataFrame(all_rows)
+
+    if source_id_filter and out_parquet.exists():
+        existing = pd.read_parquet(out_parquet)
+        existing = existing[~existing["source_id"].isin(source_id_filter)]
+        df = pd.concat([existing, df], ignore_index=True)
+
+        # merge report: mantieni le entry precedenti per le fonti non ri-buildate
+        if out_report.exists():
+            with out_report.open(encoding="utf-8") as fh:
+                prev_report = json.load(fh)
+            for sid, info in prev_report.get("sources", {}).items():
+                if sid not in report["sources"]:
+                    report["sources"][sid] = info
+
     con = duckdb.connect()
     con.register("inventory_df", df)
     con.execute("CREATE TABLE inventory AS SELECT * FROM inventory_df")

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -587,6 +587,8 @@ def parse_args() -> argparse.Namespace:
                    help="Non ri-controllare item con check_timestamp più recente di N giorni (default: 7)")
     p.add_argument("--include-no-url", dest="only_with_url", action="store_false", default=True,
                    help="Includi anche item senza URL nel catalogo (verranno comunque arricchiti via API)")
+    p.add_argument("--only-with-title", action="store_true", default=False,
+                   help="Salta item senza title nel catalogo (tipicamente righe non-sample senza metadati)")
     return p.parse_args()
 
 
@@ -605,6 +607,10 @@ def main() -> None:
         has_url = df["landing_page"].notna() | df["distribution_url"].notna()
         df = df[has_url]
         print(f"  filtro URL presenti nel catalogo: {len(df)} item")
+
+    if args.only_with_title:
+        df = df[df["title"].notna()]
+        print(f"  filtro title non nullo: {len(df)} item")
 
     if args.limit:
         df = df.head(args.limit)

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -1,0 +1,728 @@
+#!/usr/bin/env python3
+"""
+Bulk source-check su una selezione del catalogo.
+
+Per ogni item del catalogo:
+  - CKAN (inps, openbdap, ...): chiama package_show per recuperare title,
+    notes, tags, risorse (url + format), copertura temporale dagli extras.
+  - SDMX (istat_sdmx): chiama /dataflow per leggere le annotations
+    LAYOUT_DATAFLOW_KEYWORDS (granularità + anni già strutturati).
+  - Fallback: inferisce granularità e anni da titolo + tag con regex.
+  Fa poi HEAD HTTP sull'URL più rilevante trovato.
+
+Output: source_check_results.parquet
+
+Uso:
+    python scripts/bulk_source_check.py
+    python scripts/bulk_source_check.py --source-ids inps istat_sdmx
+    python scripts/bulk_source_check.py --source-ids openbdap --limit 50 --include-no-url
+    python scripts/bulk_source_check.py --out data/mycheck.parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+import requests
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from collectors.base import observatory_get, observatory_head
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_IN = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_latest.parquet"
+DEFAULT_OUT = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "source_check_results.parquet"
+REGISTRY_PATH = REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
+
+HTTP_TIMEOUT = 15
+MAX_WORKERS = 8
+
+SDMX_NS = {
+    "message": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message",
+    "structure": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure",
+    "common": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common",
+    "generic": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/data/generic",
+}
+
+
+# ── registry ─────────────────────────────────────────────────────────────────
+
+def _load_registry() -> dict[str, Any]:
+    if not REGISTRY_PATH.exists():
+        return {}
+    with REGISTRY_PATH.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+# ── euristica granularità ─────────────────────────────────────────────────────
+
+_GRAN_PATTERNS: list[tuple[str, str]] = [
+    (r"\bcomun[ei]\b|\bmunicip", "comune"),
+    (r"\bprovinc", "provincia"),
+    (
+        r"\bregion[ei]\b|\bregioni\b|piemonte|lombardia|veneto|emilia|toscana|lazio|campania|puglia|sicilia|sardegna|abruzzo|umbria|marche|molise|calabria|basilicata|friuli|trentin|liguria|valle d['\s]aosta",
+        "regione",
+    ),
+    (r"\bnazional[ei]\b|\bitali[ae]\b|\bnazione\b|\bnational\b|\bregional\b", "nazionale"),
+    (r"\beurope[ao]\b|\bue\b|\beuropa\b|\beuropean\b", "europeo"),
+]
+
+def _infer_granularity(text: str) -> str:
+    low = text.lower()
+    for pattern, label in _GRAN_PATTERNS:
+        if re.search(pattern, low):
+            return label
+    return "non_determinato"
+
+
+# ── euristica anni ────────────────────────────────────────────────────────────
+
+_YEAR_RE = re.compile(r"(?<!\d)(19\d{2}|20[012]\d)(?!\d)")
+
+def _infer_years(text: str) -> tuple[Optional[int], Optional[int]]:
+    years = [int(y) for y in _YEAR_RE.findall(text)]
+    if not years:
+        return None, None
+    return min(years), max(years)
+
+
+# ── HTTP check ────────────────────────────────────────────────────────────────
+
+def _http_head(url: str) -> tuple[Optional[int], bool, str]:
+    if not isinstance(url, str) or not url.startswith("http"):
+        return None, False, "url_missing_or_invalid"
+    # codifica spazi e caratteri non ASCII nell'URL preservando la struttura
+    from urllib.parse import urlsplit, urlunsplit, quote
+    parts = urlsplit(url)
+    url = urlunsplit(parts._replace(path=quote(parts.path, safe="/:@!$&'()*+,;=")))
+    try:
+        resp = observatory_head(url, timeout=HTTP_TIMEOUT)
+        reachable = resp.status_code < 400
+        return resp.status_code, reachable, ""
+    except requests.exceptions.SSLError:
+        return None, False, "ssl_error"
+    except requests.exceptions.ConnectionError:
+        return None, False, "connection_error"
+    except requests.exceptions.Timeout:
+        return None, False, "timeout"
+    except Exception as exc:
+        return None, False, str(exc)[:120]
+
+
+# ── CKAN enrichment ───────────────────────────────────────────────────────────
+
+def _fetch_ckan_package(base_api: str, item_name: str) -> Optional[dict]:
+    url = f"{base_api}/package_show?id={item_name}"
+    try:
+        r = observatory_get(url, timeout=HTTP_TIMEOUT)
+        if r.status_code != 200:
+            return None
+        data = r.json()
+        if not data.get("success"):
+            return None
+        return data.get("result") or None
+    except Exception:
+        return None
+
+
+def _parse_ckan_package(pkg: dict) -> dict:
+    """Estrae i campi utili da un package CKAN."""
+    tags = [
+        (t.get("display_name") or t.get("name") or "")
+        for t in (pkg.get("tags") or [])
+        if isinstance(t, dict)
+    ]
+
+    # estrai groups per arricchire l'inferenza di granularità
+    groups = [
+        (g.get("display_name") or g.get("name") or "")
+        for g in (pkg.get("groups") or [])
+        if isinstance(g, dict)
+    ]
+
+    resources = pkg.get("resources") or []
+    resource_url = None
+    resource_format = None
+    for res in resources:
+        u = res.get("url") or ""
+        if u.startswith("http"):
+            resource_url = u
+            resource_format = res.get("format") or None
+            break
+
+    # copertura temporale dagli extras (DCAT-AP)
+    extras = {e["key"]: e["value"] for e in (pkg.get("extras") or []) if isinstance(e, dict)}
+    temporal_start = extras.get("temporal_coverage_from") or extras.get("issued")
+    temporal_end = extras.get("temporal_coverage_to") or extras.get("modified")
+
+    notes = (pkg.get("notes") or "").strip()
+    title = pkg.get("title") or None
+
+    # groups hanno precedenza: concatena prima di notes per influenzare l'inferenza
+    combined = " ".join(filter(None, [title, ", ".join(groups), ", ".join(tags), notes[:500]]))
+    granularity = _infer_granularity(combined)
+
+    # anni: prima dagli extras, poi dal testo
+    year_min, year_max = None, None
+    if temporal_start:
+        ys, _ = _infer_years(temporal_start)
+        year_min = ys
+    if temporal_end:
+        _, ye = _infer_years(temporal_end)
+        year_max = ye
+    if year_min is None or year_max is None:
+        yt_min, yt_max = _infer_years(combined)
+        year_min = year_min or yt_min
+        year_max = year_max or yt_max
+
+    return {
+        "enriched_title": title,
+        "enriched_tags": ", ".join(tags) if tags else None,
+        "enriched_notes": notes[:300] if notes else None,
+        "resource_url": resource_url,
+        "resource_format": resource_format,
+        "granularity": granularity,
+        "year_min": year_min,
+        "year_max": year_max,
+        "enrich_method": "ckan_package_show",
+    }
+
+
+# ── SDMX enrichment ───────────────────────────────────────────────────────────
+
+def _fetch_sdmx_years(base_url: str, flow_id: str) -> tuple[Optional[int], Optional[int]]:
+    """Chiama l'endpoint dati SDMX per ricavare year_min/year_max dalla dimensione TIME_PERIOD."""
+    try:
+        # ricava la root SDMX togliendo /dataflow/IT1 (o simile) dal base_url
+        base = base_url.split("?")[0].rstrip("/")
+        # risali fino alla root del servizio REST (prima di /dataflow)
+        if "/dataflow/" in base:
+            sdmx_root = base[: base.index("/dataflow/")]
+        elif base.endswith("/dataflow"):
+            sdmx_root = base[: -len("/dataflow")]
+        else:
+            sdmx_root = base
+        url = f"{sdmx_root}/data/{flow_id}?lastNObservations=1"
+        r = observatory_get(url, timeout=20)
+        if r.status_code != 200:
+            return None, None
+        root = ET.fromstring(r.content)
+        time_values: list[str] = []
+        # pattern 1: <generic:Value id="TIME_PERIOD" value="..."/> dentro <generic:ObsKey>
+        for val_el in root.findall(".//generic:ObsKey/generic:Value", SDMX_NS):
+            if val_el.get("id") == "TIME_PERIOD":
+                v = val_el.get("value")
+                if v:
+                    time_values.append(v)
+        # pattern 2: attributo TIME_PERIOD su <generic:Obs> o <generic:ObsValue>
+        for obs_el in root.findall(".//generic:Obs", SDMX_NS):
+            v = obs_el.get("TIME_PERIOD")
+            if v:
+                time_values.append(v)
+        for obs_el in root.findall(".//generic:ObsValue", SDMX_NS):
+            v = obs_el.get("TIME_PERIOD")
+            if v:
+                time_values.append(v)
+        years: list[int] = []
+        for tv in time_values:
+            found = _YEAR_RE.findall(tv)
+            years.extend(int(y) for y in found)
+        if not years:
+            return None, None
+        return min(years), max(years)
+    except Exception:
+        return None, None
+
+
+def _fetch_sdmx_dataflow(base_url: str, flow_id: str) -> Optional[ET.Element]:
+    # rimuovi query string e normalizza
+    base = base_url.split("?")[0].rstrip("/")
+    # risali alla root se l'url punta al listing completo
+    if base.endswith("/IT1"):
+        root_url = base
+    else:
+        root_url = base.rsplit("/", 1)[0]
+    url = f"{root_url}/{flow_id}"
+    try:
+        r = observatory_get(url, timeout=HTTP_TIMEOUT)
+        if r.status_code != 200:
+            return None
+        return ET.fromstring(r.content)
+    except Exception:
+        return None
+
+
+def _parse_sdmx_annotations(xml_root: ET.Element, base_url: str, flow_id: str) -> dict:
+    annotations: dict[str, str] = {}
+    for ann in xml_root.findall(".//common:Annotation", SDMX_NS):
+        atype_el = ann.find("common:AnnotationType", SDMX_NS)
+        atext_el = ann.find("common:AnnotationText", SDMX_NS)
+        if atype_el is not None and atext_el is not None:
+            annotations[atype_el.text or ""] = atext_el.text or ""
+
+    keywords_raw = annotations.get("LAYOUT_DATAFLOW_KEYWORDS", "")
+    # formato: "keyword1+keyword2+...+keyword3+..."
+    keywords = [k.strip().lower() for part in keywords_raw.split("+") for k in part.split(",") if k.strip()]
+
+    combined = " ".join(keywords)
+    granularity = _infer_granularity(combined)
+    year_min, year_max = _infer_years(combined)
+
+    # se le annotations non contengono anni, prova a ricavarli dall'endpoint dati
+    if year_min is None:
+        year_min, year_max = _fetch_sdmx_years(base_url, flow_id)
+
+    metadata_url = annotations.get("METADATA_URL")
+
+    return {
+        "enriched_title": None,
+        "enriched_tags": ", ".join(keywords[:10]) if keywords else None,
+        "enriched_notes": keywords_raw[:300] if keywords_raw else None,
+        "resource_url": metadata_url,
+        "resource_format": "SDMX",
+        "granularity": granularity,
+        "year_min": year_min,
+        "year_max": year_max,
+        "enrich_method": "sdmx_dataflow_annotations",
+    }
+
+
+# ── HTML enrichment (fallback per landing_page) ───────────────────────────────
+
+def _fetch_html_metadata(url: str) -> dict:
+    """Estrae metadati leggeri da una landing_page HTML.
+
+    Ricerca:
+      - Link a file scaricabili (.csv, .json, .xlsx, .xls, .xml, .zip, .pdf)
+      - Meta tag DCAT (dcterms.temporal, dcterms.spatial)
+
+    Restituisce dict con resource_format (primo formato trovato o None),
+    enriched_notes (None), enrich_method.
+    """
+    if not isinstance(url, str) or not url.startswith("http"):
+        result = _EMPTY_ENRICH.copy()
+        result["enrich_method"] = "html_scrape_failed"
+        return result
+
+    try:
+        resp = observatory_get(url, timeout=10, stream=False)
+        resp.raise_for_status()
+
+        # Limita a 200KB
+        content_length = len(resp.content)
+        if content_length > 200000:
+            resp.close()
+            result = _EMPTY_ENRICH.copy()
+            result["enrich_method"] = "html_scrape_failed"
+            return result
+
+        html = resp.text
+
+        # Cerca link a file scaricabili: regex su href
+        file_patterns = [r'href=["\']([^"\']*\.csv)["\']',
+                        r'href=["\']([^"\']*\.json)["\']',
+                        r'href=["\']([^"\']*\.xlsx)["\']',
+                        r'href=["\']([^"\']*\.xls)["\']',
+                        r'href=["\']([^"\']*\.xml)["\']',
+                        r'href=["\']([^"\']*\.zip)["\']',
+                        r'href=["\']([^"\']*\.pdf)["\']']
+
+        resource_format = None
+        for pattern in file_patterns:
+            matches = re.findall(pattern, html, re.IGNORECASE)
+            if matches:
+                # Prendi il primo formato trovato
+                filename = matches[0]
+                ext = filename.rsplit(".", 1)[-1].upper() if "." in filename else None
+                if ext:
+                    resource_format = ext
+                    break
+
+        return {
+            "enriched_title": None,
+            "enriched_tags": None,
+            "enriched_notes": None,
+            "resource_url": None,
+            "resource_format": resource_format,
+            "granularity": None,
+            "year_min": None,
+            "year_max": None,
+            "enrich_method": "html_scrape",
+        }
+    except Exception:
+        result = _EMPTY_ENRICH.copy()
+        result["enrich_method"] = "html_scrape_failed"
+        return result
+
+
+# ── dispatcher per protocollo ─────────────────────────────────────────────────
+
+_EMPTY_ENRICH = {
+    "enriched_title": None,
+    "enriched_tags": None,
+    "enriched_notes": None,
+    "resource_url": None,
+    "resource_format": None,
+    "granularity": None,
+    "year_min": None,
+    "year_max": None,
+    "enrich_method": "none",
+}
+
+
+def _enrich(row: pd.Series, registry: dict[str, Any]) -> dict:
+    source_id = row.get("source_id") or ""
+    source_cfg = registry.get(source_id, {})
+    protocol = source_cfg.get("protocol") or row.get("protocol") or ""
+    base_url = source_cfg.get("base_url") or row.get("source_url") or ""
+    _raw_name = row.get("item_name") or row.get("item_id")
+    item_name = "" if pd.isna(_raw_name) else str(_raw_name)
+    # preferisci item_slug (nome testuale CKAN) per package_show
+    _slug = row.get("item_slug")
+    if isinstance(_slug, str) and _slug.strip():
+        item_name = _slug.strip()
+
+    if protocol == "ckan" and base_url and item_name:
+        # usa api_base_url pre-calcolata dal layer 1 (gestisce endpoint non-standard come INPS /odapi/)
+        api_base_url = row.get("api_base_url")
+        base_api = api_base_url if isinstance(api_base_url, str) and api_base_url.startswith("http") else base_url
+        pkg = _fetch_ckan_package(base_api, item_name)
+        if pkg:
+            return _parse_ckan_package(pkg)
+
+    if protocol == "sdmx" and base_url and item_name:
+        sdmx_base = base_url
+        # usa api_base_url pre-calcolata se disponibile
+        api_base_url = row.get("api_base_url")
+        if isinstance(api_base_url, str) and api_base_url.startswith("http"):
+            sdmx_base = api_base_url
+        xml_root = _fetch_sdmx_dataflow(sdmx_base, item_name)
+        if xml_root is not None:
+            return _parse_sdmx_annotations(xml_root, sdmx_base, item_name)
+
+    # HTML fallback per fonti con solo landing_page (es. dati_camera)
+    landing = row.get("landing_page")
+    if isinstance(landing, str) and landing.startswith("http"):
+        # salta se la fonte è nota per bloccare lo scraping
+        if source_cfg.get("scraping_blocked"):
+            result = _EMPTY_ENRICH.copy()
+            result["enrich_method"] = "scraping_blocked"
+            return result
+        return _fetch_html_metadata(landing)
+
+    return _EMPTY_ENRICH.copy()
+
+
+# ── fallback euristica su campi catalogo ──────────────────────────────────────
+
+def _fallback_infer(row: pd.Series) -> tuple[str, Optional[int], Optional[int]]:
+    combined = " ".join(
+        str(v) for v in [row.get("title"), row.get("tags"), row.get("notes_excerpt")]
+        if v and str(v) != "nan"
+    )
+    return _infer_granularity(combined), *_infer_years(combined)
+
+
+# ── intake scoring ────────────────────────────────────────────────────────────
+
+_GRAN_SCORE = {"comune": 40, "provincia": 30, "regione": 20, "nazionale": 10, "europeo": 5, "non_determinato": 0}
+_FORMAT_SCORE = {"CSV": 20, "JSON": 20, "XLSX": 12, "XLS": 10, "XML": 8, "SDMX": 8, "PDF": 2}
+_YEAR_SPAN_MAX = 20  # anni di copertura oltre i quali il bonus è al massimo
+
+
+def _intake_score(
+    granularity: Optional[str],
+    year_min: Optional[int],
+    year_max: Optional[int],
+    reachable: bool,
+    resource_format: Optional[str],
+    enrich_method: str,
+    needs_review: bool,
+) -> tuple[int, bool]:
+    """Restituisce (score 0-100, intake_candidate)."""
+    score = 0
+
+    # granularità — 0..40
+    score += _GRAN_SCORE.get(granularity or "non_determinato", 0)
+
+    # copertura anni — 0..20 (lineare fino a _YEAR_SPAN_MAX anni)
+    if year_min is not None and year_max is not None:
+        span = max(0, year_max - year_min)
+        score += min(20, int(span / _YEAR_SPAN_MAX * 20))
+    elif year_min is not None or year_max is not None:
+        score += 5  # almeno un anno noto
+
+    # raggiungibile — 0..20
+    score += 20 if reachable else 0
+
+    # formato — 0..20 (normalizza: estrai estensione se il campo è un nome file)
+    fmt_raw = ("" if not isinstance(resource_format, str) else resource_format).strip()
+    if "." in fmt_raw and len(fmt_raw) > 6:
+        fmt_raw = fmt_raw.rsplit(".", 1)[-1]
+    fmt = fmt_raw.upper()
+    score += _FORMAT_SCORE.get(fmt, 0)
+
+    # qualità enrichment — 0..5 bonus, -5 penalità
+    enrich_str = enrich_method if isinstance(enrich_method, str) else ""
+    if enrich_str in ("ckan_package_show", "sdmx_dataflow_annotations"):
+        score += 5
+    if needs_review:
+        score -= 5
+
+    score = max(0, min(100, score))
+    candidate = score >= 40 and not needs_review
+
+    return score, candidate
+
+
+# ── core ──────────────────────────────────────────────────────────────────────
+
+def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
+    enrich = _enrich(row, registry)
+
+    # granularità e anni: da enrichment, poi fallback su campi catalogo
+    granularity = enrich["granularity"]
+    year_min = enrich["year_min"]
+    year_max = enrich["year_max"]
+    if granularity == "non_determinato" or (granularity is None) or (year_min is None):
+        fb_gran, fb_ymin, fb_ymax = _fallback_infer(row)
+        if granularity in (None, "non_determinato"):
+            granularity = fb_gran
+        year_min = year_min or fb_ymin
+        year_max = year_max or fb_ymax
+
+    # URL da controllare: enrichment resource > catalogo landing_page > distribution_url
+    url_to_check = (
+        enrich.get("resource_url")
+        or row.get("landing_page")
+        or row.get("distribution_url")
+    )
+    # per SDMX la metadata_url non è un dato, usiamo la base_url per il check
+    if enrich["enrich_method"] == "sdmx_dataflow_annotations":
+        url_to_check = row.get("landing_page") or row.get("distribution_url")
+
+    http_status, reachable, note = _http_head(url_to_check or "")
+
+    return {
+        "check_timestamp": check_ts,
+        "source_id": row.get("source_id"),
+        "item_id": row.get("item_id"),
+        "item_name": row.get("item_name"),
+        "title": enrich["enriched_title"] or row.get("title"),
+        "organization": row.get("organization"),
+        "tags": enrich["enriched_tags"] or row.get("tags"),
+        "notes": enrich["enriched_notes"],
+        "url_checked": url_to_check,
+        "http_status": http_status,
+        "reachable": reachable,
+        "check_notes": note or None,
+        "granularity": granularity,
+        "year_min": year_min,
+        "year_max": year_max,
+        "resource_format": enrich["resource_format"] or row.get("format"),
+        "enrich_method": enrich["enrich_method"],
+        "needs_review": (granularity == "non_determinato") or (year_min is None),
+        "intake_score": None,  # placeholder, calcolato sotto
+        "intake_candidate": None,
+    }
+
+
+def _finalize_scores(result: dict) -> dict:
+    score, candidate = _intake_score(
+        granularity=result.get("granularity"),
+        year_min=result.get("year_min"),
+        year_max=result.get("year_max"),
+        reachable=result.get("reachable", False),
+        resource_format=result.get("resource_format"),
+        enrich_method=result.get("enrich_method", "none"),
+        needs_review=result.get("needs_review", True),
+    )
+    result["intake_score"] = score
+    result["intake_candidate"] = candidate
+    return result
+
+
+def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame:
+    registry = _load_registry()
+    check_ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    results = []
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(_check_row, row, check_ts, registry): i for i, row in df.iterrows()}
+        done = 0
+        total = len(futures)
+        for future in as_completed(futures):
+            try:
+                results.append(_finalize_scores(future.result()))
+            except Exception as exc:
+                results.append({"check_notes": str(exc)[:200], "enrich_method": "error"})
+            done += 1
+            if done % 50 == 0 or done == total:
+                print(f"  {done}/{total} completati")
+
+    return pd.DataFrame(results)
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--in", dest="input", type=Path, default=DEFAULT_IN)
+    p.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    p.add_argument("--source-ids", nargs="+", metavar="ID")
+    p.add_argument("--limit", type=int, default=None)
+    p.add_argument("--limit-per-source", type=int, default=None, metavar="N",
+                   help="Massimo N item per source_id (applicato prima del check)")
+    p.add_argument("--workers", type=int, default=MAX_WORKERS)
+    p.add_argument("--max-age-days", type=int, default=7,
+                   help="Non ri-controllare item con check_timestamp più recente di N giorni (default: 7)")
+    p.add_argument("--include-no-url", dest="only_with_url", action="store_false", default=True,
+                   help="Includi anche item senza URL nel catalogo (verranno comunque arricchiti via API)")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    print(f"Carico catalogo: {args.input}")
+    df = pd.read_parquet(args.input)
+    print(f"  {len(df)} item totali")
+
+    if args.source_ids:
+        df = df[df["source_id"].isin(args.source_ids)]
+        print(f"  filtro source_ids {args.source_ids}: {len(df)} item")
+
+    if args.only_with_url:
+        has_url = df["landing_page"].notna() | df["distribution_url"].notna()
+        df = df[has_url]
+        print(f"  filtro URL presenti nel catalogo: {len(df)} item")
+
+    if args.limit:
+        df = df.head(args.limit)
+        print(f"  limit {args.limit}: {len(df)} item")
+
+    if args.limit_per_source:
+        df = df.groupby("source_id", group_keys=False).head(args.limit_per_source)
+        print(f"  limit-per-source {args.limit_per_source}: {len(df)} item")
+
+    if df.empty:
+        print("Nessun item da controllare. Uscita.")
+        return
+
+    # ── Logica incrementale ──────────────────────────────────────────────────────
+    existing = None
+    skipped = 0
+    if args.out.exists():
+        print(f"\nCarico risultati precedenti: {args.out}")
+        existing = pd.read_parquet(args.out)
+        print(f"  {len(existing)} risultati precedenti")
+
+        # Parsare check_timestamp come datetime se presente
+        if "check_timestamp" in existing.columns:
+            existing["check_timestamp"] = pd.to_datetime(existing["check_timestamp"], utc=True)
+
+        # Filtra item da non ri-controllare
+        if "item_id" in existing.columns:
+            now = pd.Timestamp.now(tz="UTC")
+            cutoff = now - pd.Timedelta(days=args.max_age_days)
+
+            # Trova gli item con check recente (più recente di cutoff)
+            existing_recent = existing[existing["check_timestamp"] >= cutoff]
+            recent_ids = set(str(x) for x in existing_recent["item_id"].astype(str).unique())
+
+            # ── Secondo criterio: re-aggiungi item se la fonte ha aggiornato modified ──
+            if "modified" in df.columns and not df.empty:
+                # Prepara df per il merge
+                df_modified = df[["item_id", "modified"]].copy()
+                df_modified["item_id"] = df_modified["item_id"].astype(str)
+
+                # Prepara existing_recent per il merge
+                existing_for_merge = existing_recent[["item_id", "check_timestamp"]].copy()
+                existing_for_merge["item_id"] = existing_for_merge["item_id"].astype(str)
+
+                # Merge su item_id
+                merge_df = pd.merge(
+                    df_modified,
+                    existing_for_merge,
+                    on="item_id",
+                    how="inner"
+                )
+
+                # Parsa modified come datetime
+                merge_df["modified"] = pd.to_datetime(merge_df["modified"], utc=True, errors="coerce")
+
+                # Filtra item dove modified > check_timestamp (e modified non è null)
+                updated_mask = (merge_df["modified"].notna()) & (merge_df["modified"] > merge_df["check_timestamp"])
+                updated_ids = set(merge_df[updated_mask]["item_id"].unique())
+
+                # Rimuovi questi item da recent_ids (vanno ri-controllati)
+                reinspected = len(recent_ids & updated_ids)
+                if reinspected > 0:
+                    recent_ids = recent_ids - updated_ids
+                    print(f"  {reinspected} item ri-aggiunti perché la fonte ha aggiornato modified")
+
+            # Filtra catalogo escludendo item recenti
+            df_to_check = df[~df["item_id"].astype(str).isin(recent_ids)].copy()
+            skipped = len(df) - len(df_to_check)
+
+            if skipped > 0:
+                print(f"  Saltati {skipped} item controllati negli ultimi {args.max_age_days} giorni")
+            print(f"  {len(df_to_check)} item da controllare")
+            df = df_to_check
+        else:
+            print("  Attenzione: existing non ha colonna 'item_id', saltando dedup")
+
+    if df.empty:
+        print("Nessun item nuovo da controllare. Uscita.")
+        return
+
+    print(f"\nAvvio check su {len(df)} item ({args.workers} workers)...")
+    t0 = time.time()
+    results = run_bulk_check(df, workers=args.workers)
+    elapsed = time.time() - t0
+    print(f"Completato in {elapsed:.1f}s")
+
+    # ── Upsert ───────────────────────────────────────────────────────────────────
+    if existing is not None and not existing.empty and "item_id" in existing.columns:
+        # Tieni solo i risultati da existing che non sono stati ri-controllati
+        existing_to_keep = existing[~existing["item_id"].astype(str).isin(results["item_id"].astype(str))]
+
+        # Concatena nuovi risultati con quelli vecchi (non ri-controllati)
+        results = pd.concat([results, existing_to_keep], ignore_index=True)
+
+        # Deduplica su item_id tenendo la riga con check_timestamp più recente
+        results["check_timestamp"] = pd.to_datetime(results["check_timestamp"], utc=True)
+        results = results.sort_values("check_timestamp", ascending=False).drop_duplicates(subset=["item_id"], keep="first").reset_index(drop=True)
+        print(f"  Unificati {len(results)} risultati (nuovi + precedenti non ri-controllati)")
+
+    enrich_counts = results["enrich_method"].value_counts()
+    reachable_n = results["reachable"].sum() if "reachable" in results.columns else 0
+    reachable_pct = results["reachable"].mean() * 100 if "reachable" in results.columns else 0
+    print(f"\nArricchimento:\n{enrich_counts.to_string()}")
+    print(f"Raggiungibili: {reachable_pct:.0f}% ({reachable_n}/{len(results)})")
+    print(f"Granularità:\n{results['granularity'].value_counts().to_string()}")
+    print(f"Needs review: {results['needs_review'].sum()}")
+    if "intake_score" in results.columns:
+        candidates = results["intake_candidate"].sum()
+        avg_score = results["intake_score"].mean()
+        print(f"Intake candidates: {candidates}/{len(results)} (score medio: {avg_score:.0f})")
+        top = results[results["intake_candidate"].fillna(False)].nlargest(5, "intake_score")[["title","granularity","year_min","year_max","intake_score"]]
+        if not top.empty:
+            print(f"\nTop candidati:\n{top.to_string(index=False)}")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    results.to_parquet(args.out, index=False)
+    print(f"\nRisultati: {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -52,6 +52,25 @@ def observatory_get(
     return response
 
 
+def observatory_head(
+    url: str,
+    *,
+    timeout: int | float = DEFAULT_TIMEOUT_SECONDS,
+    headers: dict[str, str] | None = None,
+    **kwargs: Any,
+) -> requests.Response:
+    request_headers = dict(headers or {})
+    with get_observatory_session() as session:
+        response = session.head(
+            url,
+            timeout=timeout,
+            headers=request_headers or None,
+            allow_redirects=True,
+            **kwargs,
+        )
+    return response
+
+
 def strip_query(url: str) -> str:
     parts = urlsplit(url)
     return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))

--- a/scripts/collectors/ckan.py
+++ b/scripts/collectors/ckan.py
@@ -15,6 +15,25 @@ CKAN_ACTION_NAMES = {
 }
 
 
+def _ckan_api_base(url: str) -> str | None:
+    if not url:
+        return None
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    path = parsed.path
+    if "/api/3/action/" in path:
+        root = path[: path.index("/api/3/action/")]
+        return f"{parsed.scheme}://{parsed.netloc}{root}/api/3/action"
+    # endpoint non-standard (es. INPS /odapi): usa il path fino all'ultima action nota
+    for action in ("package_list", "package_search", "package_show", "current_package_list_with_resources"):
+        if f"/{action}" in path:
+            root = path[: path.index(f"/{action}")]
+            return f"{parsed.scheme}://{parsed.netloc}{root}"
+    # fallback: usa host + path senza query
+    root = path.rstrip("/").rsplit("/", 1)[0] if "/" in path.rstrip("/") else path
+    return f"{parsed.scheme}://{parsed.netloc}{root}"
+
+
 def ckan_action_endpoint(base_url: str, action: str) -> str:
     endpoint = strip_query(base_url)
     if endpoint.endswith("/"):
@@ -90,11 +109,13 @@ def extract_ckan_inventory_row(
         "item_kind": "dataset",
         "item_id": item.get("id") or item.get("name"),
         "item_name": item.get("name") or item.get("id"),
+        "item_slug": item.get("name") or None,
         "title": item.get("title"),
         "organization": organization,
         "tags": ", ".join(tags) if tags else None,
         "notes_excerpt": notes[:300] if notes else None,
         "source_url": endpoint,
+        "api_base_url": _ckan_api_base(source_cfg.get("base_url") or endpoint),
         "ordinal": ordinal,
     }
 
@@ -288,11 +309,15 @@ def collect_ckan_inventory_via_package_list(
                 "item_kind": "dataset",
                 "item_id": str(item_name),
                 "item_name": str(item_name),
+                # per fonti non-standard (es. INPS) package_list restituisce ID numerici,
+                # non slug testuali — lo slug reale è disponibile solo dopo package_show_sample
+                "item_slug": str(item_name),
                 "title": None,
                 "organization": None,
                 "tags": None,
                 "notes_excerpt": None,
                 "source_url": endpoint,
+                "api_base_url": _ckan_api_base(source_cfg.get("base_url") or endpoint),
                 "ordinal": idx,
             }
         )

--- a/scripts/collectors/sdmx.py
+++ b/scripts/collectors/sdmx.py
@@ -16,6 +16,15 @@ def parse_sdmx_name(name_elem: ET.Element | None) -> str | None:
     return text or None
 
 
+def _sdmx_api_base(url: str) -> str | None:
+    if not url:
+        return None
+    base = url.split("?")[0].rstrip("/")
+    if "/dataflow/" in base:
+        return base[: base.index("/dataflow/")]
+    return base
+
+
 def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> CollectorResult:
     attempts = len(SDMX_RETRY_DELAYS_SECONDS) + 1
     endpoint = source_cfg["base_url"]
@@ -87,6 +96,7 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
                 "tags": None,
                 "notes_excerpt": None,
                 "source_url": source_cfg["base_url"],
+                "api_base_url": _sdmx_api_base(source_cfg.get("base_url") or endpoint),
                 "ordinal": idx,
             }
         )

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -1,0 +1,133 @@
+"""Tests per bulk_source_check: regole non ovvie, edge case, bug già visti."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from bulk_source_check import (
+    _infer_granularity,
+    _infer_years,
+    _intake_score,
+)
+from collectors.ckan import _ckan_api_base
+
+
+# ── _infer_granularity ────────────────────────────────────────────────────────
+
+class TestInferGranularity:
+    def test_comune_wins_over_regione(self):
+        # precedenza: comune > regione — ordine in _GRAN_PATTERNS è load-bearing
+        assert _infer_granularity("comuni della regione Lombardia") == "comune"
+
+    def test_provincia_wins_over_nazionale(self):
+        assert _infer_granularity("dati provinciali italiani") == "provincia"
+
+    def test_regione_not_matched_by_regional(self):
+        # "regional" in inglese → nazionale, non regione (bug fix)
+        assert _infer_granularity("regional statistics") == "nazionale"
+
+    def test_regione_by_name(self):
+        assert _infer_granularity("dati Lombardia 2022") == "regione"
+
+    def test_europeo(self):
+        assert _infer_granularity("indicatori europei UE") == "europeo"
+
+    def test_non_determinato(self):
+        assert _infer_granularity("dataset generico senza territorio") == "non_determinato"
+
+    def test_empty_string(self):
+        assert _infer_granularity("") == "non_determinato"
+
+
+# ── _infer_years ──────────────────────────────────────────────────────────────
+
+class TestInferYears:
+    def test_single_year(self):
+        assert _infer_years("dati 2022") == (2022, 2022)
+
+    def test_range(self):
+        assert _infer_years("copertura 2015-2023") == (2015, 2023)
+
+    def test_no_partial_match_from_range(self):
+        # "2013-2014" non deve estrarre "20" come anno separato (bug fix regex)
+        ymin, ymax = _infer_years("periodo 2013-2014")
+        assert ymin == 2013
+        assert ymax == 2014
+
+    def test_no_false_year_from_short_number(self):
+        # "20" da soli non devono matchare
+        assert _infer_years("20 comuni") == (None, None)
+
+    def test_no_years(self):
+        assert _infer_years("nessuna data qui") == (None, None)
+
+    def test_future_year_excluded(self):
+        # anni > 2029 non matchati dal pattern 20[012]\d
+        assert _infer_years("proiezioni 2035") == (None, None)
+
+
+# ── _intake_score ─────────────────────────────────────────────────────────────
+
+class TestIntakeScore:
+    def test_nan_format_does_not_crash(self):
+        # bug già visto: float('nan') passato come resource_format crashava
+        import math
+        score, candidate = _intake_score(
+            granularity="comune",
+            year_min=2015,
+            year_max=2022,
+            reachable=True,
+            resource_format=float("nan"),  # type: ignore[arg-type]
+            enrich_method="ckan_package_show",
+            needs_review=False,
+        )
+        assert isinstance(score, int)
+        assert 0 <= score <= 100
+
+    def test_none_format_does_not_crash(self):
+        score, _ = _intake_score("comune", 2015, 2022, True, None, "ckan_package_show", False)
+        assert isinstance(score, int)
+
+    def test_high_score_comune_long_span(self):
+        score, candidate = _intake_score("comune", 2000, 2023, True, "CSV", "ckan_package_show", False)
+        assert score >= 80
+        assert candidate is True
+
+    def test_no_candidate_if_needs_review(self):
+        _, candidate = _intake_score("comune", 2000, 2023, True, "CSV", "ckan_package_show", True)
+        assert candidate is False
+
+    def test_score_capped_at_100(self):
+        score, _ = _intake_score("comune", 1990, 2024, True, "CSV", "ckan_package_show", False)
+        assert score <= 100
+
+    def test_score_floor_at_zero(self):
+        score, _ = _intake_score("non_determinato", None, None, False, None, "none", True)
+        assert score >= 0
+
+
+# ── _ckan_api_base ────────────────────────────────────────────────────────────
+
+class TestCkanApiBase:
+    def test_standard_endpoint(self):
+        url = "https://dati.consip.it/api/3/action/package_list?limit=1"
+        assert _ckan_api_base(url) == "https://dati.consip.it/api/3/action"
+
+    def test_inps_nonstandard_endpoint(self):
+        # caso reale: INPS usa /odapi/ invece di /api/3/action/
+        url = "https://serviziweb2.inps.it/odapi/package_list?limit=1"
+        assert _ckan_api_base(url) == "https://serviziweb2.inps.it/odapi"
+
+    def test_package_search_endpoint(self):
+        url = "https://example.org/api/3/action/package_search?rows=1"
+        assert _ckan_api_base(url) == "https://example.org/api/3/action"
+
+    def test_empty_string_returns_none(self):
+        assert _ckan_api_base("") is None
+
+    def test_none_returns_none(self):
+        assert _ckan_api_base(None) is None  # type: ignore[arg-type]

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
 from bulk_source_check import (
@@ -75,7 +73,6 @@ class TestInferYears:
 class TestIntakeScore:
     def test_nan_format_does_not_crash(self):
         # bug già visto: float('nan') passato come resource_format crashava
-        import math
         score, candidate = _intake_score(
             granularity="comune",
             year_min=2015,


### PR DESCRIPTION
## Sommario

Aggiunge il **layer 2 del catalog pipeline**: enrichment attivo per ogni item dell'inventory, scoring intake, upsert incrementale.

### Commit 1 — layer 1: collectors + build
- `collectors/ckan`: aggiunge `item_slug` e `api_base_url` pre-calcolato; `_ckan_api_base()` gestisce endpoint non-standard (es. INPS `/odapi/`)
- `collectors/sdmx`: aggiunge `api_base_url` per ogni row
- `collectors/base`: aggiunge `observatory_head()` con User-Agent coerente
- `build_catalog_inventory`: `--source-ids` per rebuild selettivo con upsert su parquet e merge su report JSON
- `sources_registry`: `scraping_blocked` su `dati_camera` e `anac`; INPS `sample_size` 500
- `docs/architecture.md`: guida architettura, schema colonne layer 1/2, regole collectors

### Commit 2 — layer 2: bulk source-check
- `bulk_source_check.py`: enrichment CKAN `package_show`, SDMX dataflow annotations, HTML fallback; scoring `intake_score` 0-100; upsert con `--max-age-days` + re-check su `modified > check_timestamp`; `scraping_blocked` rispettato
- `tests/test_bulk_source_check.py`: regole non ovvie (`_infer_granularity` precedenza, `_infer_years` regex fix, `_intake_score` NaN crash, `_ckan_api_base` INPS)

## Test plan

- [ ] CI verde (ruff + mypy + pytest 67 test)
- [ ] `build_catalog_inventory.py --source-ids inps` ricostruisce solo INPS e fa upsert su parquet/report
- [ ] `bulk_source_check.py --source-ids inps --limit-per-source 20 --include-no-url` produce `enrich_method: ckan_package_show` per item INPS
- [ ] `bulk_source_check.py --source-ids dati_camera` produce `enrich_method: scraping_blocked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)