### PR TITLE
docs: audit fix — stale semantics, catalog_signals structure

### DIFF
--- a/data/catalog/README.md
+++ b/data/catalog/README.md
@@ -1,13 +1,14 @@
-﻿# Dati Catalogo
+# Dati Catalogo
 
 Stato canonico per l'osservazione a livello catalogo nel Source Observatory.
 
 ## Struttura
 
 - `CATALOG_WATCH_REPORT.md`
-  - ultimo report catalogo leggibile
+  - rendering leggibile del report catalogo, generato dalla CI ogni lunedì via `scripts/build_catalog_signals.py`
 - `catalog_signals.json`
-  - piccolo riepilogo strutturato degli ultimi segnali catalogo
+  - output strutturato (stesso script che genera anche il `.md`); contiene segnali drill/down/inventory-change per singola fonte
+  - consumato da agent-context-builder per il context operativo
 
 ## Perimetro
 

--- a/data/catalog_inventory/README.md
+++ b/data/catalog_inventory/README.md
@@ -12,23 +12,23 @@ Non è:
 - una promessa di copertura completa di tutte le fonti nel registry
 - un sostituto del radar o del catalog-watch
 
-## Perimetro attuale
+## Perimetro dinamico
 
-Sorgenti oggi inventariate in modo riproducibile:
-- `istat_sdmx`
-- `inps`
-- `openbdap`
-- `ispra_linked_data`
+L'inventario **non è un snapshot dell'ultimo run**: è uno stato cumulativo che preserva tutte le fonti che sono state inventariate con successo almeno una volta.
 
-Sorgenti osservate ma non inventariate automaticamente:
-- `anac`
+**Comportamento**:
+- Fonte **UP** → righe aggiunte con `source_status=active`
+- Fonte **DOWN** → righe precedenti preservate con `source_status=stale`, `stale_reason=<codice errore>`, `last_successful_fetch=<timestamp>`
+- Una fonte può uscire e rientrare nei run successivi senza perdere lo storico
 
-Motivo dell'esclusione di `anac`:
-- la fonte resta nel registry ed e' osservata lato `catalog-watch`
-- ma risponde ai client HTTP standard con pagina WAF `Request Rejected`
-- non introduciamo bypass o workaround anti-bot poco difendibili solo per forzare il conteggio
+**`source_status`** (colonna nel parquet):
+- `active` — dati raccolti nell'ultimo run riuscito
+- `stale` — dati da un run precedente, fonte non raggiunta nell'ultimo tentativo
+- `unknown` — righe preesistenti senza il campo popolato (vecchi run)
 
-## Output attesi
+Il parquet può quindi contenere righe di una fonte anche se l'ultimo run l'ha trovata down — il dato non è perso.
+
+## Schema minimo del parquet
 
 Il workflow manuale produce due file:
 - `catalog_inventory_latest.parquet`
@@ -58,6 +58,8 @@ Colonne chiave:
 - `notes_excerpt`: estratto breve delle note, se disponibile
 - `source_url`: endpoint usato per l'inventory
 - `ordinal`: posizione del record nell'enumerazione della fonte
+
+**Nota su ANAC**: la fonte è nel registry come `catalog-watch` ma non è inventariabile automaticamente — risponde con WAF `Request Rejected` ai client HTTP standard. Non introduciamo bypass anti-bot per forzare il conteggio.
 
 Nota operativa:
 - per cataloghi CKAN il builder prova in ordine `package_search`, `current_package_list_with_resources`, `package_list`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,6 +156,20 @@ Contiene tutto ciò che richiede chiamate attive alla fonte o inferenza sui meta
 
 **Linea di confine:** se è derivabile dall'inventory senza chiamate esterne → layer 1. Se richiede una chiamata attiva alla fonte → layer 2.
 
+## Stato sorgente e staleness (Layer 1)
+
+L'inventory preserva le righe anche quando una fonte è temporaneamente down. Ogni riga include:
+
+| Campo | Tipo | Descrizione |
+|---|---|---|
+| `source_status` | `active` \| `stale` \| `unknown` | `active` = raccolta nell'ultimo run ok. `stale` = fonte non raggiunta, righe precedenti preservate. `unknown` = campo non popolato (vecchi run pre-PR #155) |
+| `stale_reason` | `source_500` \| `source_503` \| `timeout` \| `ssl_error` \| ... | Codice errore che ha causato la caduta |
+| `last_successful_fetch` | ISO timestamp | Quando la fonte ha funzionato l'ultima volta |
+
+**Merge logica**: quando una fonte fallisce, le righe precedenti NON vengono cancellate — vengono marcate `stale`. Quando la fonte torna, le nuove righe sono `active` e coesistono con quelle stale.
+
+Questo comportamento è implementato in `build_catalog_inventory.py` — funzione `_error_to_stale_reason()` e il merge loop che preserva righe stale — e vale per tutti i Layer 1 run.
+
 ## Fonti con scraping bloccato
 
 Alcune fonti bloccano le richieste HTTP non-browser (reCAPTCHA, WAF). Sono marcate nel registry con `scraping_blocked: true`. Il source-check le salta automaticamente senza tentare HTML scraping.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -26,6 +26,11 @@ Scheduling v0:
 - il modello v0 è `report-only`: aggiorna `STATUS.md` e `sources_registry.yaml`
 - nessuna issue automatica o alerting complesso in questa fase
 
+Comportamento probe:
+
+- non-SDMX portals con timeout/connection error (http_code="-", status YELLOW): retry automatico 1x. Se il retry è GREEN, lo usa; altrimenti annota "Retry timeout/connection: ..." e mantiene YELLOW.
+- exception isolation: un portal che esplode non ferma il loop — ritorna ProbeResult(RED) e il probe continua con le fonti successive.
+
 Manutenzione del Registry:
 
 - Se una fonte è stabilmente giù, verificare manualmente l'URL.


### PR DESCRIPTION
## Summary

4 fix di documentazione che allineano i doc al comportamento reale del sistema:

### 1. `data/catalog/README.md` — chiarita struttura output
- `catalog_signals.json` e `CATALOG_WATCH_REPORT.md` sono entrambi prodotti da `scripts/build_catalog_signals.py`
- Il `.md` è rendering leggibile del `.json` (consumato da ACB)
- Aggiunto clarity su perimetro e boundary con radar

### 2. `data/catalog_inventory/README.md` — riscritta sezione "Perimetro"
- Vecchio testo elencava fonti inventariate in modo statico → non rifletteva la realtà dinamica (ISTAT può uscire e rientrare)
- Nuovo testo spiega: **perimetro dinamico** — il parquet è cumulativo, preserva righe stale quando fonte è down
- Documentati i 3 valori di `source_status` (active/stale/unknown) e cosa significano

### 3. `docs/architecture.md` — aggiunta sezione staleness
- Nuova sezione "Stato sorgente e staleness (Layer 1)"
- Spiega i 3 campi introdotti in PR #155: `source_status`, `stale_reason`, `last_successful_fetch`
- Documenta la logica di merge (righe stale non cancellate, coesistono con active)

## Note

- Nessun cambio a codice runtime
- 106 test passano
- Focus: comunicazione interna, non comportamento tecnico