### PR TITLE
feat: portal-scout — discovery, scout strutturale e workflow agente

### DIFF
--- a/.github/workflows/portal-scout.yml
+++ b/.github/workflows/portal-scout.yml
@@ -161,6 +161,7 @@ jobs:
           path: |
             data/portal_scout/discovered_portals.parquet
             data/portal_scout/discovered_portals_summary.json
+            data/portal_scout/portal_scout_shortlist.md
             data/portal_scout/scout_results/
 
       - name: Publish summary

--- a/.github/workflows/portal-scout.yml
+++ b/.github/workflows/portal-scout.yml
@@ -60,8 +60,16 @@ jobs:
 
       # --- Fase 1: Discovery ---
 
+      - name: Verifica gate skip_discovery + GCS
+        if: ${{ inputs.skip_discovery == 'true' }}
+        run: |
+          if [[ -z '${{ env.PORTAL_SCOUT_GCS_PREFIX }}' ]]; then
+            echo "::error::skip_discovery=true richiede PORTAL_SCOUT_GCS_PREFIX configurato. Imposta il secret o lancia con skip_discovery=false."
+            exit 1
+          fi
+
       - name: Download discovered_portals from GCS (se skip_discovery)
-        if: ${{ inputs.skip_discovery == 'true' && env.PORTAL_SCOUT_GCS_PREFIX != '' }}
+        if: ${{ inputs.skip_discovery == 'true' }}
         run: |
           prefix='${{ env.PORTAL_SCOUT_GCS_PREFIX }}'
           prefix="${prefix%/}"

--- a/.github/workflows/portal-scout.yml
+++ b/.github/workflows/portal-scout.yml
@@ -112,8 +112,14 @@ jobs:
                                    "--registry-path", tmp,
                                    "--out-dir", "data/portal_scout/scout_results"],
                                   check=False)
-          if result.returncode != 0:
+          scout_ok = result.returncode == 0
+          if not scout_ok:
               print(f"[warn] portal_scout.py exited with code {result.returncode}", file=sys.stderr)
+
+          # Scrive stato scout per il summary finale
+          Path("data/portal_scout/.scout_status").write_text(
+              "ok" if scout_ok else f"partial (exit {result.returncode})"
+          )
           PY
 
       # --- Upload su GCS ---
@@ -156,9 +162,17 @@ jobs:
           from pathlib import Path
 
           df = pd.read_parquet("data/portal_scout/discovered_portals.parquet")
+
+          scout_status_file = Path("data/portal_scout/.scout_status")
+          scout_status = scout_status_file.read_text().strip() if scout_status_file.exists() else "skipped (nessun candidato strutturato)"
+
           lines = ["## Portal Scout", ""]
           lines.append(f"- Domini totali rilevati: **{len(df)}**")
           lines.append(f"- Nuovi candidati (non nel registry): **{len(df[df['in_registry'] == 'no'])}**")
+          lines.append(f"- Scout strutturale: **{scout_status}**")
+          if scout_status.startswith("partial"):
+              lines.append("")
+              lines.append("> ⚠️ Lo scout strutturale ha avuto errori — `scout_results` potrebbero essere incompleti o assenti.")
           lines.append("")
           lines.append("### Protocolli strutturati rilevati")
           structured = df[df["protocol"].isin(["ckan", "sdmx", "sparql"])]

