### PR TITLE
fix(bulk_source_check): rimuovi encoding manuale in _http_head

### DIFF
--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -100,10 +100,6 @@ def _infer_years(text: str) -> tuple[Optional[int], Optional[int]]:
 def _http_head(url: str) -> tuple[Optional[int], bool, str]:
     if not isinstance(url, str) or not url.startswith("http"):
         return None, False, "url_missing_or_invalid"
-    # codifica spazi e caratteri non ASCII nell'URL preservando la struttura
-    from urllib.parse import urlsplit, urlunsplit, quote
-    parts = urlsplit(url)
-    url = urlunsplit(parts._replace(path=quote(parts.path, safe="/:@!$&'()*+,;=")))
     try:
         resp = observatory_head(url, timeout=HTTP_TIMEOUT)
         reachable = resp.status_code < 400


### PR DESCRIPTION
## Summary

- Rimuove encoding manuale URL in `_http_head()` (bulk_source_check.py)
- L'encoding double-encodes URL già parzialmente encoded (es. `%20`, `+`) → 400 o risorse errate
- `requests.head()` gestisce già URL encoding nativamente

## Test

- 72 test passano

## Ref

Closes #140