### PR TITLE
fix(bulk_source_check): parsare Periodo di riferimento negli extras CKAN italiani

### DIFF
--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -160,6 +160,15 @@ def _parse_ckan_package(pkg: dict) -> dict:
     temporal_start = extras.get("temporal_coverage_from") or extras.get("issued")
     temporal_end = extras.get("temporal_coverage_to") or extras.get("modified")
 
+    # fallback DCAT-IT: "Periodo di riferimento: YYYY - YYYY"
+    # presente in molti CKAN italiani (MEF/Consip, Regioni, etc.)
+    if temporal_start is None and temporal_end is None:
+        periodo = extras.get("Periodo di riferimento") or extras.get("periodo di riferimento")
+        if periodo:
+            years = _YEAR_RE.findall(str(periodo))
+            if len(years) >= 2:
+                temporal_start, temporal_end = years[0], years[-1]
+
     notes = (pkg.get("notes") or "").strip()
     title = pkg.get("title") or None
 


### PR DESCRIPTION
## Summary
- **Problema**: I 17 dataset Consip hanno tutti `needs_review=True` per `year` mancante — il malus `-5` porta score sotto soglia nonostante i dataset siano raggiungibili e arricchiti.
- **Causa**: `_parse_ckan_package` cerca solo `temporal_coverage_from/to` e `issued/modified`; ignora `Periodo di riferimento` (extra non standard usato da CKAN italiani MEF/Consip).
- **Fix**: fallback che estrae gli anni da `Periodo di riferimento: YYYY - YYYY` quando temporal_start/end sono assenti.

## Test
```bash
cd source-observatory
python -c "
from scripts.bulk_source_check import _parse_ckan_package
import requests
r = requests.get('https://dati.consip.it/api/3/action/package_show?id=dataset-beni-e-servizi-acquistati-tramite-rdo-td-su-mepa', timeout=15)
pkg = r.json()['result']
result = _parse_ckan_package(pkg)
assert result['year_min'] == 2023
assert result['year_max'] == 2025
print('PASS')
"
```

## Impatto downstream
- 17 dataset Consip: score risale ~62-67 → `intake_candidate=True`
- Nessuna rottura di contratti — arricchimento aggiuntivo, nessun effetto su CKAN standard
- Issue associata: dataciviclab/source-observatory#145

Closes #145 