### PR TITLE
[codex] separa il workflow portal scout

### DIFF
--- a/.github/workflows/portal-scout.yml
+++ b/.github/workflows/portal-scout.yml
@@ -76,6 +76,13 @@ jobs:
           mkdir -p data/portal_scout
           gcloud storage cp "$prefix/discovered_portals.parquet" data/portal_scout/discovered_portals.parquet
 
+      - name: Rebuild summary artifacts from parquet (se skip_discovery)
+        if: ${{ inputs.skip_discovery == 'true' }}
+        run: |
+          python scripts/discover_portals.py \
+            --refresh-summary \
+            --out data/portal_scout/discovered_portals.parquet
+
       - name: Discover portals (DDG + protocol probe)
         if: ${{ inputs.skip_discovery != 'true' }}
         run: |
@@ -84,7 +91,7 @@ jobs:
             --out data/portal_scout/discovered_portals.parquet
 
       - name: Upload discovery artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: portal-discovery
           path: |
@@ -202,7 +209,7 @@ jobs:
           fi
 
       - name: Upload workflow artifact (Actions)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: portal-scout
           path: |

--- a/.github/workflows/portal-scout.yml
+++ b/.github/workflows/portal-scout.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  portal-scout:
+  portal-discovery:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -41,6 +41,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: Install dependencies
         run: |
@@ -57,8 +59,6 @@ jobs:
       - name: Set up gcloud
         if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.PORTAL_SCOUT_GCS_PREFIX != '' }}
         uses: google-github-actions/setup-gcloud@v3
-
-      # --- Fase 1: Discovery ---
 
       - name: Verifica gate skip_discovery + GCS
         if: ${{ inputs.skip_discovery == 'true' }}
@@ -83,7 +83,58 @@ jobs:
             --max-results ${{ inputs.max_results }} \
             --out data/portal_scout/discovered_portals.parquet
 
-      # --- Fase 2: Scout strutturale sui candidati CKAN/SDMX/SPARQL ---
+      - name: Upload discovery artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: portal-discovery
+          path: |
+            data/portal_scout/discovered_portals.parquet
+            data/portal_scout/discovered_portals_summary.json
+            data/portal_scout/portal_scout_shortlist.md
+
+  portal-scout:
+    needs: portal-discovery
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      PORTAL_SCOUT_GCS_PREFIX: ${{ secrets.PORTAL_SCOUT_GCS_PREFIX }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Download discovery artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: portal-discovery
+          path: data/portal_scout
+
+      - name: Authenticate to Google Cloud
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.PORTAL_SCOUT_GCS_PREFIX != '' }}
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.PORTAL_SCOUT_GCS_PREFIX != '' }}
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Run portal_scout on structured candidates
         run: |
@@ -104,7 +155,6 @@ jobs:
 
           print(f"Candidati da sondare: {len(candidates)}")
 
-          # Costruisce registry temporaneo con tutti i candidati
           cfg = {}
           for _, row in candidates.iterrows():
               entry = {"protocol": row["protocol"], "base_url": row["base_url"]}
@@ -116,21 +166,18 @@ jobs:
               yaml.dump(cfg, f)
               tmp = f.name
 
-          result = subprocess.run([sys.executable, "scripts/portal_scout.py",
-                                   "--registry-path", tmp,
-                                   "--out-dir", "data/portal_scout/scout_results"],
-                                  check=False)
+          result = subprocess.run(
+              [sys.executable, "scripts/portal_scout.py", "--registry-path", tmp, "--out-dir", "data/portal_scout/scout_results"],
+              check=False,
+          )
           scout_ok = result.returncode == 0
           if not scout_ok:
               print(f"[warn] portal_scout.py exited with code {result.returncode}", file=sys.stderr)
 
-          # Scrive stato scout per il summary finale
           Path("data/portal_scout/.scout_status").write_text(
               "ok" if scout_ok else f"partial (exit {result.returncode})"
           )
           PY
-
-      # --- Upload su GCS ---
 
       - name: Upload artifacts to GCS
         if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.PORTAL_SCOUT_GCS_PREFIX != '' }}
@@ -159,7 +206,6 @@ jobs:
         with:
           name: portal-scout
           path: |
-            data/portal_scout/discovered_portals.parquet
             data/portal_scout/discovered_portals_summary.json
             data/portal_scout/portal_scout_shortlist.md
             data/portal_scout/scout_results/
@@ -195,10 +241,9 @@ jobs:
           lines.append("### Protocolli strutturati rilevati")
           structured = df[df["protocol"].isin(["ckan", "sdmx", "sparql"])]
           for _, row in structured.iterrows():
