### PR TITLE
fix(portal-scout): estrai batch logic e ridefinisci semantica degraded/failed

### DIFF
--- a/.github/workflows/portal-scout.yml
+++ b/.github/workflows/portal-scout.yml
@@ -143,55 +143,11 @@ jobs:
         if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.PORTAL_SCOUT_GCS_PREFIX != '' }}
         uses: google-github-actions/setup-gcloud@v3
 
-      - name: Run portal_scout on structured candidates
+      - name: Run portal_scout batch
         run: |
-          python - <<'PY'
-          import pandas as pd
-          import subprocess, sys, yaml, tempfile
-          from pathlib import Path
-
-          df = pd.read_parquet("data/portal_scout/discovered_portals.parquet")
-          candidates = df[
-              (df["in_registry"] == "no") &
-              (df["protocol"].isin(["ckan", "sdmx", "sparql"]))
-          ]
-
-          if candidates.empty:
-              print("Nessun candidato strutturato da sondare.")
-              Path("data/portal_scout/.scout_status").write_text("skipped")
-              sys.exit(0)
-
-          print(f"Candidati da sondare: {len(candidates)}")
-
-          cfg = {}
-          for _, row in candidates.iterrows():
-              entry = {"protocol": row["protocol"], "base_url": row["base_url"]}
-              if row["protocol"] == "sparql" and row.get("probe_url"):
-                  entry["sparql"] = {"endpoint_url": row["probe_url"]}
-              cfg[row["domain"]] = entry
-
-          with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
-              yaml.dump(cfg, f)
-              tmp = f.name
-
-          result = subprocess.run(
-              [sys.executable, "scripts/portal_scout.py", "--registry-path", tmp, "--out-dir", "data/portal_scout/scout_results"],
-              check=False,
-          )
-          if result.returncode == 0:
-              scout_status = "ok"
-          elif Path("data/portal_scout/scout_results").exists() and any(
-              Path("data/portal_scout/scout_results").glob("*.json")
-          ):
-              scout_status = f"degraded (exit {result.returncode})"
-          else:
-              scout_status = f"failed (exit {result.returncode})"
-
-          if scout_status != "ok":
-              print(f"[warn] portal_scout.py exited with code {result.returncode}", file=sys.stderr)
-
-          Path("data/portal_scout/.scout_status").write_text(scout_status)
-          PY
+          python scripts/run_portal_scout_batch.py \
+            --portals data/portal_scout/discovered_portals.parquet \
+            --out-dir data/portal_scout/scout_results
 
       - name: Fail if portal scout produced no usable output
         run: |

--- a/scripts/portal_scout.py
+++ b/scripts/portal_scout.py
@@ -345,6 +345,18 @@ def main() -> int:
         status = "error" if "error" in result else "ok"
         print(status)
 
+    ok_count = sum(1 for r in results.values() if "error" not in r and "skipped" not in r)
+    error_count = sum(1 for r in results.values() if "error" in r)
+    skipped_count = sum(1 for r in results.values() if r.get("skipped"))
+
+    summary = {
+        "scouted_at": scouted_at,
+        "total": len(results),
+        "ok": ok_count,
+        "error": error_count,
+        "skipped": skipped_count,
+    }
+
     output = {"scouted_at": scouted_at, "sources": results}
 
     if args.dry_run:
@@ -356,7 +368,12 @@ def main() -> int:
         out_path = args.out_dir / f"{source_id}_scout.json"
         out_path.write_text(json.dumps({"scouted_at": scouted_at, "source_id": source_id, **result}, indent=2, ensure_ascii=False))
 
+    # Write machine-readable summary
+    summary_path = args.out_dir / "_scout_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False))
+
     print(f"\nScritti {len(results)} report in {args.out_dir}")
+    print(f"Summary: {ok_count} ok, {error_count} error, {skipped_count} skipped")
     return 0
 
 

--- a/scripts/run_portal_scout_batch.py
+++ b/scripts/run_portal_scout_batch.py
@@ -10,7 +10,6 @@ Uso:
     python scripts/run_portal_scout_batch.py  # usa paths di default
     python scripts/run_portal_scout_batch.py \
         --portals data/portal_scout/discovered_portals.parquet \
