### PR TITLE
chore: harden source-observatory workflows

### DIFF
--- a/.github/workflows/catalog-inventory.yml
+++ b/.github/workflows/catalog-inventory.yml
@@ -39,6 +39,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Initialize previous report baseline
+        run: |
+          echo "{}" > previous_report.json
+
       - name: Build catalog inventory
         run: |
           python scripts/build_catalog_inventory.py --out-dir data/catalog_inventory/generated --workers=4

--- a/.github/workflows/portal-scout.yml
+++ b/.github/workflows/portal-scout.yml
@@ -158,6 +158,7 @@ jobs:
 
           if candidates.empty:
               print("Nessun candidato strutturato da sondare.")
+              Path("data/portal_scout/.scout_status").write_text("skipped")
               sys.exit(0)
 
           print(f"Candidati da sondare: {len(candidates)}")
@@ -177,14 +178,28 @@ jobs:
               [sys.executable, "scripts/portal_scout.py", "--registry-path", tmp, "--out-dir", "data/portal_scout/scout_results"],
               check=False,
           )
-          scout_ok = result.returncode == 0
-          if not scout_ok:
+          if result.returncode == 0:
+              scout_status = "ok"
+          elif Path("data/portal_scout/scout_results").exists() and any(
+              Path("data/portal_scout/scout_results").glob("*.json")
+          ):
+              scout_status = f"degraded (exit {result.returncode})"
+          else:
+              scout_status = f"failed (exit {result.returncode})"
+
+          if scout_status != "ok":
               print(f"[warn] portal_scout.py exited with code {result.returncode}", file=sys.stderr)
 
-          Path("data/portal_scout/.scout_status").write_text(
-              "ok" if scout_ok else f"partial (exit {result.returncode})"
-          )
+          Path("data/portal_scout/.scout_status").write_text(scout_status)
           PY
+
+      - name: Fail if portal scout produced no usable output
+        run: |
+          status=$(cat data/portal_scout/.scout_status)
+          if [[ "$status" == failed* ]]; then
+            echo "::error::portal_scout non ha prodotto output utilizzabile ($status)."
+            exit 1
+          fi
 
       - name: Upload artifacts to GCS
         if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.PORTAL_SCOUT_GCS_PREFIX != '' }}
@@ -235,15 +250,23 @@ jobs:
           df = pd.read_parquet("data/portal_scout/discovered_portals.parquet")
 
           scout_status_file = Path("data/portal_scout/.scout_status")
-          scout_status = scout_status_file.read_text().strip() if scout_status_file.exists() else "skipped (nessun candidato strutturato)"
+          scout_status = scout_status_file.read_text().strip() if scout_status_file.exists() else "skipped"
 
           lines = ["## Portal Scout", ""]
           lines.append(f"- Domini totali rilevati: **{len(df)}**")
           lines.append(f"- Nuovi candidati (non nel registry): **{len(df[df['in_registry'] == 'no'])}**")
           lines.append(f"- Scout strutturale: **{scout_status}**")
-          if scout_status.startswith("partial"):
+          if scout_status.startswith("degraded"):
               lines.append("")
-              lines.append("> ⚠️ Lo scout strutturale ha avuto errori — `scout_results` potrebbero essere incompleti o assenti.")
+              lines.append("> [!WARNING]")
+              lines.append("> Lo scout strutturale ha avuto errori parziali; `scout_results` possono essere incompleti.")
+          elif scout_status.startswith("failed"):
+              lines.append("")
+              lines.append("> [!CAUTION]")
+              lines.append("> Lo scout strutturale non ha prodotto output utilizzabile.")
+          elif scout_status == "skipped":
+              lines.append("")
+              lines.append("_Nessun candidato strutturato da sondare in questo run._")
           lines.append("")
           lines.append("### Protocolli strutturati rilevati")
           structured = df[df["protocol"].isin(["ckan", "sdmx", "sparql"])]

--- a/.github/workflows/source-check.yml
+++ b/.github/workflows/source-check.yml
@@ -65,14 +65,6 @@ jobs:
             --out-dir data/catalog_inventory/generated \
             --workers 4
 
-      - name: Download previous source-check results from GCS
-        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
-        run: |
-          prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
-          prefix="${prefix%/}"
-          gcloud storage cp "$prefix/source-check/source_check_results.parquet" \
-            data/catalog_inventory/generated/source_check_results.parquet || true
-
       - name: Run bulk source-check
         run: |
           python scripts/bulk_source_check.py \

--- a/README.md
+++ b/README.md
@@ -46,17 +46,20 @@ python scripts/build_catalog_inventory.py --out-dir data/catalog_inventory/gener
 
 ## Workflow
 
