### PR TITLE
feat: generate radar_summary.json for ACB consumption

### DIFF
--- a/.github/workflows/radar-scheduled.yml
+++ b/.github/workflows/radar-scheduled.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           python -c "import yaml; yaml.safe_load(open('data/radar/sources_registry.yaml'))"
           test -s data/radar/STATUS.md
+          test -f data/radar/radar_summary.json
           python -c "import json; json.load(open('data/radar/radar_summary.json'))"
 
       - name: Commit updated radar state

--- a/.github/workflows/radar-scheduled.yml
+++ b/.github/workflows/radar-scheduled.yml
@@ -37,12 +37,13 @@ jobs:
         run: |
           python -c "import yaml; yaml.safe_load(open('data/radar/sources_registry.yaml'))"
           test -s data/radar/STATUS.md
+          python -c "import json; json.load(open('data/radar/radar_summary.json'))"
 
       - name: Commit updated radar state
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/radar/STATUS.md data/radar/sources_registry.yaml
+          git add data/radar/STATUS.md data/radar/sources_registry.yaml data/radar/radar_summary.json
           git diff --cached --quiet && exit 0
           git commit -m "chore: refresh radar status"
           git push

--- a/data/radar/README.md
+++ b/data/radar/README.md
@@ -9,6 +9,9 @@ Stato canonico dei controlli radar a livello portale.
   - una entry per portale
 - `STATUS.md`
   - ultimo output leggibile del probe radar
+- `radar_summary.json`
+  - summary compatto generato da `scripts/radar_check.py`, consumabile da agent-context-builder (ACB)
+  - contiene: timestamp, conteggi status (GREEN/YELLOW/RED), lista fonti con status e metadati essenziali
 
 ## Perimetro
 

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 from collections import Counter
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, timezone
 import json
 import time
 from pathlib import Path
@@ -20,6 +20,7 @@ from _constants import SDMX_RETRYABLE_STATUS_CODES, SDMX_RETRY_DELAYS_SECONDS
 WORKSPACE_ROOT = Path(__file__).resolve().parents[1]
 REGISTRY_PATH = WORKSPACE_ROOT / "data" / "radar" / "sources_registry.yaml"
 STATUS_PATH = WORKSPACE_ROOT / "data" / "radar" / "STATUS.md"
+SUMMARY_PATH = WORKSPACE_ROOT / "data" / "radar" / "radar_summary.json"
 USER_AGENT = "DataCivicLab-SourceObservatory/1.0"
 TIMEOUT_SECONDS = 10
 
@@ -327,6 +328,60 @@ def update_last_probed(registry: dict[str, dict[str, Any]], probe_date: str) -> 
         meta["last_probed"] = probe_date
 
 
+def build_radar_summary(
+    registry: dict[str, dict[str, Any]],
+    results: dict[str, ProbeResult],
+    probe_date: str,
+) -> dict[str, Any]:
+    """Build compact radar summary JSON consumable by agent-context-builder.
+
+    Schema:
+    {
+        "generated_at": ISO8601 timestamp,
+        "probe_date": YYYY-MM-DD,
+        "sources_total": N,
+        "status_counts": { "GREEN": N, "YELLOW": N, "RED": N },
+        "sources": [
+            {
+                "id": source_id,
+                "status": GREEN|YELLOW|RED,
+                "protocol": protocol,
+                "observation_mode": radar-only|catalog-watch|monitor-active,
+                "http_code": "200" | "-",
+                "last_check": YYYY-MM-DD,
+                "datasets_in_use": [...]
+            }
+        ]
+    }
+    """
+    status_counts = Counter(result.status for result in results.values())
+    sources_list = []
+
+    for source_id, meta in registry.items():
+        result = results[source_id]
+        sources_list.append({
+            "id": source_id,
+            "status": result.status,
+            "protocol": meta.get("protocol", "-"),
+            "observation_mode": meta.get("observation_mode", "radar-only"),
+            "http_code": result.http_code,
+            "last_check": probe_date,
+            "datasets_in_use": meta.get("datasets_in_use") or [],
+        })
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "probe_date": probe_date,
+        "sources_total": len(registry),
+        "status_counts": {
+            "GREEN": status_counts.get("GREEN", 0),
+            "YELLOW": status_counts.get("YELLOW", 0),
+            "RED": status_counts.get("RED", 0),
+        },
+        "sources": sources_list,
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Probe radar source portals and build STATUS.md."
@@ -357,16 +412,22 @@ def main() -> int:
         results[portal] = probe_url(str(base_url))
 
     report = build_status_report(registry, results, probe_date)
+    summary = build_radar_summary(registry, results, probe_date)
 
     if args.dry_run:
         print(report)
+        print("\n--- SUMMARY JSON ---")
+        print(json.dumps(summary, indent=2, ensure_ascii=False))
         return 0
 
     update_last_probed(registry, probe_date)
     STATUS_PATH.parent.mkdir(parents=True, exist_ok=True)
     STATUS_PATH.write_text(report, encoding="utf-8")
+    SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SUMMARY_PATH.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
     save_registry(REGISTRY_PATH, registry)
     print(f"Wrote {STATUS_PATH}")
