### PR TITLE
refactor(http layer): estrai SSL fallback in base.py, unifica radar_check (#132)

### DIFF
--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -14,6 +14,15 @@ USER_AGENT = "DataCivicLab-SourceObservatory/1.0"
 DEFAULT_TIMEOUT_SECONDS = 60
 
 
+class SslFallbackFailed(Exception):
+    """Raised when both the SSL attempt and the fallback (verify=False) fail."""
+
+    def __init__(self, ssl_error: requests.exceptions.SSLError, fallback_error: requests.exceptions.RequestException):
+        self.ssl_error = ssl_error
+        self.fallback_error = fallback_error
+        super().__init__(f"SSL failed ({ssl_error}) then fallback failed ({fallback_error})")
+
+
 @dataclass
 class CollectorResult:
     rows: list[dict[str, Any]]
@@ -64,7 +73,8 @@ def observatory_ssl_fallback_get(
     """Get with SSL fallback: tries verify=True first, falls back to verify=False on SSLError.
 
     Returns (response, exc). If response is not None, exc is None.
-    If exc is not None, response is None and exc is the original SSLError.
+    If exc is not None, response is None and exc carries both the original
+    SSLError and the fallback failure (SslFallbackFailed).
     """
     request_headers = dict(headers or {})
     try:
@@ -80,6 +90,7 @@ def observatory_ssl_fallback_get(
         urllib3.disable_warnings(category=InsecureRequestWarning)
         try:
             with requests.Session() as session:
+                session.headers.update({"User-Agent": USER_AGENT})
                 response = session.get(
                     url,
                     timeout=timeout,
@@ -89,7 +100,7 @@ def observatory_ssl_fallback_get(
                 )
             return response, exc
         except requests.exceptions.RequestException as fallback_exc:
-            return None, fallback_exc
+            return None, SslFallbackFailed(ssl_error=exc, fallback_error=fallback_exc)
 
 
 def observatory_head(

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from urllib.parse import urlsplit, urlunsplit
 from dataclasses import dataclass
 from typing import Any
 from datetime import datetime, timezone
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
 
 
 USER_AGENT = "DataCivicLab-SourceObservatory/1.0"
@@ -50,6 +52,44 @@ def observatory_get(
             **kwargs,
         )
     return response
+
+
+def observatory_ssl_fallback_get(
+    url: str,
+    *,
+    timeout: int | float | tuple[float, float] = DEFAULT_TIMEOUT_SECONDS,
+    headers: dict[str, str] | None = None,
+    **kwargs: Any,
+) -> tuple[requests.Response | None, Exception | None]:
+    """Get with SSL fallback: tries verify=True first, falls back to verify=False on SSLError.
+
+    Returns (response, exc). If response is not None, exc is None.
+    If exc is not None, response is None and exc is the original SSLError.
+    """
+    request_headers = dict(headers or {})
+    try:
+        with get_observatory_session() as session:
+            response = session.get(
+                url,
+                timeout=timeout,
+                headers=request_headers or None,
+                **kwargs,
+            )
+        return response, None
+    except requests.exceptions.SSLError as exc:
+        urllib3.disable_warnings(category=InsecureRequestWarning)
+        try:
+            with requests.Session() as session:
+                response = session.get(
+                    url,
+                    timeout=timeout,
+                    headers=request_headers or None,
+                    verify=False,
+                    **kwargs,
+                )
+            return response, exc
+        except requests.exceptions.RequestException as fallback_exc:
+            return None, fallback_exc
 
 
 def observatory_head(

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -10,11 +10,10 @@ from pathlib import Path
 from typing import Any
 
 import requests
-import urllib3
 import yaml
-from urllib3.exceptions import InsecureRequestWarning
 
 from _constants import SDMX_RETRYABLE_STATUS_CODES, SDMX_RETRY_DELAYS_SECONDS
+from collectors.base import observatory_ssl_fallback_get
 
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[1]
@@ -149,38 +148,25 @@ def _build_probe_result(
 
 
 def _probe_once(base_url: str) -> ProbeResult:
-    """Single probe attempt (no retry)."""
-    headers = {"User-Agent": USER_AGENT}
-    try:
-        with requests.get(
-            base_url,
-            timeout=TIMEOUT_SECONDS,
-            headers=headers,
-            allow_redirects=True,
-            stream=True,
-        ) as response:
-            return _build_probe_result(base_url, response)
-    except requests.exceptions.SSLError as exc:
-        try:
-            with requests.Session() as session:
-                urllib3.disable_warnings(category=InsecureRequestWarning)
-                with session.get(
-                    base_url,
-                    timeout=TIMEOUT_SECONDS,
-                    headers=headers,
-                    allow_redirects=True,
-                    verify=False,
-                    stream=True,
-                ) as response:
-                    return _build_probe_result(base_url, response, ssl_failure=exc)
-        except requests.exceptions.RequestException as fallback_exc:
-            return _make_error_result(
-                fallback_exc,
-                ssl_fallback_used=True,
-                ssl_failure=exc,
-            )
-    except requests.exceptions.RequestException as exc:
-        return _make_error_result(exc)
+    """Single probe attempt (no retry). Uses shared SSL fallback from base.py."""
+    response, exc = observatory_ssl_fallback_get(
+        base_url,
+        timeout=TIMEOUT_SECONDS,
+        allow_redirects=True,
+        stream=True,
+    )
+    if response is not None:
+        # If exc is not None, we had an SSLError first then fallback succeeded
+        ssl_failure = exc if isinstance(exc, requests.exceptions.SSLError) else None
+        return _build_probe_result(base_url, response, ssl_failure=ssl_failure)
+    # exc is not None — original SSLError, fallback also failed
+    ssl_failure = exc if isinstance(exc, requests.exceptions.SSLError) else None
+    fallback_exc = exc if not ssl_failure else None
+    return _make_error_result(
+        fallback_exc or exc,
+        ssl_fallback_used=ssl_failure is not None,
+        ssl_failure=ssl_failure,
+    )
 
 
 def probe_url(base_url: str) -> ProbeResult:

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -4,6 +4,7 @@ import argparse
 from collections import Counter
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
+from typing import TYPE_CHECKING
 import json
 import time
 from pathlib import Path
@@ -14,6 +15,9 @@ import yaml
 
 from _constants import SDMX_RETRYABLE_STATUS_CODES, SDMX_RETRY_DELAYS_SECONDS
 from collectors.base import SslFallbackFailed, observatory_ssl_fallback_get
+
+if TYPE_CHECKING:
+    from requests.exceptions import RequestException
 
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[1]
@@ -161,7 +165,7 @@ def _probe_once(base_url: str) -> ProbeResult:
         return _build_probe_result(base_url, response, ssl_failure=ssl_failure)
     # exc is not None — both attempts failed
     ssl_failure = None
-    error_exc: requests.exceptions.RequestException
+    error_exc: RequestException
     if isinstance(exc, SslFallbackFailed):
         ssl_failure = exc.ssl_error
         error_exc = exc.fallback_error

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -160,10 +160,11 @@ def _probe_once(base_url: str) -> ProbeResult:
         ssl_failure = exc if isinstance(exc, requests.exceptions.SSLError) else None
         return _build_probe_result(base_url, response, ssl_failure=ssl_failure)
     # exc is not None — original SSLError, fallback also failed
+    if exc is None:
+        raise RuntimeError("Expected exception when response is None from observatory_ssl_fallback_get")
     ssl_failure = exc if isinstance(exc, requests.exceptions.SSLError) else None
-    fallback_exc = exc if not ssl_failure else None
     return _make_error_result(
-        fallback_exc or exc,
+        exc,
         ssl_fallback_used=ssl_failure is not None,
         ssl_failure=ssl_failure,
     )

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -361,15 +361,17 @@ def build_radar_summary(
 
     for source_id, meta in registry.items():
         result = results.get(source_id) or _missing
-        sources_list.append({
-            "id": source_id,
-            "status": result.status,
-            "protocol": meta.get("protocol", "-"),
-            "observation_mode": meta.get("observation_mode", "radar-only"),
-            "http_code": result.http_code,
-            "last_check": probe_date,
-            "datasets_in_use": meta.get("datasets_in_use") or [],
-        })
+        sources_list.append(
+            {
+                "id": source_id,
+                "status": result.status,
+                "protocol": meta.get("protocol", "-"),
+                "observation_mode": meta.get("observation_mode", "radar-only"),
+                "http_code": result.http_code,
+                "last_check": probe_date,
+                "datasets_in_use": meta.get("datasets_in_use") or [],
+            }
+        )
 
     return {
         "generated_at": generated_at,
@@ -426,7 +428,9 @@ def main() -> int:
     STATUS_PATH.parent.mkdir(parents=True, exist_ok=True)
     STATUS_PATH.write_text(report, encoding="utf-8")
     SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
-    SUMMARY_PATH.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    SUMMARY_PATH.write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
     save_registry(REGISTRY_PATH, registry)
     print(f"Wrote {STATUS_PATH}")
     print(f"Wrote {SUMMARY_PATH}")

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -4,7 +4,6 @@ import argparse
 from collections import Counter
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
-from typing import TYPE_CHECKING
 import json
 import time
 from pathlib import Path
@@ -15,9 +14,6 @@ import yaml
 
 from _constants import SDMX_RETRYABLE_STATUS_CODES, SDMX_RETRY_DELAYS_SECONDS
 from collectors.base import SslFallbackFailed, observatory_ssl_fallback_get
-
-if TYPE_CHECKING:
-    from requests.exceptions import RequestException
 
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[1]
@@ -164,16 +160,20 @@ def _probe_once(base_url: str) -> ProbeResult:
         ssl_failure = exc if isinstance(exc, requests.exceptions.SSLError) else None
         return _build_probe_result(base_url, response, ssl_failure=ssl_failure)
     # exc is not None — both attempts failed
+    if exc is None:
+        raise RuntimeError("Expected exception when response is None from observatory_ssl_fallback_get")
     ssl_failure = None
-    error_exc: RequestException
+    error_exc: requests.exceptions.RequestException
     if isinstance(exc, SslFallbackFailed):
         ssl_failure = exc.ssl_error
         error_exc = exc.fallback_error
     elif isinstance(exc, requests.exceptions.SSLError):
         ssl_failure = exc
         error_exc = exc
-    else:
+    elif isinstance(exc, requests.exceptions.RequestException):
         error_exc = exc
+    else:
+        raise RuntimeError(f"Unexpected exception type in _probe_once: {type(exc)}")
     return _make_error_result(
         error_exc,
         ssl_fallback_used=ssl_failure is not None,

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -13,7 +13,7 @@ import requests
 import yaml
 
 from _constants import SDMX_RETRYABLE_STATUS_CODES, SDMX_RETRY_DELAYS_SECONDS
-from collectors.base import observatory_ssl_fallback_get
+from collectors.base import SslFallbackFailed, observatory_ssl_fallback_get
 
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[1]
@@ -159,12 +159,19 @@ def _probe_once(base_url: str) -> ProbeResult:
         # If exc is not None, we had an SSLError first then fallback succeeded
         ssl_failure = exc if isinstance(exc, requests.exceptions.SSLError) else None
         return _build_probe_result(base_url, response, ssl_failure=ssl_failure)
-    # exc is not None — original SSLError, fallback also failed
-    if exc is None:
-        raise RuntimeError("Expected exception when response is None from observatory_ssl_fallback_get")
-    ssl_failure = exc if isinstance(exc, requests.exceptions.SSLError) else None
+    # exc is not None — both attempts failed
+    ssl_failure = None
+    error_exc: requests.exceptions.RequestException
+    if isinstance(exc, SslFallbackFailed):
+        ssl_failure = exc.ssl_error
+        error_exc = exc.fallback_error
+    elif isinstance(exc, requests.exceptions.SSLError):
+        ssl_failure = exc
+        error_exc = exc
+    else:
+        error_exc = exc
     return _make_error_result(
-        exc,
+        error_exc,
         ssl_fallback_used=ssl_failure is not None,
         ssl_failure=ssl_failure,
     )

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -1,4 +1,5 @@
 """Test per radar_check.py."""
+
 from __future__ import annotations
 
 import json

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -123,13 +123,13 @@ def test_is_sdmx_url() -> None:
 
 
 def test_probe_url_success(monkeypatch) -> None:
-    def fake_get(*args, **kwargs):
+    def fake_ssl_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
         return FakeResponse(
             status_code=200,
             json_payload={"success": True, "result": []},
-        )
+        ), None
 
-    monkeypatch.setattr(radar_check.requests, "get", fake_get)
+    monkeypatch.setattr(radar_check, "observatory_ssl_fallback_get", fake_ssl_get)
     result = radar_check.probe_url("https://demo.test/api/3/action/package_list")
     assert result.status == "GREEN"
     assert result.http_code == "200"
@@ -139,10 +139,10 @@ def test_probe_url_success(monkeypatch) -> None:
 def test_probe_url_timeout(monkeypatch) -> None:
     import requests as real_requests
 
-    def fake_get(*args, **kwargs):
-        raise real_requests.exceptions.Timeout("Connection timed out")
+    def fake_ssl_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
+        return None, real_requests.exceptions.Timeout("Connection timed out")
 
-    monkeypatch.setattr(radar_check.requests, "get", fake_get)
+    monkeypatch.setattr(radar_check, "observatory_ssl_fallback_get", fake_ssl_get)
     result = radar_check.probe_url("https://slow.test/api/3/action")
     assert result.status == "YELLOW"
     assert "Timeout" in (result.note or "")
@@ -151,10 +151,10 @@ def test_probe_url_timeout(monkeypatch) -> None:
 def test_probe_url_connection_error(monkeypatch) -> None:
     import requests as real_requests
 
-    def fake_get(*args, **kwargs):
-        raise real_requests.exceptions.ConnectionError("Connection refused")
+    def fake_ssl_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
+        return None, real_requests.exceptions.ConnectionError("Connection refused")
 
-    monkeypatch.setattr(radar_check.requests, "get", fake_get)
+    monkeypatch.setattr(radar_check, "observatory_ssl_fallback_get", fake_ssl_get)
     result = radar_check.probe_url("https://dead.test/api/3/action")
     assert result.status == "RED"
     assert "Connection error" in (result.note or "")
@@ -165,17 +165,18 @@ def test_probe_url_ssl_fallback(monkeypatch) -> None:
 
     call_count = {"n": 0}
 
-    def fake_get(*args, **kwargs):
+    def fake_ssl_fallback_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
         call_count["n"] += 1
         if call_count["n"] == 1:
-            raise real_requests.exceptions.SSLError("SSL certificate verify failed")
-        return FakeResponse(
-            status_code=200,
-            json_payload={"success": True},
-        )
+            # Normal get raises SSLError → fallback succeeds
+            response = FakeResponse(status_code=200, json_payload={"success": True})
+            return response, real_requests.exceptions.SSLError("SSL certificate verify failed")
+        # fallback also failed
+        return None, real_requests.exceptions.ConnectionError("SSL fallback failed")
 
-    monkeypatch.setattr(radar_check.requests, "get", fake_get)
-    # Disable actual urllib3 warning suppression for test safety
+    monkeypatch.setattr(
+        radar_check, "observatory_ssl_fallback_get", fake_ssl_fallback_get
+    )
     monkeypatch.setattr(
         radar_check.requests.packages.urllib3,
         "disable_warnings",

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -162,18 +162,38 @@ def test_probe_url_connection_error(monkeypatch) -> None:
 
 
 def test_probe_url_ssl_fallback(monkeypatch) -> None:
+    """SSL error first, fallback succeeds — ssl_fallback_used=True."""
     import requests as real_requests
 
-    call_count = {"n": 0}
+    def fake_ssl_fallback_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
+        # Normal get raises SSLError → fallback succeeds
+        response = FakeResponse(status_code=200, json_payload={"success": True})
+        ssl_exc = real_requests.exceptions.SSLError("SSL certificate verify failed")
+        return response, ssl_exc
+
+    monkeypatch.setattr(
+        radar_check, "observatory_ssl_fallback_get", fake_ssl_fallback_get
+    )
+    monkeypatch.setattr(
+        radar_check.requests.packages.urllib3,
+        "disable_warnings",
+        lambda *args, **kwargs: None,
+    )
+
+    result = radar_check._probe_once("https://ssl-broken.test/api/3/action")
+    assert result.ssl_fallback_used is True
+    assert "SSL verify failed" in (result.note or "")
+
+
+def test_probe_url_ssl_fallback_double_failure(monkeypatch) -> None:
+    """SSL error first, fallback also fails — ssl_fallback_used=True, both errors preserved."""
+    import requests as real_requests
+    from collectors.base import SslFallbackFailed
 
     def fake_ssl_fallback_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            # Normal get raises SSLError → fallback succeeds
-            response = FakeResponse(status_code=200, json_payload={"success": True})
-            return response, real_requests.exceptions.SSLError("SSL certificate verify failed")
-        # fallback also failed
-        return None, real_requests.exceptions.ConnectionError("SSL fallback failed")
+        ssl_exc = real_requests.exceptions.SSLError("SSL cert verify failed")
+        fallback_exc = real_requests.exceptions.ConnectionError("Connection refused after fallback")
+        return None, SslFallbackFailed(ssl_error=ssl_exc, fallback_error=fallback_exc)
 
     monkeypatch.setattr(
         radar_check, "observatory_ssl_fallback_get", fake_ssl_fallback_get


### PR DESCRIPTION
## Summary
- **Problema**: `radar_check._probe_once()` usava `requests.get()` diretto con SSL fallback reimplementato localmente — duplicazione della policy HTTP rispetto a `collectors/base.py`.
- **Fix**: estrae `observatory_ssl_fallback_get()` in `base.py` e lo riutilizza in `_probe_once()`. Un solo posto per: user-agent, timeout, SSL fallback, connessione.

## Cosa cambia
| File | Delta |
|---|---|
| `collectors/base.py` | +42 righe: `observatory_ssl_fallback_get()` |
| `radar_check.py` | -52/+24 righe: `_probe_once()` ora chiama `base.py`, rimossi `requests.get` diretto + `urllib3` import |
| `tests/test_radar_check.py` | test aggiornati per mockare `observatory_ssl_fallback_get` invece di `requests.get` |

## Test
```bash
cd source-observatory && python -m pytest tests/ -v
# 84 passed in 1.54s
```

Closes #132