-I workflow sono istruzioni per agenti — non pipeline CI/CD. Seguire in ordine per ogni portale nuovo.
+I workflow in `workflows/` sono istruzioni operative per agenti e review umana. In parallelo, alcuni workflow GitHub Actions schedulati producono artifact e report di osservazione.
 
 - [`workflows/portal-scout.md`](workflows/portal-scout.md) — classifica un portale e assegna verdict
 - [`workflows/source-check.md`](workflows/source-check.md) — valuta se una fonte regge come pista del Lab
 - [`workflows/catalog-inventory-scout.md`](workflows/catalog-inventory-scout.md) — triage degli item in un catalogo noto
 
 > I segnali di drift/inventory change sono prodotti automaticamente ogni lunedì dalla CI (`catalog-inventory.yml`) e leggibili in `data/catalog/CATALOG_WATCH_REPORT.md`.
+> Il workflow `portal-scout.yml` può chiudere lo scout strutturale come `ok`, `degraded` o `failed`, a seconda della qualità dell'output prodotto.
 
 ## Output e artefatti
 
 Gli artifact generati (`parquet`, `json`, `STATUS.md`) non sono versionati nel repo. Si ottengono da GitHub Actions o GCS se configurato.
+
+Se GCS non è configurato, i workflow restano eseguibili: usano artifact Actions e saltano i passaggi opzionali di storage remoto.
 
 - `data/radar/STATUS.md` — stato corrente delle fonti nel registry
 - `data/radar/radar_summary.json` — health complessivo (GREEN/YELLOW/RED per fonte)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -35,7 +35,7 @@ Manutenzione del Registry:
 Boundary:
 
 - Se il problema è di contenuto (non infrastrutturale) -> [source-check.md](../workflows/source-check.md)
-- Se il catalogo è cambiato ma la fonte è viva -> [catalog-watch.md](../workflows/catalog-watch.md)
+- Se il catalogo è cambiato ma la fonte è viva -> [catalog-inventory-scout.md](../workflows/catalog-inventory-scout.md)
 
 ## Catalog-watch
 
@@ -52,9 +52,9 @@ Usa `catalog-watch` quando la domanda è:
 
 Modello v0:
 
-- `catalog-watch` resta `human-run`
-- nessuno scheduler dedicato in questa fase
-- il run va usato quando serve un check metodologicamente difendibile, non come polling continuo
+- i segnali vengono prodotti automaticamente dal workflow schedulato `catalog-inventory.yml`
+- il follow-up resta `human-run`: il report non sostituisce la review umana sui cambi rilevanti
+- il run manuale va usato quando serve un check metodologicamente difendibile fuori schedule
 - gli output canonici restano `CATALOG_WATCH_REPORT.md` e `catalog_signals.json`
 - problemi di connessione/HTTP vanno letti in `radar_summary.json`, non in `catalog_signals.json`
 
@@ -84,7 +84,18 @@ Disciplina:
 - una fonte può restare osservata in SO ma non essere inventariabile
 - `anac` oggi resta escluso dall'inventory automatico per vincoli WAF
 - l'upload su GCS è opzionale e richiede secret espliciti
+- in assenza di GCS il workflow resta valido: usa baseline locale vuota e salta i passaggi opzionali di storage/diff
 - il workflow gira ogni lunedì (schedule) ed è disponibile anche via `workflow_dispatch`
+
+## Portal scout
+
+Il workflow `portal-scout.yml` ha tre esiti operativi per lo scout strutturale:
+
+- `ok` se `portal_scout.py` completa il run
+- `degraded` se lo script esce con errore ma produce comunque JSON utilizzabili in `scout_results/`
+- `failed` se lo script non produce output utilizzabile; in questo caso il job fallisce
+
+`skip_discovery=true` richiede GCS configurato, perché il parquet di discovery viene recuperato da storage invece di essere ricostruito via DDG.
 
 ## Ordine consigliato
 


### PR DESCRIPTION
## Cosa cambia

Questa PR indurisce i workflow principali di `source-observatory` e riallinea la documentazione operativa al comportamento reale del repo.

In particolare:
- `catalog-inventory.yml` inizializza sempre una baseline locale per `previous_report.json`, così il build dei segnali non dipende implicitamente da GCS
- `portal-scout.yml` distingue gli esiti `ok`, `degraded`, `failed` e fallisce solo quando lo scout non produce output utilizzabile
- `source-check.yml` rimuove il download del baseline precedente da GCS, che non veniva usato nel run successivo
- `README.md` e `docs/runbook.md` chiariscono scheduler reali, GCS opzionale e semantica degli esiti di `portal-scout`

## Perché

L'audit sui workflow aveva evidenziato tre punti deboli concreti:
- dipendenza fragile da file opzionali nei workflow
- successo parziale trattato come successo pieno in `portal-scout`
- documentazione non più allineata al comportamento effettivo dei workflow schedulati

Questa PR risolve quei problemi senza introdurre refactor più larghi sul layer HTTP o sulla logica dei collector.

## Impatto

- i workflow restano eseguibili anche senza GCS configurato
- il report di `portal-scout` comunica meglio la qualità reale dell'output prodotto
- la doc operativa riduce ambiguità per manutenzione e review

## Verifiche

- parsing YAML dei workflow con `yaml.safe_load`
- controllo diff finale dei file toccati