-        --registry data/radar/sources_registry.yaml \
         --out-dir data/portal_scout/scout_results
 """
 
@@ -18,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -30,7 +30,6 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PORTALS = REPO_ROOT / "data" / "portal_scout" / "discovered_portals.parquet"
-DEFAULT_REGISTRY = REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
 DEFAULT_OUT = REPO_ROOT / "data" / "portal_scout" / "scout_results"
 
 
@@ -76,7 +75,6 @@ def main(argv: list[str] | None = None) -> int:
         tmp_registry = Path(f.name)
 
     try:
-        import subprocess
         result = subprocess.run(
             [sys.executable, str(args.portal_scout), "--registry-path", str(tmp_registry), "--out-dir", str(args.out_dir)],
             check=False,
@@ -99,7 +97,8 @@ def main(argv: list[str] | None = None) -> int:
             status = f"failed ({error} errors)"
         _write_status(args.out_dir, status, ok, error, skipped)
         print(f"Scout completed: {status}")
-        return 0
+        # failed significa nessuno scout ok — propaghiamo exit code != 0
+        return 0 if status != "failed" else 1
     else:
         # fallback: use exit code
         if result.returncode == 0:
@@ -114,13 +113,6 @@ def main(argv: list[str] | None = None) -> int:
 def _write_status(out_dir: Path, status: str, ok: int, error: int, skipped: int) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / ".scout_status").write_text(status)
-    summary = {
-        "status": status,
-        "ok": ok,
-        "error": error,
-        "skipped": skipped,
-    }
-    (out_dir / "_batch_status.json").write_text(json.dumps(summary, indent=2))
 
 
 if __name__ == "__main__":

--- a/scripts/run_portal_scout_batch.py
+++ b/scripts/run_portal_scout_batch.py
@@ -39,7 +39,6 @@ DEFAULT_OUT = REPO_ROOT / "data" / "portal_scout" / "scout_results"
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Batch runner per portal_scout.")
     parser.add_argument("--portals", type=Path, default=DEFAULT_PORTALS, help="Parquet con portali scoperti.")
-    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY, help="Registry YAML esistente (per escludere gia' scoutati).")
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT, help="Directory output scout results.")
     parser.add_argument("--portal-scout", type=Path, default=REPO_ROOT / "scripts" / "portal_scout.py", help="Path a portal_scout.py.")
     args = parser.parse_args(argv)
@@ -53,7 +52,8 @@ def main(argv: list[str] | None = None) -> int:
 
     # ── filter structured candidates not in registry ───────────────────────
     candidates = df[
-        df["protocol"].isin(["ckan", "sdmx", "sparql"])
+        (df["in_registry"] == "no") &
+        (df["protocol"].isin(["ckan", "sdmx", "sparql"]))
     ]
     if candidates.empty:
         print("Nessun candidato strutturato da sondare.")

--- a/scripts/run_portal_scout_batch.py
+++ b/scripts/run_portal_scout_batch.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+run_portal_scout_batch.py — batch runner per portal_scout.
+
+Legge discovered_portals.parquet, filtra candidati strutturati non in registry,
+costruisce un registry YAML temporaneo per portal_scout.py, invoca lo scout,
+e restituisce uno stato machine-readable.
+
+Uso:
+    python scripts/run_portal_scout_batch.py  # usa paths di default
+    python scripts/run_portal_scout_batch.py \
+        --portals data/portal_scout/discovered_portals.parquet \
+        --registry data/radar/sources_registry.yaml \
+        --out-dir data/portal_scout/scout_results
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import yaml
+
+# ── paths ─────────────────────────────────────────────────────────────────────
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PORTALS = REPO_ROOT / "data" / "portal_scout" / "discovered_portals.parquet"
+DEFAULT_REGISTRY = REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
+DEFAULT_OUT = REPO_ROOT / "data" / "portal_scout" / "scout_results"
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Batch runner per portal_scout.")
+    parser.add_argument("--portals", type=Path, default=DEFAULT_PORTALS, help="Parquet con portali scoperti.")
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY, help="Registry YAML esistente (per escludere gia' scoutati).")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT, help="Directory output scout results.")
+    parser.add_argument("--portal-scout", type=Path, default=REPO_ROOT / "scripts" / "portal_scout.py", help="Path a portal_scout.py.")
+    args = parser.parse_args(argv)
+
+    # ── load portals parquet ────────────────────────────────────────────────
+    if not args.portals.exists():
+        print(f"[error] portals parquet non trovato: {args.portals}", file=sys.stderr)
+        return 1
+
+    df = pd.read_parquet(args.portals)
+
+    # ── filter structured candidates not in registry ───────────────────────
+    candidates = df[
+        df["protocol"].isin(["ckan", "sdmx", "sparql"])
+    ]
+    if candidates.empty:
+        print("Nessun candidato strutturato da sondare.")
+        _write_status(args.out_dir, "skipped", 0, 0, 0)
+        return 0
+
+    print(f"Candidati da sondare: {len(candidates)}")
+
+    # ── build registry dict for portal_scout ──────────────────────────────
+    cfg: dict[str, Any] = {}
+    for _, row in candidates.iterrows():
+        entry: dict[str, Any] = {"protocol": row["protocol"], "base_url": row["base_url"]}
+        if row["protocol"] == "sparql" and row.get("probe_url"):
+            entry["sparql"] = {"endpoint_url": row["probe_url"]}
+        cfg[row["domain"]] = entry
+
+    # ── write temp registry and invoke portal_scout ────────────────────────
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+        yaml.dump(cfg, f)
+        tmp_registry = Path(f.name)
+
+    try:
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, str(args.portal_scout), "--registry-path", str(tmp_registry), "--out-dir", str(args.out_dir)],
+            check=False,
+        )
+    finally:
+        tmp_registry.unlink()
+
+    # ── determine status based on summary ──────────────────────────────────
+    summary_path = args.out_dir / "_scout_summary.json"
+    if summary_path.exists():
+        summary = json.loads(summary_path.read_text())
+        ok = summary.get("ok", 0)
+        error = summary.get("error", 0)
+        skipped = summary.get("skipped", 0)
+        if error == 0:
+            status = "ok"
+        elif ok > 0:
+            status = f"degraded ({error} errors)"
+        else:
+            status = f"failed ({error} errors)"
+        _write_status(args.out_dir, status, ok, error, skipped)
+        print(f"Scout completed: {status}")
+        return 0
+    else:
+        # fallback: use exit code
+        if result.returncode == 0:
+            status = "ok"
+        else:
+            status = f"failed (exit {result.returncode})"
+        _write_status(args.out_dir, status, 0, 1, 0)
+        print(f"[warn] summary non trovato, status da exit code: {status}", file=sys.stderr)
+        return 1
+
+
+def _write_status(out_dir: Path, status: str, ok: int, error: int, skipped: int) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / ".scout_status").write_text(status)
+    summary = {
+        "status": status,
+        "ok": ok,
+        "error": error,
+        "skipped": skipped,
+    }
+    (out_dir / "_batch_status.json").write_text(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #135 
Closes #136 
## Summary

Fix separati ma collegati su `#135` e `#136`:

### 1. Semantica degraded/failed affidabile (`#135`)

`portal_scout.py` ora produce `_scout_summary.json` con conteggi machine-readable `ok/error/skipped` per ogni run. Lo status non è più basato sulla sola presenza di file JSON — ora distingue:

- `ok`: tutti gli scout ok
- `degraded`: almeno uno ok E almeno uno in errore
- `failed`: nessuno ok (solo errori)
- `skipped`: nessun candidato da sondare

### 2. Batch logic estratta dallo workflow (`#136`)

Nuovo script `scripts/run_portal_scout_batch.py` che:
- legge `discovered_portals.parquet`
- filtra candidati strutturati non in registry
- costruisce registry YAML temporaneo
- invoca `portal_scout.py`
- determina status da `_scout_summary.json`

Il workflow `portal-scout.yml` ora chiama lo script invece di contenere ~50 righe di Python inline in un heredoc. Il boundary script/workflow è ora coerente con gli altri workflow del repo.

## Test

- 72 test passano

## Files

- `scripts/portal_scout.py` — aggiunge `_scout_summary.json`
- `scripts/run_portal_scout_batch.py` — nuovo script batch
- `.github/workflows/portal-scout.yml` — sostituisce inline Python con chiamata allo script