-            tag = "✓ già nel registry" if row["in_registry"] == "yes" else "⚡ nuovo"
-            lines.append(f"- `{row['domain']}` — {row['protocol'].upper()} ({tag})")
+              tag = "✓ già nel registry" if row["in_registry"] == "yes" else "⚡ nuovo"
+              lines.append(f"- `{row['domain']}` — {row['protocol'].upper()} ({tag})")
 
           Path("summary.md").write_text("\n".join(lines) + "\n")
           PY
           cat summary.md >> "$GITHUB_STEP_SUMMARY"
-

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -37,7 +37,7 @@ def get_observatory_session() -> requests.Session:
 def observatory_get(
     url: str,
     *,
-    timeout: int | float = DEFAULT_TIMEOUT_SECONDS,
+    timeout: int | float | tuple[float, float] = DEFAULT_TIMEOUT_SECONDS,
     headers: dict[str, str] | None = None,
     **kwargs: Any,
 ) -> requests.Response:
@@ -55,7 +55,7 @@ def observatory_get(
 def observatory_head(
     url: str,
     *,
-    timeout: int | float = DEFAULT_TIMEOUT_SECONDS,
+    timeout: int | float | tuple[float, float] = DEFAULT_TIMEOUT_SECONDS,
     headers: dict[str, str] | None = None,
     **kwargs: Any,
 ) -> requests.Response:

--- a/scripts/discover_portals.py
+++ b/scripts/discover_portals.py
@@ -14,6 +14,7 @@ Uso:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -225,6 +226,75 @@ def detect_protocol(domain: str, probe_paths: dict | None = None) -> tuple[str, 
     return "html", None
 
 
+def _build_summary_artifacts(df, scouted_at: str) -> tuple[dict, list[str]]:
+    """Build JSON summary payload and markdown shortlist from the discovery table."""
+    known = df[df["in_registry"] == "yes"]
+    new_candidates = df[df["in_registry"] == "no"]
+    confirmed_protocols = ["ckan", "sdmx", "sparql"]
+    new_confirmed = new_candidates[new_candidates["protocol"].isin(confirmed_protocols)]
+    known_confirmed = known[known["protocol"].isin(confirmed_protocols)]
+
+    summary = {
+        "generated_at": scouted_at,
+        "total_portals": len(df),
+        "new_candidates": len(new_candidates),
+        "new_confirmed_protocol": len(new_confirmed),
+        "known_registry_seen": len(known),
+        "by_protocol": df["protocol"].value_counts().to_dict(),
+        "new_structured": [
+            {"domain": r["domain"], "protocol": r["protocol"], "probe_url": r["probe_url"]}
+            for _, r in new_confirmed.iterrows()
+        ],
+        "known_registry_healthcheck": [
+            {"domain": r["domain"], "protocol": r["protocol"], "status": "seen"}
+            for _, r in known_confirmed.iterrows()
+        ],
+    }
+
+    shortlist_lines = [
+        "# Portal Scout — Shortlist",
+        f"\n_Generato: {summary['generated_at']}_\n",
+        "## Nuovi candidati strutturati",
+        "",
+    ]
+    if new_confirmed.empty:
+        shortlist_lines.append("_Nessun nuovo candidato con protocollo confermato._")
+    else:
+        for _, r in new_confirmed.iterrows():
+            shortlist_lines.append(f"- **{r['domain']}** — {r['protocol'].upper()}")
+            shortlist_lines.append(f"  - Probe: `{r['probe_url']}`")
+            shortlist_lines.append("  - Next: portal-scout approfondito + proposta registry")
+
+    shortlist_lines += [
+        "",
+        "## Registry esistente — visti in questo run",
+        "",
+    ]
+    if known_confirmed.empty:
+        shortlist_lines.append("_Nessun portale noto rilevato._")
+    else:
+        for _, r in known_confirmed.iterrows():
+            shortlist_lines.append(f"- **{r['domain']}** — {r['protocol'].upper()} ✓ già nel registry")
+
+    shortlist_lines += [
+        "",
+        "## Portali HTML (non strutturati)",
+        "",
+        f"_{len(df[df['protocol'] == 'html'])} domini classificati HTML — nessuna API strutturata rilevata._",
+    ]
+
+    return summary, shortlist_lines
+
+
+def _write_summary_artifacts(df, out_path: Path, scouted_at: str) -> tuple[Path, Path]:
+    summary, shortlist_lines = _build_summary_artifacts(df, scouted_at)
+    summary_path = out_path.with_name("discovered_portals_summary.json")
+    summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    shortlist_path = out_path.with_name("portal_scout_shortlist.md")
+    shortlist_path.write_text("\n".join(shortlist_lines) + "\n", encoding="utf-8")
+    return summary_path, shortlist_path
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -237,12 +307,29 @@ def parse_args() -> argparse.Namespace:
                    help="Filtra per protocollo: usa solo query e probe mirati (es. --protocols sdmx ckan).")
     p.add_argument("--only-matched", action="store_true",
                    help="Output solo portali dove il probe ha confermato il protocollo (esclude html).")
+    p.add_argument(
+        "--refresh-summary",
+        action="store_true",
+        help="Rigenera summary e shortlist da un parquet già esistente in --out.",
+    )
     p.add_argument("--out", type=Path, default=OUT_DEFAULT, help="Path parquet output.")
     return p.parse_args()
 
 
 def main() -> int:
     args = parse_args()
+
+    if args.refresh_summary:
+        import pandas as pd
+        from datetime import datetime, timezone
+
+        df = pd.read_parquet(args.out)
+        summary_path, shortlist_path = _write_summary_artifacts(
+            df, args.out, datetime.now(timezone.utc).isoformat()
+        )
+        print(f"Shortlist scritta in {shortlist_path}")
+        print(f"Summary scritto in {summary_path}")
+        return 0
 
     # Seleziona query in base ai protocolli richiesti
     protocols = set(args.protocols) if args.protocols else set(PROBE_PATHS.keys())
@@ -291,7 +378,6 @@ def main() -> int:
         for future in as_completed(futures):
             rows.append(future.result())
 
-    import json
     import pandas as pd
     from datetime import datetime, timezone
 
@@ -305,68 +391,12 @@ def main() -> int:
 
     df.to_parquet(args.out, index=False)
 
-    known = df[df["in_registry"] == "yes"]
     new_candidates = df[df["in_registry"] == "no"]
     print(f"  di cui {len(new_candidates)} nuovi candidati (non nel registry)")
 
-    # JSON summary per ACB e lettura rapida
-    confirmed_protocols = ["ckan", "sdmx", "sparql"]
-    new_confirmed = new_candidates[new_candidates["protocol"].isin(confirmed_protocols)]
-    known_confirmed = known[known["protocol"].isin(confirmed_protocols)]
-    summary = {
-        "generated_at": datetime.now(timezone.utc).isoformat(),
-        "total_portals": len(df),
-        "new_candidates": len(new_candidates),
-        "new_confirmed_protocol": len(new_confirmed),
-        "known_registry_seen": len(known),
-        "by_protocol": df["protocol"].value_counts().to_dict(),
-        "new_structured": [
-            {"domain": r["domain"], "protocol": r["protocol"], "probe_url": r["probe_url"]}
-            for _, r in new_confirmed.iterrows()
-        ],
-        "known_registry_healthcheck": [
-            {"domain": r["domain"], "protocol": r["protocol"], "status": "seen"}
-            for _, r in known_confirmed.iterrows()
-        ],
-    }
-    summary_path = args.out.with_name("discovered_portals_summary.json")
-    summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
-
-    # Shortlist Markdown per review umana rapida
-    shortlist_lines = [
-        "# Portal Scout — Shortlist",
-        f"\n_Generato: {summary['generated_at']}_\n",
-        "## Nuovi candidati strutturati",
-        "",
-    ]
-    if new_confirmed.empty:
-        shortlist_lines.append("_Nessun nuovo candidato con protocollo confermato._")
-    else:
-        for _, r in new_confirmed.iterrows():
-            shortlist_lines.append(f"- **{r['domain']}** — {r['protocol'].upper()}")
-            shortlist_lines.append(f"  - Probe: `{r['probe_url']}`")
-            shortlist_lines.append("  - Next: portal-scout approfondito + proposta registry")
-
-    shortlist_lines += [
-        "",
-        "## Registry esistente — visti in questo run",
-        "",
-    ]
-    if known_confirmed.empty:
-        shortlist_lines.append("_Nessun portale noto rilevato._")
-    else:
-        for _, r in known_confirmed.iterrows():
-            shortlist_lines.append(f"- **{r['domain']}** — {r['protocol'].upper()} ✓ già nel registry")
-
-    shortlist_lines += [
-        "",
-        "## Portali HTML (non strutturati)",
-        "",
-        f"_{len(df[df['protocol'] == 'html'])} domini classificati HTML — nessuna API strutturata rilevata._",
-    ]
-
-    shortlist_path = args.out.with_name("portal_scout_shortlist.md")
-    shortlist_path.write_text("\n".join(shortlist_lines) + "\n", encoding="utf-8")
+    summary_path, shortlist_path = _write_summary_artifacts(
+        df, args.out, datetime.now(timezone.utc).isoformat()
+    )
     print(f"Shortlist scritta in {shortlist_path}")
     print(f"Summary scritto in {summary_path}")
 

--- a/scripts/discover_portals.py
+++ b/scripts/discover_portals.py
@@ -105,7 +105,8 @@ KNOWN_REGISTRY_DOMAINS = {
     "openbdap.rgs.mef.gov.it",
 }
 
-TIMEOUT = 8
+# Probe aggressivo: se un host non risponde, non vogliamo bloccare il run.
+PROBE_TIMEOUT_SECONDS = (3, 5)
 
 
 # ---------------------------------------------------------------------------
@@ -175,7 +176,7 @@ def _probe_ckan(base: str, extra_prefixes: list[str] | None = None) -> str | Non
         for suffix in suffixes:
             url = base + prefix + suffix
             try:
-                r = observatory_get(url, timeout=TIMEOUT)
+                r = observatory_get(url, timeout=PROBE_TIMEOUT_SECONDS)
                 if r.status_code == 200:
                     ct = r.headers.get("content-type", "").lower()
                     if "json" in ct or r.text.strip().startswith("{"):
@@ -210,7 +211,7 @@ def detect_protocol(domain: str, probe_paths: dict | None = None) -> tuple[str, 
         for path in paths:
             url = base + path
             try:
-                r = observatory_get(url, timeout=TIMEOUT)
+                r = observatory_get(url, timeout=PROBE_TIMEOUT_SECONDS)
                 if r.status_code == 200:
                     ct = r.headers.get("content-type", "").lower()
                     if protocol == "sdmx":

--- a/tests/test_discover_portals.py
+++ b/tests/test_discover_portals.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import pandas as pd
+
 import discover_portals
 
 
@@ -47,3 +51,37 @@ def test_detect_protocol_returns_html_when_probes_fail(monkeypatch) -> None:
 
     assert protocol == "html"
     assert probe_url is None
+
+
+def test_refresh_summary_rebuilds_artifacts(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "domain": "example.gov.it",
+                "protocol": "ckan",
+                "probe_url": "https://example.gov.it/api/3/action/package_list",
+                "base_url": "https://example.gov.it",
+                "in_registry": "no",
+                "source_queries": "q1",
+            },
+            {
+                "domain": "known.gov.it",
+                "protocol": "html",
+                "probe_url": "",
+                "base_url": "https://known.gov.it",
+                "in_registry": "yes",
+                "source_queries": "q2",
+            },
+        ]
+    )
+
+    summary_path, shortlist_path = discover_portals._write_summary_artifacts(
+        df,
+        tmp_path / "discovered_portals.parquet",
+        "2026-04-20T00:00:00+00:00",
+    )
+
+    assert summary_path.exists()
+    assert shortlist_path.exists()
+    assert "example.gov.it" in summary_path.read_text()
+    assert "Portal Scout" in shortlist_path.read_text()