+    print(f"Wrote {SUMMARY_PATH}")
     print(f"Updated {REGISTRY_PATH}")
     return 0
 

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -354,11 +354,13 @@ def build_radar_summary(
         ]
     }
     """
+    generated_at = datetime.now(timezone.utc).isoformat()
+    _missing = ProbeResult(status="RED", http_code="-", note="probe result missing")
     status_counts = Counter(result.status for result in results.values())
     sources_list = []
 
     for source_id, meta in registry.items():
-        result = results[source_id]
+        result = results.get(source_id) or _missing
         sources_list.append({
             "id": source_id,
             "status": result.status,
@@ -370,7 +372,7 @@ def build_radar_summary(
         })
 
     return {
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": generated_at,
         "probe_date": probe_date,
         "sources_total": len(registry),
         "status_counts": {

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -223,3 +223,71 @@ def test_build_status_report_basic() -> None:
     assert "| istat_sdmx |" in report
     assert "## Note" in report
     assert "istat_sdmx" in report
+
+
+def test_build_radar_summary_schema() -> None:
+    """Test che build_radar_summary produce un JSON consumabile da ACB."""
+    registry = {
+        "demo_ckan": {
+            "base_url": "https://demo.test/api/3/action/package_list",
+            "source_kind": "catalog",
+            "protocol": "ckan",
+            "observation_mode": "catalog-watch",
+            "datasets_in_use": ["dataset1", "dataset2"],
+        },
+        "istat_sdmx": {
+            "base_url": "https://sdmx.istat.it/rest/",
+            "source_kind": "catalog",
+            "protocol": "sdmx",
+            "observation_mode": "radar-only",
+            "datasets_in_use": [],
+        },
+    }
+    results = {
+        "demo_ckan": radar_check.ProbeResult(
+            status="GREEN", http_code="200", content_type="application/json"
+        ),
+        "istat_sdmx": radar_check.ProbeResult(
+            status="YELLOW", http_code="-", note="Timeout"
+        ),
+    }
+
+    summary = radar_check.build_radar_summary(registry, results, "2026-04-18")
+
+    # Verifica struttura top-level
+    assert "generated_at" in summary
+    assert "probe_date" in summary
+    assert "sources_total" in summary
+    assert "status_counts" in summary
+    assert "sources" in summary
+
+    # Verifica conteggi
+    assert summary["probe_date"] == "2026-04-18"
+    assert summary["sources_total"] == 2
+    assert summary["status_counts"]["GREEN"] == 1
+    assert summary["status_counts"]["YELLOW"] == 1
+    assert summary["status_counts"]["RED"] == 0
+
+    # Verifica entry fonte
+    sources_by_id = {s["id"]: s for s in summary["sources"]}
+    assert "demo_ckan" in sources_by_id
+    assert "istat_sdmx" in sources_by_id
+
+    demo = sources_by_id["demo_ckan"]
+    assert demo["status"] == "GREEN"
+    assert demo["protocol"] == "ckan"
+    assert demo["observation_mode"] == "catalog-watch"
+    assert demo["http_code"] == "200"
+    assert demo["last_check"] == "2026-04-18"
+    assert demo["datasets_in_use"] == ["dataset1", "dataset2"]
+
+    istat = sources_by_id["istat_sdmx"]
+    assert istat["status"] == "YELLOW"
+    assert istat["http_code"] == "-"
+    assert istat["datasets_in_use"] == []
+
+    # Verifica JSON-serializable
+    json_str = json.dumps(summary)
+    assert isinstance(json_str, str)
+    reparsed = json.loads(json_str)
+    assert reparsed == summary


### PR DESCRIPTION
## Descrizione

Implementa SO #116: il workflow GitHub Actions del radar daily ora produce un file `radar_summary.json` come output secondario, consumabile da agent-context-builder (ACB).

## Che cosa è cambiato

### Script (`scripts/radar_check.py`)
- **Nuova funzione `build_radar_summary()`**: genera un JSON compatto con schema:
  ```json
  {
    "generated_at": "ISO8601 timestamp",
    "probe_date": "YYYY-MM-DD",
    "sources_total": N,
    "status_counts": { "GREEN": N, "YELLOW": N, "RED": N },
    "sources": [{ "id", "status", "protocol", "observation_mode", "http_code", "last_check", "datasets_in_use" }]
  }
  ```
- Import datetime.timezone per timestamp ISO8601
- main() genera e salva summary JSON alongside STATUS.md

### Workflow (`.github/workflows/radar-scheduled.yml`)
- Aggiunto `data/radar/radar_summary.json` al commit git
- Validation step verifica JSON well-formed

### Documentazione (`data/radar/README.md`)
- Documentato nuovo artifact e scopo (consumo ACB)

### Test (`tests/test_radar_check.py`)
- test_build_radar_summary_schema(): schema, conteggi, entry fonti, JSON-serialization

## Backward compatibility
- Schema additivo, nessun campo rimosso da artefatti esistenti
- radar_summary.json è file nuovo, non fa break di consumer
- STATUS.md e sources_registry.yaml invariati

## Test
- Tutti 15 test radar_check passano
- Nuovo test copre schema e ACB contract

## Next
ACB consumerà il file da `source-observatory/data/radar/radar_summary.json` per orientare agenti sul radar health.
Closes #116 