--- a/.github/workflows/portal-scout.yml
+++ b/.github/workflows/portal-scout.yml
@@ -1,0 +1,171 @@
+name: portal-scout
+
+on:
+  workflow_dispatch:
+    inputs:
+      max_results:
+        description: "Risultati DDG per query (default: 20)"
+        required: false
+        default: "20"
+      skip_discovery:
+        description: "Salta discovery, usa parquet esistente in GCS"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  portal-scout:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      PORTAL_SCOUT_GCS_PREFIX: ${{ secrets.PORTAL_SCOUT_GCS_PREFIX }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Authenticate to Google Cloud
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.PORTAL_SCOUT_GCS_PREFIX != '' }}
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.PORTAL_SCOUT_GCS_PREFIX != '' }}
+        uses: google-github-actions/setup-gcloud@v3
+
+      # --- Fase 1: Discovery ---
+
+      - name: Download discovered_portals from GCS (se skip_discovery)
+        if: ${{ inputs.skip_discovery == 'true' && env.PORTAL_SCOUT_GCS_PREFIX != '' }}
+        run: |
+          prefix='${{ env.PORTAL_SCOUT_GCS_PREFIX }}'
+          prefix="${prefix%/}"
+          mkdir -p data/portal_scout
+          gcloud storage cp "$prefix/discovered_portals.parquet" data/portal_scout/discovered_portals.parquet
+
+      - name: Discover portals (DDG + protocol probe)
+        if: ${{ inputs.skip_discovery != 'true' }}
+        run: |
+          python scripts/discover_portals.py \
+            --max-results ${{ inputs.max_results }} \
+            --out data/portal_scout/discovered_portals.parquet
+
+      # --- Fase 2: Scout strutturale sui candidati CKAN/SDMX/SPARQL ---
+
+      - name: Run portal_scout on structured candidates
+        run: |
+          python - <<'PY'
+          import pandas as pd
+          import subprocess, sys, yaml, tempfile
+          from pathlib import Path
+
+          df = pd.read_parquet("data/portal_scout/discovered_portals.parquet")
+          candidates = df[
+              (df["in_registry"] == "no") &
+              (df["protocol"].isin(["ckan", "sdmx", "sparql"]))
+          ]
+
+          if candidates.empty:
+              print("Nessun candidato strutturato da sondare.")
+              sys.exit(0)
+
+          print(f"Candidati da sondare: {len(candidates)}")
+
+          # Costruisce registry temporaneo con tutti i candidati
+          cfg = {}
+          for _, row in candidates.iterrows():
+              entry = {"protocol": row["protocol"], "base_url": row["base_url"]}
+              if row["protocol"] == "sparql" and row.get("probe_url"):
+                  entry["sparql"] = {"endpoint_url": row["probe_url"]}
+              cfg[row["domain"]] = entry
+
+          with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+              yaml.dump(cfg, f)
+              tmp = f.name
+
+          result = subprocess.run([sys.executable, "scripts/portal_scout.py",
+                                   "--registry-path", tmp,
+                                   "--out-dir", "data/portal_scout/scout_results"],
+                                  check=False)
+          if result.returncode != 0:
+              print(f"[warn] portal_scout.py exited with code {result.returncode}", file=sys.stderr)
+          PY
+
+      # --- Upload su GCS ---
+
+      - name: Upload artifacts to GCS
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.PORTAL_SCOUT_GCS_PREFIX != '' }}
+        run: |
+          stamp=$(python -c "from datetime import datetime, timezone; print(datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S'))")
+          prefix='${{ env.PORTAL_SCOUT_GCS_PREFIX }}'
+          prefix="${prefix%/}"
+
+          gcloud storage cp data/portal_scout/discovered_portals.parquet \
+            "$prefix/discovered_portals.parquet"
+          gcloud storage cp data/portal_scout/discovered_portals.parquet \
+            "$prefix/snapshots/discovered_portals_${stamp}.parquet"
+
+          if [ -f data/portal_scout/discovered_portals_summary.json ]; then
+            gcloud storage cp data/portal_scout/discovered_portals_summary.json \
+              "$prefix/discovered_portals_summary.json"
+          fi
+
+          if compgen -G "data/portal_scout/scout_results/*.json" > /dev/null; then
+            gcloud storage cp data/portal_scout/scout_results/*.json \
+              "$prefix/scout_results/"
+          fi
+
+      - name: Upload workflow artifact (Actions)
+        uses: actions/upload-artifact@v7
+        with:
+          name: portal-scout
+          path: |
+            data/portal_scout/discovered_portals.parquet
+            data/portal_scout/discovered_portals_summary.json
+            data/portal_scout/scout_results/
+
+      - name: Publish summary
+        run: |
+          python - <<'PY'
+          import pandas as pd
+          from pathlib import Path
+
+          df = pd.read_parquet("data/portal_scout/discovered_portals.parquet")
+          lines = ["## Portal Scout", ""]
+          lines.append(f"- Domini totali rilevati: **{len(df)}**")
+          lines.append(f"- Nuovi candidati (non nel registry): **{len(df[df['in_registry'] == 'no'])}**")
+          lines.append("")
+          lines.append("### Protocolli strutturati rilevati")
+          structured = df[df["protocol"].isin(["ckan", "sdmx", "sparql"])]
+          for _, row in structured.iterrows():
+            tag = "✓ già nel registry" if row["in_registry"] == "yes" else "⚡ nuovo"
+            lines.append(f"- `{row['domain']}` — {row['protocol'].upper()} ({tag})")
+
+          Path("summary.md").write_text("\n".join(lines) + "\n")
+          PY
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ data/monitor/reports/diff_summary.json
 
 # Local artifacts (parquet, reports)
 data/catalog_inventory/generated/
+data/portal_scout/
 

--- a/README.md
+++ b/README.md
@@ -1,73 +1,74 @@
 # Source Observatory
 
-Intelligence layer leggero per fonti pubbliche italiane.
+Intelligence layer leggero per fonti pubbliche italiane — parte dell'ecosistema [DataCivicLab](https://github.com/dataciviclab).
 
-Fa parte dell'ecosistema [DataCivicLab](https://github.com/dataciviclab).
+Risponde a una domanda sola: **questa fonte vale il tempo del Lab?**
 
-Tre pezzi principali:
+## Il funnel
 
-1. **catalog inventory** - enumera cosa esiste nei cataloghi osservati e produce un parquet interrogabile
-2. **radar** - verifica se una fonte risponde prima di investirci tempo
-3. **source-check / portal-scout** - workflow disciplinati per decidere se una fonte merita lavoro del Lab
+```
+discover_portals  →  portal-scout  →  gate
+                                        ├─ catalog-watch   (catalogo osservabile)
+                                        ├─ radar-only      (monitoraggio passivo)
+                                        └─ source-check    (valutazione manuale)
+                                              ↓
+                                        catalog-inventory  (snapshot interrogabile)
+```
 
-Non è:
+1. **Discover** — trova portali PA nazionali via DDG, proba il protocollo (CKAN/SDMX/SPARQL)
+2. **Portal-scout** — classifica la superficie tecnica, assegna un verdict
+3. **Gate** — decide il regime di osservazione
+4. **Catalog-inventory** — enumera gli item dei cataloghi ammessi
 
-- una pipeline dataset
-- un sistema di intake candidate
-- una piattaforma di monitoraggio diffuso
+## Script
 
-## Catalog inventory
-
-`scripts/build_catalog_inventory.py` entra nei cataloghi CKAN, SDMX e SPARQL del registry e produce uno snapshot tabulare di tutti gli item enumerabili.
-
-Output:
-
-- `data/catalog_inventory/generated/catalog_inventory_latest.parquet`
-- `data/catalog_inventory/generated/catalog_inventory_report.json`
-
-Il parquet contiene oggi oltre 6000 item da fonti come INPS, OpenBDAP, MIM USTAT, Lavoro, Consip, Camera, ISPRA. È il punto di partenza per lo scouting: invece di navigare portali ostili manualmente, si interroga il parquet in DuckDB e si shortlista.
-
-Questi file **non sono versionati nel repo**. Per ottenerli: artifact del workflow `catalog-inventory` su GitHub Actions, oppure GCS se configurato. Per generarli localmente usare il comando sotto.
+| Script | Cosa fa |
+|---|---|
+| `scripts/discover_portals.py` | Discovery DDG + protocol probe → parquet candidati |
+| `scripts/portal_scout.py` | Sonda copertura metadata su campione → JSON per portale |
+| `scripts/radar_check.py` | Health check giornaliero delle fonti nel registry |
+| `scripts/build_catalog_inventory.py` | Snapshot tabulare di tutti gli item enumerabili |
 
 ```bash
+# Discovery mirata per protocollo
+python scripts/discover_portals.py --protocols ckan --only-matched
+
+# Scout su candidati
+python scripts/portal_scout.py --registry-path /tmp/candidate.yaml --dry-run
+
+# Radar
+python scripts/radar_check.py
+
+# Catalog inventory
 python scripts/build_catalog_inventory.py --out-dir data/catalog_inventory/generated
 ```
 
-## Radar
+## Workflow
 
-`scripts/radar_check.py` fa un health check economico di tutte le fonti nel registry: risponde, ha problemi SSL, è fragile?
+I workflow sono istruzioni per agenti — non pipeline CI/CD. Seguire in ordine per ogni portale nuovo.
 
-Output: [`data/radar/STATUS.md`](data/radar/STATUS.md) - un artefatto leggibile usabile come pre-flight prima di un source-check o di un run DI.
+- [`workflows/portal-scout.md`](workflows/portal-scout.md) — classifica un portale e assegna verdict
+- [`workflows/source-check.md`](workflows/source-check.md) — valuta se una fonte regge come pista del Lab
+- [`workflows/catalog-watch.md`](workflows/catalog-watch.md) — osserva cambi inventariali del catalogo
+- [`workflows/catalog-inventory-scout.md`](workflows/catalog-inventory-scout.md) — triage degli item in un catalogo noto
 
-```bash
-python scripts/radar_check.py
+## Output e artefatti
+
+Gli artifact generati (`parquet`, `json`, `STATUS.md`) non sono versionati nel repo. Si ottengono da GitHub Actions o GCS se configurato.
+
+- `data/radar/STATUS.md` — stato corrente delle fonti nel registry
+- `data/portal_scout/discovered_portals.parquet` — candidati discovery
+- `data/portal_scout/discovered_portals_summary.json` — sommario leggibile per agenti
+- `data/catalog_inventory/generated/catalog_inventory_latest.parquet` — oltre 6000 item da INPS, OpenBDAP, ISPRA, Camera e altri
+
+## Struttura
+
 ```
-
-Schedulato giornalmente via GitHub Actions. Il registry è in [`data/radar/sources_registry.yaml`](data/radar/sources_registry.yaml).
-
-## Source-check e portal-scout
-
-Non sono script, sono workflow disciplinati documentati in `workflows/`.
-
-- [`portal-scout.md`](workflows/portal-scout.md) - classifica un portale prima che entri nel registry: è un catalogo reale? è inventariabile? quale modalità di osservazione ha senso?
-- [`source-check.md`](workflows/source-check.md) - verifica se una fonte o un dataset regge davvero come pista del Lab. Entra con una fonte opaca, esce con un verdetto esplicito e un next step.
-
-Il valore è nel processo: impedisce di portare in `dataset-incubator` candidate non ancora maturi.
-
-## Catalog-watch
-
-Osserva i cataloghi del registry per segnali di cambiamento inventariale. Non enumera cosa c'è dentro (quello è catalog inventory), risponde a "il catalogo è cambiato?".
-
-Output: [`data/catalog/CATALOG_WATCH_REPORT.md`](data/catalog/CATALOG_WATCH_REPORT.md)
-
-Resta `human-run` nella v0.
-
-## Struttura del repo
-
-- `scripts/` - codice runtime canonico
-- `data/` - stato generato e report
-- `docs/` - architettura, runbook, policy di misura
-- `workflows/` - workflow operativi documentati
+scripts/    codice runtime
+data/       stato generato e report
+workflows/  istruzioni operative per agenti
+docs/       architettura, runbook, policy
+```
 
 ## Documentazione
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,14 @@ I workflow sono istruzioni per agenti — non pipeline CI/CD. Seguire in ordine 
 Gli artifact generati (`parquet`, `json`, `STATUS.md`) non sono versionati nel repo. Si ottengono da GitHub Actions o GCS se configurato.
 
 - `data/radar/STATUS.md` — stato corrente delle fonti nel registry
-- `data/portal_scout/discovered_portals.parquet` — candidati discovery
-- `data/portal_scout/discovered_portals_summary.json` — sommario leggibile per agenti
+- `data/radar/radar_summary.json` — health complessivo (GREEN/YELLOW/RED per fonte)
+- `data/catalog/catalog_signals.json` — segnali di regressione per singola fonte
+- `data/portal_scout/discovered_portals.parquet` — candidati discovery (parquet completo)
+- `data/portal_scout/discovered_portals_summary.json` — sommario nuovi portali strutturati
+- `data/portal_scout/portal_scout_shortlist.md` — shortlist leggibile per review umana
 - `data/catalog_inventory/generated/catalog_inventory_latest.parquet` — oltre 6000 item da INPS, OpenBDAP, ISPRA, Camera e altri
+
+I tre JSON (`radar_summary`, `catalog_signals`, `discovered_portals_summary`) sono consumati da **agent-context-builder** per includere lo stato delle fonti nel contesto operativo degli agenti AI.
 
 ## Struttura
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML>=6.0,<7.0
 duckdb>=1.0,<2.0
 pandas>=2.1,<4.0
 pyarrow>=14.0,<20.0
+ddgs>=9.0,<10.0

--- a/scripts/collectors/ckan.py
+++ b/scripts/collectors/ckan.py
@@ -47,7 +47,8 @@ def ckan_action_endpoint(base_url: str, action: str) -> str:
     if last_segment in CKAN_ACTION_NAMES:
         root = endpoint.rsplit("/", 1)[0]
         return f"{root}/{action}"
-    return endpoint
+    # Nessun path API rilevato — aggiunge il path standard CKAN
+    return f"{endpoint}/api/3/action/{action}"
 
 
 def ckan_get_json(url: str, **kwargs: Any) -> dict[str, Any]:

--- a/scripts/discover_portals.py
+++ b/scripts/discover_portals.py
@@ -29,9 +29,16 @@ OUT_DEFAULT = Path(__file__).resolve().parents[1] / "data" / "portal_scout" / "d
 SEARCH_QUERIES_BASE = [
     '"open data" "comuni" site:gov.it',
     '"dati comunali" "ministero" site:gov.it',
-    '"granularità comunale" "open data" site:gov.it',
     '"codice comune" dataset site:gov.it',
     '"API" "open data" ministero site:gov.it',
+]
+
+# Query mirate .it — pescano portali CKAN/SDMX regionali/utility con API strutturata
+SEARCH_QUERIES_IT = [
+    '"api/3/action" "open data" site:.it',
+    '"CKAN" "dati aperti" site:.it',
+    '"SDMX" "dataflow" "open data" site:.it',
+    '"SPARQL" endpoint "dati aperti" site:.it',
 ]
 
 # Query specifiche per protocollo
@@ -40,6 +47,12 @@ SEARCH_QUERIES_BY_PROTOCOL: dict[str, list[str]] = {
     "sdmx":   ['"SDMX" "dataflow" site:gov.it', '"SDMX" ISTAT site:gov.it'],
     "sparql": ['"SPARQL" endpoint "linked data" site:gov.it', '"SPARQL" "dati.gov.it"'],
 }
+
+# Pattern che identificano portali open data istituzionali su .it generico
+IT_OPENDATA_PATTERNS = [
+    "opendata.", "open-data.", "dati.", "portale-dati.", "datiaperiti.",
+    ".comune.", ".regione.", ".provincia.", ".cm.",  # enti locali con portale dati
+]
 
 # Endpoint probe per protocol detection
 PROBE_PATHS = {
@@ -55,12 +68,11 @@ SKIP_DOMAINS = {
     "agea.gov.it",  # falso positivo SDMX — redirect a SPA React
 }
 
-# Pattern di sottodomini da scartare: portali locali/singoli comune o regione
-# (interesse basso vs portali nazionali con granularità comunale)
+# Pattern da scartare sempre (siti non-dati, falsi positivi)
 SKIP_DOMAIN_PATTERNS = [
-    ".comune.",
-    ".regione.",
     "città metropolitana",
+    "artbonus.",
+    ".camcom.",  # camere di commercio locali — dati frammentati
 ]
 
 # Portali nazionali tier-1 da includere sempre nel probe, indipendentemente dalla DDG
@@ -130,8 +142,13 @@ def extract_domains(results: list[dict]) -> dict[str, set[str]]:
             continue
         if any(pat in domain for pat in SKIP_DOMAIN_PATTERNS):
             continue
-        # Tieni solo portali nazionali PA (.gov.it)
-        if not domain.endswith(".gov.it"):
+        # Accetta .gov.it sempre; accetta .it generico solo se il dominio
+        # ha pattern che indicano un portale open data istituzionale
+        if domain.endswith(".gov.it"):
+            pass
+        elif domain.endswith(".it") and any(pat in domain for pat in IT_OPENDATA_PATTERNS):
+            pass
+        else:
             continue
         if domain not in domains:
             domains[domain] = set()
@@ -193,7 +210,7 @@ def main() -> int:
 
     # Seleziona query in base ai protocolli richiesti
     protocols = set(args.protocols) if args.protocols else set(PROBE_PATHS.keys())
-    queries = list(SEARCH_QUERIES_BASE)
+    queries = list(SEARCH_QUERIES_BASE) + list(SEARCH_QUERIES_IT)
     for proto in sorted(protocols):
         queries.extend(SEARCH_QUERIES_BY_PROTOCOL.get(proto, []))
 

--- a/scripts/discover_portals.py
+++ b/scripts/discover_portals.py
@@ -25,20 +25,20 @@ from collectors.base import observatory_get
 
 OUT_DEFAULT = Path(__file__).resolve().parents[1] / "data" / "portal_scout" / "discovered_portals.parquet"
 
-# Query generiche (sempre usate)
+# Query generiche (sempre usate) — orientate a portali nazionali con dati comunali
 SEARCH_QUERIES_BASE = [
-    '"open data" site:gov.it',
-    '"opendata" site:gov.it',
-    '"dati aperti" site:gov.it',
-    '"catalogo dati" site:gov.it',
+    '"open data" "comuni" site:gov.it',
+    '"dati comunali" "ministero" site:gov.it',
+    '"granularità comunale" "open data" site:gov.it',
+    '"codice comune" dataset site:gov.it',
     '"API" "open data" ministero site:gov.it',
 ]
 
 # Query specifiche per protocollo
 SEARCH_QUERIES_BY_PROTOCOL: dict[str, list[str]] = {
-    "ckan":   ['"CKAN" "open data" site:gov.it'],
-    "sdmx":   ['"SDMX" site:gov.it'],
-    "sparql": ['"SPARQL" endpoint site:gov.it', '"linked open data" site:gov.it'],
+    "ckan":   ['"CKAN" "comuni" site:gov.it', '"CKAN" "open data" ministero site:gov.it'],
+    "sdmx":   ['"SDMX" "dataflow" site:gov.it', '"SDMX" ISTAT site:gov.it'],
+    "sparql": ['"SPARQL" endpoint "linked data" site:gov.it', '"SPARQL" "dati.gov.it"'],
 }
 
 # Endpoint probe per protocol detection
@@ -53,6 +53,26 @@ SKIP_DOMAINS = {
     "github.com", "medium.com", "agid.gov.it", "developers.italia.it",
     "docs.italia.it", "forum.italia.it", "innovazione.gov.it",
     "agea.gov.it",  # falso positivo SDMX — redirect a SPA React
+}
+
+# Pattern di sottodomini da scartare: portali locali/singoli comune o regione
+# (interesse basso vs portali nazionali con granularità comunale)
+SKIP_DOMAIN_PATTERNS = [
+    ".comune.",
+    ".regione.",
+    "città metropolitana",
+]
+
+# Portali nazionali tier-1 da includere sempre nel probe, indipendentemente dalla DDG
+TIER1_DOMAINS: dict[str, str] = {
+    "esploradati.istat.it": "sdmx",
+    "bdap-opendata.rgs.mef.gov.it": "ckan",
+    "serviziweb2.inps.it": "sparql",
+    "dati.anticorruzione.it": "ckan",
+    "dati.isprambiente.it": "ckan",
+    "dati.camera.it": "sparql",
+    "opencoesione.gov.it": "ckan",
+    "dati-ustat.mur.gov.it": "ckan",
 }
 
 # Domini già noti nel registry — usati per marcare i candidati come nuovi vs noti
@@ -108,7 +128,9 @@ def extract_domains(results: list[dict]) -> dict[str, set[str]]:
             continue
         if any(skip in domain for skip in SKIP_DOMAINS):
             continue
-        # Tieni solo domini che sembrano portali PA (.gov.it, .regione.*, .comune.*, .it)
+        if any(pat in domain for pat in SKIP_DOMAIN_PATTERNS):
+            continue
+        # Tieni solo portali nazionali PA (.gov.it)
         if not domain.endswith(".gov.it"):
             continue
         if domain not in domains:
@@ -184,7 +206,11 @@ def main() -> int:
     print(f"  {len(results)} risultati grezzi")
 
     domains = extract_domains(results)
-    print(f"  {len(domains)} domini unici estratti")
+    # Aggiungi sempre i portali nazionali tier-1
+    for tier1_domain in TIER1_DOMAINS:
+        if tier1_domain not in domains:
+            domains[tier1_domain] = {"tier1-allowlist"}
+    print(f"  {len(domains)} domini unici estratti (inclusi {len(TIER1_DOMAINS)} tier-1)")
 
     def _probe_domain(domain: str, sources: set[str]) -> dict:
         if args.no_probe:

--- a/scripts/discover_portals.py
+++ b/scripts/discover_portals.py
@@ -344,7 +344,7 @@ def main() -> int:
         for _, r in new_confirmed.iterrows():
             shortlist_lines.append(f"- **{r['domain']}** — {r['protocol'].upper()}")
             shortlist_lines.append(f"  - Probe: `{r['probe_url']}`")
-            shortlist_lines.append(f"  - Next: portal-scout approfondito + proposta registry")
+            shortlist_lines.append("  - Next: portal-scout approfondito + proposta registry")
 
     shortlist_lines += [
         "",

--- a/scripts/discover_portals.py
+++ b/scripts/discover_portals.py
@@ -127,7 +127,7 @@ def search_ddg(queries: list[str], max_per_query: int) -> list[dict]:
 
 
 def extract_domains(results: list[dict]) -> dict[str, set[str]]:
-    """Ritorna {domain: set_of_source_queries}."""
+    """Ritorna {domain: set_of_source_queries}. Salva path DDG per CKAN path-based probe."""
     domains: dict[str, set[str]] = {}
     for r in results:
         url = r.get("href") or r.get("url") or ""
@@ -153,33 +153,68 @@ def extract_domains(results: list[dict]) -> dict[str, set[str]]:
         if domain not in domains:
             domains[domain] = set()
         domains[domain].add(query or url)
+        # Salva il path DDG per probe CKAN path-based
+        if parsed.path and parsed.path != "/":
+            _DDG_PATHS.setdefault(domain, set()).add(parsed.path)
     return domains
+
+
+# Path DDG per probe CKAN path-based (popolato da extract_domains)
+_DDG_PATHS: dict[str, set[str]] = {}
 
 
 # ---------------------------------------------------------------------------
 # Protocol detection
 # ---------------------------------------------------------------------------
 
+def _probe_ckan(base: str, extra_prefixes: list[str] | None = None) -> str | None:
+    """Torna l'URL funzionante CKAN o None. Prova path standard + path-based da DDG."""
+    suffixes = ["/api/3/action/package_list", "/api/action/package_list"]
+    prefixes = [""] + (extra_prefixes or [])
+    for prefix in prefixes:
+        for suffix in suffixes:
+            url = base + prefix + suffix
+            try:
+                r = observatory_get(url, timeout=TIMEOUT)
+                if r.status_code == 200:
+                    ct = r.headers.get("content-type", "").lower()
+                    if "json" in ct or r.text.strip().startswith("{"):
+                        data = r.json()
+                        if isinstance(data, dict) and "result" in data:
+                            return url
+            except Exception:
+                pass
+    return None
+
+
 def detect_protocol(domain: str, probe_paths: dict | None = None) -> tuple[str, str | None]:
     """Torna (protocol, working_url) o ('html', None)."""
     base = f"https://{domain}"
+
+    # CKAN: probe standard + path-based da URL DDG (es. /opendata, /catalogo)
+    ddg_paths = _DDG_PATHS.get(domain, set())
+    ckan_prefixes = sorted({
+        "/" + p.strip("/").split("/")[0]
+        for p in ddg_paths
+        if p.strip("/")
+    })
+    if "ckan" in (probe_paths or PROBE_PATHS):
+        url = _probe_ckan(base, ckan_prefixes)
+        if url:
+            return "ckan", url
+
+    # SDMX e SPARQL: probe standard
     for protocol, paths in (probe_paths or PROBE_PATHS).items():
+        if protocol == "ckan":
+            continue
         for path in paths:
             url = base + path
             try:
                 r = observatory_get(url, timeout=TIMEOUT)
                 if r.status_code == 200:
                     ct = r.headers.get("content-type", "").lower()
-                    if protocol == "ckan" and ("json" in ct or r.text.strip().startswith("{")):
-                        try:
-                            data = r.json()
-                            if isinstance(data, dict) and "result" in data:
-                                return "ckan", url
-                        except Exception:
-                            pass
-                    elif protocol == "sdmx":
+                    if protocol == "sdmx":
                         text = r.text[:5000]
-                        # Richiede namespace SDMX reale — scarta SPA/HTML che iniziano con <
                         if "sdmx.org" in text and text.strip().startswith("<") and "<!DOCTYPE" not in text[:100] and "<html" not in text[:200]:
                             return "sdmx", url
                     elif protocol == "sparql" and ("json" in ct or "xml" in ct or "sparql" in ct):
@@ -269,25 +304,69 @@ def main() -> int:
 
     df.to_parquet(args.out, index=False)
 
+    known = df[df["in_registry"] == "yes"]
     new_candidates = df[df["in_registry"] == "no"]
     print(f"  di cui {len(new_candidates)} nuovi candidati (non nel registry)")
 
     # JSON summary per ACB e lettura rapida
     confirmed_protocols = ["ckan", "sdmx", "sparql"]
     new_confirmed = new_candidates[new_candidates["protocol"].isin(confirmed_protocols)]
+    known_confirmed = known[known["protocol"].isin(confirmed_protocols)]
     summary = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "total_portals": len(df),
         "new_candidates": len(new_candidates),
         "new_confirmed_protocol": len(new_confirmed),
+        "known_registry_seen": len(known),
         "by_protocol": df["protocol"].value_counts().to_dict(),
-        "top_candidates": [
+        "new_structured": [
             {"domain": r["domain"], "protocol": r["protocol"], "probe_url": r["probe_url"]}
             for _, r in new_confirmed.iterrows()
+        ],
+        "known_registry_healthcheck": [
+            {"domain": r["domain"], "protocol": r["protocol"], "status": "seen"}
+            for _, r in known_confirmed.iterrows()
         ],
     }
     summary_path = args.out.with_name("discovered_portals_summary.json")
     summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    # Shortlist Markdown per review umana rapida
+    shortlist_lines = [
+        "# Portal Scout — Shortlist",
+        f"\n_Generato: {summary['generated_at']}_\n",
+        "## Nuovi candidati strutturati",
+        "",
+    ]
+    if new_confirmed.empty:
+        shortlist_lines.append("_Nessun nuovo candidato con protocollo confermato._")
+    else:
+        for _, r in new_confirmed.iterrows():
+            shortlist_lines.append(f"- **{r['domain']}** — {r['protocol'].upper()}")
+            shortlist_lines.append(f"  - Probe: `{r['probe_url']}`")
+            shortlist_lines.append(f"  - Next: portal-scout approfondito + proposta registry")
+
+    shortlist_lines += [
+        "",
+        "## Registry esistente — visti in questo run",
+        "",
+    ]
+    if known_confirmed.empty:
+        shortlist_lines.append("_Nessun portale noto rilevato._")
+    else:
+        for _, r in known_confirmed.iterrows():
+            shortlist_lines.append(f"- **{r['domain']}** — {r['protocol'].upper()} ✓ già nel registry")
+
+    shortlist_lines += [
+        "",
+        "## Portali HTML (non strutturati)",
+        "",
+        f"_{len(df[df['protocol'] == 'html'])} domini classificati HTML — nessuna API strutturata rilevata._",
+    ]
+
+    shortlist_path = args.out.with_name("portal_scout_shortlist.md")
+    shortlist_path.write_text("\n".join(shortlist_lines) + "\n", encoding="utf-8")
+    print(f"Shortlist scritta in {shortlist_path}")
     print(f"Summary scritto in {summary_path}")
 
     print(f"\nScritti {len(rows)} portali in {args.out}")

--- a/scripts/discover_portals.py
+++ b/scripts/discover_portals.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+discover_portals.py — scopre portali open data PA italiani via ricerca web.
+
+Esegue query DDG su domini .gov.it, estrae domini unici, tenta
+protocol detection (CKAN, SDMX, SPARQL, HTML) e produce un Parquet.
+
+Uso:
+    python scripts/discover_portals.py
+    python scripts/discover_portals.py --max-results 50 --out data/portal_scout/discovered_portals.parquet
+    python scripts/discover_portals.py --no-probe    # solo raccolta URL, senza detection
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from collectors.base import observatory_get
+
+OUT_DEFAULT = Path(__file__).resolve().parents[1] / "data" / "portal_scout" / "discovered_portals.parquet"
+
+# Query generiche (sempre usate)
+SEARCH_QUERIES_BASE = [
+    '"open data" site:gov.it',
+    '"opendata" site:gov.it',
+    '"dati aperti" site:gov.it',
+    '"catalogo dati" site:gov.it',
+    '"API" "open data" ministero site:gov.it',
+]
+
+# Query specifiche per protocollo
+SEARCH_QUERIES_BY_PROTOCOL: dict[str, list[str]] = {
+    "ckan":   ['"CKAN" "open data" site:gov.it'],
+    "sdmx":   ['"SDMX" site:gov.it'],
+    "sparql": ['"SPARQL" endpoint site:gov.it', '"linked open data" site:gov.it'],
+}
+
+# Endpoint probe per protocol detection
+PROBE_PATHS = {
+    "ckan":   ["/api/3/action/package_list", "/api/action/package_list"],
+    "sdmx":   ["/SDMXWS/rest/dataflow", "/sdmx/rest/dataflow", "/rest/dataflow"],
+    "sparql": ["/sparql", "/sparql/query", "/endpoint/sparql", "/lod/sparql", "/opendata/sparql"],
+}
+
+SKIP_DOMAINS = {
+    "www.gov.it", "www.governo.it", "www.italia.it", "wikipedia.org",
+    "github.com", "medium.com", "agid.gov.it", "developers.italia.it",
+    "docs.italia.it", "forum.italia.it", "innovazione.gov.it",
+    "agea.gov.it",  # falso positivo SDMX — redirect a SPA React
+}
+
+# Domini già noti nel registry — usati per marcare i candidati come nuovi vs noti
+KNOWN_REGISTRY_DOMAINS = {
+    "esploradati.istat.it",
+    "dati.anticorruzione.it",
+    "serviziweb2.inps.it",
+    "bdap-opendata.rgs.mef.gov.it",
+    "www.dati.salute.gov.it",
+    "dati.inail.it",
+    "dati.istruzione.it",
+    "dati.camera.it",
+    "dati.isprambiente.it",
+    "dati.consip.it",
+    "dati.lavoro.gov.it",
+    "dati-ustat.mur.gov.it",
+    "opencoesione.gov.it",
+    "openbdap.rgs.mef.gov.it",
+}
+
+TIMEOUT = 8
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+def search_ddg(queries: list[str], max_per_query: int) -> list[dict]:
+    from ddgs import DDGS
+    results = []
+    with DDGS() as ddgs:
+        for query in queries:
+            try:
+                hits = list(ddgs.text(query, max_results=max_per_query))
+                results.extend(hits)
+                time.sleep(1.5)  # rate limit
+            except Exception as exc:
+                print(f"  [warn] query '{query}': {exc}", file=sys.stderr)
+    return results
+
+
+def extract_domains(results: list[dict]) -> dict[str, set[str]]:
+    """Ritorna {domain: set_of_source_queries}."""
+    domains: dict[str, set[str]] = {}
+    for r in results:
+        url = r.get("href") or r.get("url") or ""
+        query = r.get("query", "")
+        if not url:
+            continue
+        parsed = urlparse(url)
+        domain = parsed.netloc.lower().lstrip("www.")
+        if not domain:
+            continue
+        if any(skip in domain for skip in SKIP_DOMAINS):
+            continue
+        # Tieni solo domini che sembrano portali PA (.gov.it, .regione.*, .comune.*, .it)
+        if not domain.endswith(".gov.it"):
+            continue
+        if domain not in domains:
+            domains[domain] = set()
+        domains[domain].add(query or url)
+    return domains
+
+
+# ---------------------------------------------------------------------------
+# Protocol detection
+# ---------------------------------------------------------------------------
+
+def detect_protocol(domain: str, probe_paths: dict | None = None) -> tuple[str, str | None]:
+    """Torna (protocol, working_url) o ('html', None)."""
+    base = f"https://{domain}"
+    for protocol, paths in (probe_paths or PROBE_PATHS).items():
+        for path in paths:
+            url = base + path
+            try:
+                r = observatory_get(url, timeout=TIMEOUT)
+                if r.status_code == 200:
+                    ct = r.headers.get("content-type", "").lower()
+                    if protocol == "ckan" and ("json" in ct or r.text.strip().startswith("{")):
+                        try:
+                            data = r.json()
+                            if isinstance(data, dict) and "result" in data:
+                                return "ckan", url
+                        except Exception:
+                            pass
+                    elif protocol == "sdmx":
+                        text = r.text[:5000]
+                        # Richiede namespace SDMX reale — scarta SPA/HTML che iniziano con <
+                        if "sdmx.org" in text and text.strip().startswith("<") and "<!DOCTYPE" not in text[:100] and "<html" not in text[:200]:
+                            return "sdmx", url
+                    elif protocol == "sparql" and ("json" in ct or "xml" in ct or "sparql" in ct):
+                        return "sparql", url
+            except Exception:
+                pass
+    return "html", None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Scopre portali open data PA via ricerca web.")
+    p.add_argument("--max-results", type=int, default=20, help="Risultati max per query DDG (default: 20).")
+    p.add_argument("--no-probe", action="store_true", help="Salta protocol detection.")
+    p.add_argument("--protocols", nargs="+", choices=["ckan", "sdmx", "sparql"],
+                   help="Filtra per protocollo: usa solo query e probe mirati (es. --protocols sdmx ckan).")
+    p.add_argument("--only-matched", action="store_true",
+                   help="Output solo portali dove il probe ha confermato il protocollo (esclude html).")
+    p.add_argument("--out", type=Path, default=OUT_DEFAULT, help="Path parquet output.")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Seleziona query in base ai protocolli richiesti
+    protocols = set(args.protocols) if args.protocols else set(PROBE_PATHS.keys())
+    queries = list(SEARCH_QUERIES_BASE)
+    for proto in sorted(protocols):
+        queries.extend(SEARCH_QUERIES_BY_PROTOCOL.get(proto, []))
+
+    # Limita i probe ai protocolli richiesti
+    active_probe_paths = {k: v for k, v in PROBE_PATHS.items() if k in protocols}
+
+    print(f"Ricerca su {len(queries)} query DDG (max {args.max_results} risultati ciascuna)"
+          + (f" — protocolli: {', '.join(sorted(protocols))}" if args.protocols else "") + "...")
+    results = search_ddg(queries, args.max_results)
+    print(f"  {len(results)} risultati grezzi")
+
+    domains = extract_domains(results)
+    print(f"  {len(domains)} domini unici estratti")
+
+    rows = []
+    for domain, sources in sorted(domains.items()):
+        if args.no_probe:
+            protocol, probe_url = "unknown", None
+        else:
+            print(f"  probe {domain} ...", end=" ", flush=True)
+            protocol, probe_url = detect_protocol(domain, active_probe_paths)
+            print(protocol)
+
+        in_registry = domain in KNOWN_REGISTRY_DOMAINS or any(
+            domain.endswith("." + kd) or kd.endswith("." + domain)
+            for kd in KNOWN_REGISTRY_DOMAINS
+        )
+        rows.append({
+            "domain": domain,
+            "protocol": protocol,
+            "probe_url": probe_url or "",
+            "base_url": f"https://{domain}",
+            "in_registry": "yes" if in_registry else "no",
+            "source_queries": " | ".join(sorted(sources)),
+        })
+
+    import json
+    import pandas as pd
+    from datetime import datetime, timezone
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(rows, columns=["domain", "protocol", "probe_url", "base_url", "in_registry", "source_queries"])
+
+    if args.only_matched:
+        confirmed = args.protocols if args.protocols else list(PROBE_PATHS.keys())
+        df = df[df["protocol"].isin(confirmed)]
+        print(f"  filtrati a {len(df)} portali con protocollo confermato ({', '.join(confirmed)})")
+
+    df.to_parquet(args.out, index=False)
+
+    new_candidates = df[df["in_registry"] == "no"]
+    print(f"  di cui {len(new_candidates)} nuovi candidati (non nel registry)")
+
+    # JSON summary per ACB e lettura rapida
+    confirmed_protocols = ["ckan", "sdmx", "sparql"]
+    new_confirmed = new_candidates[new_candidates["protocol"].isin(confirmed_protocols)]
+    summary = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "total_portals": len(df),
+        "new_candidates": len(new_candidates),
+        "new_confirmed_protocol": len(new_confirmed),
+        "by_protocol": df["protocol"].value_counts().to_dict(),
+        "top_candidates": [
+            {"domain": r["domain"], "protocol": r["protocol"], "probe_url": r["probe_url"]}
+            for _, r in new_confirmed.iterrows()
+        ],
+    }
+    summary_path = args.out.with_name("discovered_portals_summary.json")
+    summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"Summary scritto in {summary_path}")
+
+    print(f"\nScritti {len(rows)} portali in {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/discover_portals.py
+++ b/scripts/discover_portals.py
@@ -80,7 +80,7 @@ TIMEOUT = 8
 # ---------------------------------------------------------------------------
 
 def search_ddg(queries: list[str], max_per_query: int) -> list[dict]:
-    from ddgs import DDGS
+    from ddgs import DDGS  # type: ignore[import-not-found]
     results = []
     with DDGS() as ddgs:
         for query in queries:

--- a/scripts/discover_portals.py
+++ b/scripts/discover_portals.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -185,27 +186,31 @@ def main() -> int:
     domains = extract_domains(results)
     print(f"  {len(domains)} domini unici estratti")
 
-    rows = []
-    for domain, sources in sorted(domains.items()):
+    def _probe_domain(domain: str, sources: set[str]) -> dict:
         if args.no_probe:
             protocol, probe_url = "unknown", None
         else:
-            print(f"  probe {domain} ...", end=" ", flush=True)
             protocol, probe_url = detect_protocol(domain, active_probe_paths)
-            print(protocol)
-
+            print(f"  probe {domain} ... {protocol}", flush=True)
         in_registry = domain in KNOWN_REGISTRY_DOMAINS or any(
             domain.endswith("." + kd) or kd.endswith("." + domain)
             for kd in KNOWN_REGISTRY_DOMAINS
         )
-        rows.append({
+        return {
             "domain": domain,
             "protocol": protocol,
             "probe_url": probe_url or "",
             "base_url": f"https://{domain}",
             "in_registry": "yes" if in_registry else "no",
             "source_queries": " | ".join(sorted(sources)),
-        })
+        }
+
+    rows = []
+    workers = 1 if args.no_probe else 10
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(_probe_domain, d, s): d for d, s in sorted(domains.items())}
+        for future in as_completed(futures):
+            rows.append(future.result())
 
     import json
     import pandas as pd

--- a/scripts/portal_scout.py
+++ b/scripts/portal_scout.py
@@ -235,7 +235,9 @@ def scout_sdmx(source_id: str, source_cfg: dict[str, Any]) -> dict[str, Any]:
 
 def scout_sparql(source_id: str, source_cfg: dict[str, Any]) -> dict[str, Any]:
     sparql_cfg = source_cfg.get("sparql") or {}
-    endpoint = sparql_cfg.get("endpoint_url") or source_cfg.get("base_url")
+    endpoint: str | None = sparql_cfg.get("endpoint_url") or source_cfg.get("base_url")
+    if not endpoint:
+        return {"protocol": "sparql", "error": "endpoint mancante nella configurazione"}
     query = SPARQL_QUERY_TEMPLATES["dcat_datasets"].replace("{limit}", str(SPARQL_SAMPLE_SIZE))
     errors: list[str] = []
 

--- a/scripts/portal_scout.py
+++ b/scripts/portal_scout.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""
+portal_scout.py — sonda strutturale leggera per fonte nel registry.
+
+Non scarica l'intero catalogo. Per ogni fonte sonda un campione minimo
+e risponde a: quali campi metadata sono popolati e con che copertura?
+
+Protocolli supportati: ckan, sdmx, sparql
+Protocolli skip (non automatizzabili): html, rest, aem
+
+Output: data/portal_scout/{source_id}_scout.json  (o stdout con --dry-run)
+
+Uso:
+    python scripts/portal_scout.py
+    python scripts/portal_scout.py --source-ids inps openbdap
+    python scripts/portal_scout.py --source-ids istat_sdmx --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from collectors.base import observatory_get, now_utc_iso, sparql_binding_value
+from collectors.ckan import ckan_action_endpoint, ckan_get_json
+from collectors.sdmx import parse_sdmx_name, _sdmx_api_base
+from collectors.sparql import SPARQL_QUERY_TEMPLATES
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
+OUT_DIR = REPO_ROOT / "data" / "portal_scout"
+
+SUPPORTED_PROTOCOLS = {"ckan", "sdmx", "sparql"}
+CKAN_SAMPLE_SIZE = 10
+SDMX_SAMPLE_SIZE = 10
+SPARQL_SAMPLE_SIZE = 20
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _coverage(values: list[Any]) -> dict[str, Any]:
+    total = len(values)
+    populated = sum(1 for v in values if v not in (None, "", [], {}))
+    samples = [v for v in values if v not in (None, "", [], {})][:3]
+    return {
+        "total_sampled": total,
+        "populated": populated,
+        "coverage_pct": round(populated / total * 100) if total else 0,
+        "samples": samples,
+    }
+
+
+def _field_report(items: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggrega copertura per ogni campo trovato nel campione."""
+    accum: dict[str, list[Any]] = defaultdict(list)
+    for item in items:
+        for k, v in item.items():
+            accum[k].append(v)
+    return {field: _coverage(vals) for field, vals in sorted(accum.items())}
+
+
+# ---------------------------------------------------------------------------
+# CKAN scout
+# ---------------------------------------------------------------------------
+
+def scout_ckan(source_id: str, source_cfg: dict[str, Any]) -> dict[str, Any]:
+    base_url = source_cfg.get("base_url")
+    if not base_url:
+        return {"protocol": "ckan", "error": "base_url mancante nella configurazione"}
+    errors: list[str] = []
+
+    # 1. package_search per sample
+    items: list[dict] = []
+    try:
+        endpoint = ckan_action_endpoint(base_url, "package_search")
+        payload = ckan_get_json(endpoint, params={"rows": CKAN_SAMPLE_SIZE, "start": 0})
+        items = (payload.get("result") or {}).get("results") or []
+    except Exception as exc:
+        errors.append(f"package_search failed: {exc}")
+
+    # fallback: package_list + package_show
+    if not items:
+        try:
+            pl_endpoint = ckan_action_endpoint(base_url, "package_list")
+            pl = ckan_get_json(pl_endpoint)
+            slugs = (pl.get("result") or [])[:CKAN_SAMPLE_SIZE]
+            ps_endpoint = ckan_action_endpoint(base_url, "package_show")
+            for slug in slugs:
+                try:
+                    ps = ckan_get_json(ps_endpoint, params={"id": slug})
+                    item = ps.get("result") or {}
+                    if item:
+                        items.append(item)
+                except Exception:
+                    pass
+        except Exception as exc:
+            errors.append(f"package_list fallback failed: {exc}")
+
+    if not items:
+        return {"protocol": "ckan", "error": "; ".join(errors) or "no items retrieved"}
+
+    # Estrai campi flat + extras normalizzati
+    flat_items: list[dict] = []
+    for item in items:
+        flat: dict[str, Any] = {
+            "id": item.get("id"),
+            "name": item.get("name"),
+            "title": item.get("title"),
+            "notes": item.get("notes"),
+            "author": item.get("author"),
+            "maintainer": item.get("maintainer"),
+            "metadata_created": item.get("metadata_created"),
+            "metadata_modified": item.get("metadata_modified"),
+            "organization": (item.get("organization") or {}).get("title"),
+            "tags": [t.get("name") for t in (item.get("tags") or [])],
+            "num_resources": item.get("num_resources"),
+            "license_id": item.get("license_id"),
+            "isopen": item.get("isopen"),
+            "resource_formats": list({
+                r.get("format") for r in (item.get("resources") or []) if r.get("format")
+            }),
+        }
+        # extras → chiavi individuali per visibilità
+        for extra in item.get("extras") or []:
+            key = extra.get("key") or ""
+            flat[f"extra:{key}"] = extra.get("value")
+        flat_items.append(flat)
+
+    field_report = _field_report(flat_items)
+
+    # Evidenzia campi temporali e di formato
+    temporal_keys = [k for k in field_report if any(
+        tok in k.lower() for tok in ("temporal", "date", "year", "start", "end", "period", "modified", "created")
+    )]
+    format_keys = [k for k in field_report if any(
+        tok in k.lower() for tok in ("format", "resource", "distribution")
+    )]
+
+    return {
+        "protocol": "ckan",
+        "sample_size": len(flat_items),
+        "errors": errors or None,
+        "temporal_fields": {k: field_report[k] for k in temporal_keys},
+        "format_fields": {k: field_report[k] for k in format_keys},
+        "all_fields": field_report,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SDMX scout
+# ---------------------------------------------------------------------------
+
+_SDMX_NS = {
+    "mes": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message",
+    "str": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure",
+    "com": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common",
+}
+
+
+def scout_sdmx(source_id: str, source_cfg: dict[str, Any]) -> dict[str, Any]:
+    base_url = source_cfg.get("base_url")
+    if not base_url:
+        return {"protocol": "sdmx", "error": "base_url mancante nella configurazione"}
+    root_url = _sdmx_api_base(base_url)
+    errors: list[str] = []
+
+    try:
+        r = observatory_get(f"{root_url}/dataflow", timeout=30)
+        r.raise_for_status()
+        xml_root = ET.fromstring(r.content)
+    except Exception as exc:
+        return {"protocol": "sdmx", "error": str(exc)}
+
+    flows = xml_root.findall(".//str:Dataflow", _SDMX_NS)
+    sample = flows[:SDMX_SAMPLE_SIZE]
+
+    if not sample:
+        return {"protocol": "sdmx", "error": "no dataflows found in response"}
+
+    annotation_keys: dict[str, list[Any]] = defaultdict(list)
+    has_name: list[bool] = []
+    has_description: list[bool] = []
+
+    for flow in sample:
+        name_el = flow.find(".//com:Name", _SDMX_NS)
+        has_name.append(bool(parse_sdmx_name(name_el)))
+
+        desc_el = flow.find(".//com:Description", _SDMX_NS)
+        has_description.append(desc_el is not None and bool((desc_el.text or "").strip()))
+
+        for ann in flow.findall(".//com:Annotation", _SDMX_NS):
+            ann_type = ann.find("com:AnnotationType", _SDMX_NS)
+            ann_text = ann.find("com:AnnotationText", _SDMX_NS)
+            if ann_type is not None and ann_text is not None:
+                key = (ann_type.text or "").strip()
+                val = (ann_text.text or "").strip()
+                if key:
+                    annotation_keys[key].append(val or None)
+
+    ann_report = {
+        k: _coverage(vals) for k, vals in sorted(annotation_keys.items())
+    }
+
+    temporal_ann = [k for k in ann_report if any(
+        tok in k.upper() for tok in ("TIME", "PERIOD", "YEAR", "DATE", "START", "END")
+    )]
+
+    return {
+        "protocol": "sdmx",
+        "total_dataflows": len(flows),
+        "sample_size": len(sample),
+        "errors": errors or None,
+        "core_fields": {
+            "Name": _coverage(has_name),
+            "Description": _coverage(has_description),
+        },
+        "temporal_annotations": {k: ann_report[k] for k in temporal_ann},
+        "all_annotations": ann_report,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SPARQL scout
+# ---------------------------------------------------------------------------
+
+def scout_sparql(source_id: str, source_cfg: dict[str, Any]) -> dict[str, Any]:
+    sparql_cfg = source_cfg.get("sparql") or {}
+    endpoint = sparql_cfg.get("endpoint_url") or source_cfg.get("base_url")
+    query = SPARQL_QUERY_TEMPLATES["dcat_datasets"].replace("{limit}", str(SPARQL_SAMPLE_SIZE))
+    errors: list[str] = []
+
+    try:
+        r = observatory_get(
+            endpoint,
+            params={"query": query, "format": "application/sparql-results+json"},
+            timeout=30,
+            headers={"Accept": "application/sparql-results+json"},
+        )
+        r.raise_for_status()
+        data = r.json()
+    except Exception as exc:
+        return {"protocol": "sparql", "error": str(exc)}
+
+    bindings = data.get("results", {}).get("bindings") or []
+    if not bindings:
+        return {"protocol": "sparql", "error": "query returned no bindings", "errors": errors}
+
+    by_dataset: dict[str, dict] = {}
+    for row in bindings:
+        ds_uri = sparql_binding_value(row, "dataset")
+        if not ds_uri:
+            continue
+        if ds_uri not in by_dataset:
+            by_dataset[ds_uri] = {
+                "title": None, "description": None, "modified": None,
+                "issued": None, "publisher": None, "theme": None, "formats": [],
+            }
+        rec = by_dataset[ds_uri]
+        for field in ("title", "description", "modified", "issued", "publisher", "theme"):
+            if rec[field] is None:
+                rec[field] = sparql_binding_value(row, field)
+        fmt = sparql_binding_value(row, "format")
+        if fmt and fmt not in rec["formats"]:
+            rec["formats"].append(fmt)
+
+    items = list(by_dataset.values())
+    field_report = _field_report([
+        {k: (v if k != "formats" else (v or None)) for k, v in item.items()}
+        for item in items
+    ])
+
+    temporal_keys = [k for k in field_report if any(
+        tok in k.lower() for tok in ("modified", "issued", "date", "temporal")
+    )]
+
+    return {
+        "protocol": "sparql",
+        "sample_size": len(items),
+        "errors": errors or None,
+        "temporal_fields": {k: field_report[k] for k in temporal_keys},
+        "all_fields": field_report,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dispatch + main
+# ---------------------------------------------------------------------------
+
+def scout_source(source_id: str, source_cfg: dict[str, Any]) -> dict[str, Any]:
+    protocol = source_cfg.get("protocol", "")
+    if protocol == "ckan":
+        return scout_ckan(source_id, source_cfg)
+    if protocol == "sdmx":
+        return scout_sdmx(source_id, source_cfg)
+    if protocol == "sparql":
+        return scout_sparql(source_id, source_cfg)
+    return {"protocol": protocol, "skipped": True, "reason": f"protocollo '{protocol}' non automatizzabile"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Portal scout — sonda strutturale leggera per fonte nel registry.")
+    parser.add_argument("--source-ids", nargs="+", metavar="SOURCE_ID", help="Filtra per source_id (default: tutte).")
+    parser.add_argument("--dry-run", action="store_true", help="Stampa su stdout invece di scrivere file.")
+    parser.add_argument("--out-dir", type=Path, default=OUT_DIR, help="Directory output (default: data/portal_scout/).")
+    parser.add_argument("--registry-path", type=Path, default=REGISTRY_PATH, help="Path YAML registry alternativo (es. candidati discovery).")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    with args.registry_path.open(encoding="utf-8") as fh:
+        registry: dict[str, dict] = yaml.safe_load(fh) or {}
+
+    filter_ids = set(args.source_ids) if args.source_ids else None
+    scouted_at = now_utc_iso()
+    results: dict[str, Any] = {}
+
+    for source_id, source_cfg in registry.items():
+        if filter_ids and source_id not in filter_ids:
+            continue
+        protocol = source_cfg.get("protocol", "")
+        if protocol not in SUPPORTED_PROTOCOLS:
+            results[source_id] = {"protocol": protocol, "skipped": True, "reason": f"protocollo '{protocol}' non automatizzabile"}
+            print(f"  skip  {source_id} ({protocol})")
+            continue
+
+        print(f"  scout {source_id} ({protocol}) ...", end=" ", flush=True)
+        try:
+            result = scout_source(source_id, source_cfg)
+        except Exception as exc:
+            result = {"protocol": protocol, "error": str(exc)}
+        results[source_id] = result
+        status = "error" if "error" in result else "ok"
+        print(status)
+
+    output = {"scouted_at": scouted_at, "sources": results}
+
+    if args.dry_run:
+        print(json.dumps(output, indent=2, ensure_ascii=False))
+        return 0
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    for source_id, result in results.items():
+        out_path = args.out_dir / f"{source_id}_scout.json"
+        out_path.write_text(json.dumps({"scouted_at": scouted_at, "source_id": source_id, **result}, indent=2, ensure_ascii=False))
+
+    print(f"\nScritti {len(results)} report in {args.out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -45,24 +45,24 @@ Se la domanda è:
 
 Sequenza canonica minima per un nuovo portale:
 
-1. `portal-scout`
-2. decision gate
-3. eventuale ingresso nel registry
-4. eventuale baseline o inventory
-5. eventuale `source-check` su item specifici
+1. `discover_portals.py` (opzionale, per discovery batch) → parquet candidati
+2. `portal-scout` → verdict + soglie minime
+3. decision gate
+4. eventuale ingresso nel registry
+5. eventuale baseline o inventory
+6. eventuale `source-check` su item specifici
 
-Esiti canonici del gate:
+Esiti canonici del gate e soglie minime:
 
-- `GO catalog-watch`
-- `GO radar-only`
-- `GO source-check item-based`
-- `NO per ora`
+| Esito | Condizioni minime |
+|---|---|
+| `GO catalog-watch` | Probe reale · enumerabile · temporale ≥ 80% · ≥ 20 dataset strutturati · non duplicato |
+| `GO radar-only` | Raggiungibile · PA nazionale · non automatizzabile ora |
+| `GO source-check item-based` | Strutturato ma < 20 dataset o > 50% PDF |
+| `NO per ora` | Falso positivo · WAF · fuori scope · duplicato |
 
-Regola di orientamento:
-
-- se il metodo di enumerazione degli item è stabile e riproducibile -> `catalog-watch`
-- se il portale è utile ma non inventariabile in modo affidabile -> `radar-only`
-- se il valore sta in pochi item noti e non nel portale come catalogo -> `source-check item-based`
+`GO catalog-watch` → proponi YAML per registry + apri issue SO (`portal-scout`).
+`GO radar-only` → aggiorna registry direttamente, nessuna issue.
 
 ## Nota: catalog inventory
 

--- a/workflows/portal-scout.md
+++ b/workflows/portal-scout.md
@@ -1,52 +1,71 @@
 ---
 name: portal-scout
-description: Workflow light per classificare portali e superfici web nel funnel del Lab.
+description: Workflow per classificare un portale PA (o un tema di portali) e decidere se merita il registry SO.
 license: MIT
 metadata:
-  version: "0.2"
+  version: "0.4"
   owner: "DataCivicLab"
 ---
 
 # Workflow: portal-scout
 
-**Stato: Operativo (Compact Mode)**
-Identifica il tipo di superficie tecnica di un portale e il metodo di osservazione ideale.
+**Stato: Operativo**
+Classifica la superficie tecnica di un portale PA nazionale e decide se e come aggiungerlo al registry SO.
 
 ## 1. Obiettivo e Boundary
 
-- **SÌ**: Capire se è un catalogo strutturato o un listing statico.
-- **SÌ**: Individuare la superficie tecnica reale (API, sitemap, listing) per l'osservazione.
-- **SÌ**: Valutare l'inventariabilità per futuro `catalog-watch`.
-- **NO**: Verificare singoli dataset (usare `source-check`).
-- **NO**: Costruire inventory completi o monitoraggio continuo.
+- **SÌ**: Classificare protocollo reale, sondare copertura metadata, decidere `observation_mode`.
+- **NO**: Verificare singoli dataset (→ `source-check`). NO inventory completi o monitoraggio.
 
 ## 2. Quando usarlo
 
-- [ ] Portale nuovo entra nel radar.
-- [ ] Landing page dati non chiara (non è palesemente CKAN/SDMX).
-- [ ] Serve classificazione prima di aggiornare `sources_registry.yaml`.
-- **STOP**: Se devi seguire una risorsa specifica Tier 1.
-- **STOP**: Se il portale è già in `catalog-watch`.
+- [ ] Portale nuovo nel radar (segnalazione, discovery, suggerimento).
+- [ ] Tema da sondare in batch (es. "portali MEF", "portali cultura.gov.it").
+- **STOP**: Già nel registry con `observation_mode` definitivo.
+- **STOP**: Serve verifica dataset specifici → `source-check`.
 
-## 3. Workflow Minimo (Checklist)
+## 3. Passi Canonici
 
-1. **Inquadramento**: Annota URL base, publisher e superfici secondarie.
-2. **Classificazione Tipo**: `ckan`, `sdmx`, `html/sitemap`, `sparql`, `custom`.
-3. **Punto di Osservazione**: Distingui tra branding (UI) e superficie tecnica (API, endpoint API, sitemap).
-4. **Inventariabilità**:
-   - [ ] Gli item sono enumerabili?
-   - [ ] Il metodo è riproducibile e il conteggio difendibile?
-   - [ ] La superficie è stabile per una baseline?
-5. **Deduplica**: Verifica presenza leggera in `sources_registry.yaml`.
-6. **Verdetto**: Esprimi un esito unico.
+1. **Scope**: singolo URL o tema. Per temi: `discover_portals.py --no-probe`, poi filtra manualmente.
+2. **Protocol detection**: probe via script o curl diretto (`/api/3/action/package_list`, `/SDMXWS/rest/dataflow`).
+3. **Scout strutturale** (solo CKAN/SDMX/SPARQL): `portal_scout.py --registry-path /tmp/candidate.yaml --dry-run`. Leggi copertura temporale e formati.
+4. **Classificazione**: protocollo confermato? enumerabile? temporale popolato? duplicato?
+5. **Verdict** (vedi soglie §4) + output §5.
 
-## 4. Verdetti Ammessi
+## 4. Soglie Minime
 
-- `portale pronto per catalog-watch`: Superficie stabile e inventariabile.
-- `portale da tenere radar-only`: Osservabile ma non enumerabile in modo affidabile.
-- `portale utile solo per source-check`: Utile solo per verifiche item-based.
-- `superficie non abbastanza chiara`: Da rivalutare o scartare.
+| Verdict | Condizioni (tutte per catalog-watch, ≥ 2 per radar-only) |
+|---|---|
+| `catalog-watch` | Probe reale confermato · enumerabile senza WAF/login · temporale ≥ 80% (valutazione umana su campione scout) · ≥ 20 dataset strutturati (CSV/JSON/XML) · non duplicato |
+| `radar-only` | Raggiungibile · PA nazionale rilevante · non automatizzabile ora (HTML / WAF / < 20 dataset / prevalenza PDF) |
+| `source-check-only` | Strutturato ma < 20 dataset o > 50% PDF |
+| `scarta` | Falso positivo probe · WAF strutturale · fuori scope · duplicato esatto |
+
+**Azioni post-verdict**:
+- `catalog-watch` → proponi YAML per registry + apri issue SO (`portal-scout`).
+- `radar-only` → aggiorna registry direttamente, nessuna issue.
+- `source-check-only` / `scarta` → nessuna azione.
+
+## 5. Output
+
+```
+**Portale**: [domain]
+**Protocollo**: [ckan / sdmx / sparql / html]
+**Dataset totali**: [N]
+**Copertura metadata**: [temporale ≥ 80%? formati prevalenti?]
+**Verdict**: [catalog-watch / radar-only / source-check-only / scarta]
+**Motivo**: [soglia determinante]
+**Next step**: [apri issue / aggiorna registry / nessuna azione]
+```
+
+## 6. Strumenti
+
+| Script | Flag utili |
+|---|---|
+| `discover_portals.py` | `--protocols sdmx` · `--only-matched` · `--no-probe` |
+| `portal_scout.py` | `--registry-path /tmp/x.yaml` · `--dry-run` |
+
+Output: `data/portal_scout/discovered_portals.parquet`, `data/portal_scout/scout_results/`.
 
 ---
-**Next Step**: Proponi aggiornamento di `sources_registry.yaml` o passa a `source-check` su item specifici.
-**Done**: Superficie classificata, metodo di osservazione fissato.
+**Done**: Ogni portale ha verdict + motivo. `catalog-watch` → YAML + issue. `radar-only` → registry aggiornato.


### PR DESCRIPTION
## Summary

- **`discover_portals.py`** — discovery DDG su `.gov.it` con protocol probe (CKAN/SDMX/SPARQL), output parquet + JSON summary per ACB, flag `--protocols` e `--only-matched`, fix SDMX false positive (agea.gov.it aggiunto a SKIP_DOMAINS)
- **`portal_scout.py`** — aggiunto `--registry-path` per candidati discovery; fix KeyError su `base_url` mancante in `scout_ckan`/`scout_sdmx`; rimosso `portal_scout_summary.json` ridondante
- **`collectors/ckan.py`** — fix `ckan_action_endpoint` quando `base_url` non ha path (fallback a `base_url/api/3/action/{action}`)
- **`.github/workflows/portal-scout.yml`** — Action manuale (`workflow_dispatch`) per discovery batch + scout strutturale + upload GCS; fix mapping SPARQL `endpoint_url` nel registry temporaneo; log warning su exit code non-zero
- **`workflows/portal-scout.md`** — v0.4 compact mode, soglia temporale chiarita come valutazione umana
- **`README.md`** — riscritto con funnel esplicito orientato a esterni
- **`workflows/README.md`** — sequenza onboarding aggiornata con soglie gate

## Test plan

- [x] Run locale `discover_portals.py --protocols ckan --only-matched --max-results 5` — produce parquet + summary JSON corretti
- [x] `--only-matched` senza `--protocols` filtra su tutti i protocolli strutturati (fix bug logico)
- [ ] Run Action `portal-scout` su GitHub Actions con `skip_discovery=false`
- [ ] Verifica upload GCS se secret configurati

🤖 Generated with [Claude Code](https://claude.com/claude-code)