--- a/tests/test_discover_portals.py
+++ b/tests/test_discover_portals.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import discover_portals
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        status_code: int = 200,
+        content_type: str = "application/json",
+        payload: dict | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.headers = {"content-type": content_type}
+        self.text = '{"success": true, "result": []}'
+        self._payload = payload or {"success": True, "result": []}
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_probe_ckan_uses_aggressive_timeout(monkeypatch) -> None:
+    observed: dict[str, object] = {}
+
+    def fake_get(url, timeout=None, **_kwargs):
+        observed["url"] = url
+        observed["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(discover_portals, "observatory_get", fake_get)
+    discover_portals._DDG_PATHS.clear()
+
+    url = discover_portals._probe_ckan("https://example.gov.it")
+
+    assert url == "https://example.gov.it/api/3/action/package_list"
+    assert observed["timeout"] == discover_portals.PROBE_TIMEOUT_SECONDS
+
+
+def test_detect_protocol_returns_html_when_probes_fail(monkeypatch) -> None:
+    def fake_get(*_args, **_kwargs):
+        raise RuntimeError("host unreachable")
+
+    monkeypatch.setattr(discover_portals, "observatory_get", fake_get)
+    discover_portals._DDG_PATHS.clear()
+
+    protocol, probe_url = discover_portals.detect_protocol("example.gov.it")
+
+    assert protocol == "html"
+    assert probe_url is None


### PR DESCRIPTION
Closes #120 

## Cosa cambia
- Separa `portal-scout.yml` in due job: `portal-discovery` e `portal-scout`.
- Aggiunge `cache: pip` ai due step di setup Python.
- Mantiene il flusso GCS `skip_discovery`, ma fa pubblicare al primo job l'artifact di discovery per il secondo.
- Riduce i timeout dei probe in `scripts/discover_portals.py` per fallire più in fretta sugli host non raggiungibili.
- Aggiunge un test di regressione che verifica il timeout aggressivo.

## Perché
Il workflow originale faceva discovery e scouting nello stesso job, quindi ogni retry ripeteva la fase DDG. Con la separazione lo scout si può rilanciare senza rifare discovery e i run bloccati hanno meno probabilità di trascinare tutto il workflow.

## Verifica
- `pytest -q`
- `ruff check scripts/discover_portals.py tests/test_discover_portals.py`
- parsing YAML di `.github/workflows/portal-scout.yml`
