### PR TITLE
feat(sources_registry): aggiungi dati_cultura (MiC ArCo) come catalog-watch SPARQL

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -166,6 +166,30 @@ dati_camera:
     DCAT generico non valorizza titolo e descrizione perché l'endpoint usa dc:title
     e dc:description.
   datasets_in_use: []
+dati_cultura:
+  source_kind: catalog
+  protocol: sparql
+  observation_mode: catalog-watch
+  base_url: https://dati.cultura.gov.it/sparql
+  last_probed: '2026-04-11'
+  catalog_baseline:
+    captured_at: '2026-04-11'
+    metric: dataset_count
+    value: 150
+    method: sparql_query
+    query_name: dcat_datasets
+    reliability: medium
+    note: Catalogo linked-data MiC (ArCo) con metadati DCAT interrogabili via SPARQL.
+      ~150 dataset/thesaurus nel catalogo. Pilot per inventory SPARQL oltre ISPRA.
+  sparql:
+    endpoint_url: https://dati.cultura.gov.it/sparql
+    query_name: dcat_datasets
+    limit: 5000
+    timeout_seconds: 90
+  verdict: go
+  note: Catalogo ArCo MiC inventariabile via SPARQL DCAT. Source-check e portal-scout
+    completati con verdict watchlist/catalog-watch.
+  datasets_in_use: []
 ispra_linked_data:
   source_kind: catalog
   protocol: sparql


### PR DESCRIPTION
## Summary
- **Problema**: `dati_cultura` (MiC ArCo) è stato scoutato e verificato via SPARQL ma non è ancora nel `sources_registry.yaml`.
- **Fix**: aggiunge entry `dati_cultura` come `catalog-watch` con protocollo `sparql`, endpoint `https://dati.cultura.gov.it/sparql`, query `dcat_datasets`.

## Verifica builder
```bash
python scripts/build_catalog_inventory.py --source-ids dati_cultura --out-dir /tmp/dati_cultura_test
# → 213 dataset raccolti via SPARQL query dcat_datasets
```

## Criteri di chiusura
- [x] Entry presente nel registry
- [x] Run del builder senza errori per `dati_cultura`
- [x] Parquet aggiornato con 213 righe MiC

## Impatto downstream
- Nessuna rottura — solo aggiunta di fonte nuova al registry
- Il parquet inventory verrà aggiornato dal prossimo run CI

Closes #66