### PR TITLE
fix(#150): convert print to logging in SO scripts

### DIFF
--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -22,6 +22,7 @@ Uso:
 from __future__ import annotations
 
 import argparse
+import logging
 import re
 import sys
 import time
@@ -37,6 +38,8 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from collectors.base import observatory_get, observatory_head
+
+logger = logging.getLogger(__name__)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_IN = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_latest.parquet"
@@ -578,17 +581,19 @@ def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame
     results = []
 
     with ThreadPoolExecutor(max_workers=workers) as pool:
-        futures = {pool.submit(_check_row, row, check_ts, registry): i for i, row in df.iterrows()}
+        future_to_idx = {pool.submit(_check_row, row, check_ts, registry): i for i, row in df.iterrows()}
         done = 0
-        total = len(futures)
-        for future in as_completed(futures):
+        total = len(future_to_idx)
+        for future in as_completed(future_to_idx):
+            i = future_to_idx[future]
             try:
                 results.append(_finalize_scores(future.result()))
-            except Exception as exc:
-                results.append({"check_notes": str(exc)[:200], "enrich_method": "error"})
+            except Exception:
+                logger.exception("Row check failed for index %d", i)
+                results.append({"check_notes": "check failed", "enrich_method": "error"})
             done += 1
             if done % 50 == 0 or done == total:
-                print(f"  {done}/{total} completati")
+                logger.info("  %d/%d completed", done, total)
 
     return pd.DataFrame(results)
 
@@ -614,44 +619,45 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    logging.basicConfig(format="%(levelname)s %(message)s", level=logging.INFO)
     args = parse_args()
 
-    print(f"Carico catalogo: {args.input}")
+    logger.info("Loading catalog: %s", args.input)
     df = pd.read_parquet(args.input)
-    print(f"  {len(df)} item totali")
+    logger.info("  %d total items", len(df))
 
     if args.source_ids:
         df = df[df["source_id"].isin(args.source_ids)]
-        print(f"  filtro source_ids {args.source_ids}: {len(df)} item")
+        logger.info("  source_ids filter %s: %d items", args.source_ids, len(df))
 
     if args.only_with_url:
         has_url = df["landing_page"].notna() | df["distribution_url"].notna()
         df = df[has_url]
-        print(f"  filtro URL presenti nel catalogo: {len(df)} item")
+        logger.info("  URL present in catalog filter: %d items", len(df))
 
     if args.only_with_title:
         df = df[df["title"].notna()]
-        print(f"  filtro title non nullo: {len(df)} item")
+        logger.info("  non-null title filter: %d items", len(df))
 
     if args.limit:
         df = df.head(args.limit)
-        print(f"  limit {args.limit}: {len(df)} item")
+        logger.info("  limit %d: %d items", args.limit, len(df))
 
     if args.limit_per_source:
         df = df.groupby("source_id", group_keys=False).head(args.limit_per_source)
-        print(f"  limit-per-source {args.limit_per_source}: {len(df)} item")
+        logger.info("  limit-per-source %d: %d items", args.limit_per_source, len(df))
 
     if df.empty:
-        print("Nessun item da controllare. Uscita.")
+        logger.info("No items to check. Exiting.")
         return
 
     # ── Logica incrementale ──────────────────────────────────────────────────────
     existing = None
     skipped = 0
     if args.out.exists():
-        print(f"\nCarico risultati precedenti: {args.out}")
+        logger.info("Loading previous results: %s", args.out)
         existing = pd.read_parquet(args.out)
-        print(f"  {len(existing)} risultati precedenti")
+        logger.info("  %d previous results", len(existing))
 
         # Parsare check_timestamp come datetime se presente
         if "check_timestamp" in existing.columns:
@@ -695,28 +701,28 @@ def main() -> None:
                 reinspected = len(recent_ids & updated_ids)
                 if reinspected > 0:
                     recent_ids = recent_ids - updated_ids
-                    print(f"  {reinspected} item ri-aggiunti perché la fonte ha aggiornato modified")
+                    logger.info("  %d items re-added because source updated modified", reinspected)
 
             # Filtra catalogo escludendo item recenti
             df_to_check = df[~df["item_id"].astype(str).isin(recent_ids)].copy()
             skipped = len(df) - len(df_to_check)
 
             if skipped > 0:
-                print(f"  Saltati {skipped} item controllati negli ultimi {args.max_age_days} giorni")
-            print(f"  {len(df_to_check)} item da controllare")
+                logger.info("  Skipped %d items checked in last %d days", skipped, args.max_age_days)
+            logger.info("  %d items to check", len(df_to_check))
             df = df_to_check
         else:
-            print("  Attenzione: existing non ha colonna 'item_id', saltando dedup")
+            logger.warning("  existing has no 'item_id' column, skipping dedup")
 
     if df.empty:
-        print("Nessun item nuovo da controllare. Uscita.")
+        logger.info("No new items to check. Exiting.")
         return
 
-    print(f"\nAvvio check su {len(df)} item ({args.workers} workers)...")
+    logger.info("Starting check on %d items (%d workers)...", len(df), args.workers)
     t0 = time.time()
     results = run_bulk_check(df, workers=args.workers)
     elapsed = time.time() - t0
-    print(f"Completato in {elapsed:.1f}s")
+    logger.info("Completed in %.1fs", elapsed)
 
     # ── Upsert ───────────────────────────────────────────────────────────────────
     if existing is not None and not existing.empty and "item_id" in existing.columns:
@@ -729,26 +735,26 @@ def main() -> None:
         # Deduplica su item_id tenendo la riga con check_timestamp più recente
         results["check_timestamp"] = pd.to_datetime(results["check_timestamp"], utc=True)
         results = results.sort_values("check_timestamp", ascending=False).drop_duplicates(subset=["item_id"], keep="first").reset_index(drop=True)
-        print(f"  Unificati {len(results)} risultati (nuovi + precedenti non ri-controllati)")
+        logger.info("  Unified %d results (new + previous not re-checked)", len(results))
 
     enrich_counts = results["enrich_method"].value_counts()
     reachable_n = results["reachable"].sum() if "reachable" in results.columns else 0
     reachable_pct = results["reachable"].mean() * 100 if "reachable" in results.columns else 0
-    print(f"\nArricchimento:\n{enrich_counts.to_string()}")
-    print(f"Raggiungibili: {reachable_pct:.0f}% ({reachable_n}/{len(results)})")
-    print(f"Granularità:\n{results['granularity'].value_counts().to_string()}")
-    print(f"Needs review: {results['needs_review'].sum()}")
+    logger.info("Enrichment:\n%s", enrich_counts.to_string())
+    logger.info("Reachable: %.0f%% (%d/%d)", reachable_pct, reachable_n, len(results))
+    logger.info("Granularity:\n%s", results["granularity"].value_counts().to_string())
+    logger.info("Needs review: %d", results["needs_review"].sum())
     if "intake_score" in results.columns:
         candidates = results["intake_candidate"].sum()
         avg_score = results["intake_score"].mean()
-        print(f"Intake candidates: {candidates}/{len(results)} (score medio: {avg_score:.0f})")
+        logger.info("Intake candidates: %d/%d (avg score: %.0f)", candidates, len(results), avg_score)
         top = results[results["intake_candidate"].fillna(False)].nlargest(5, "intake_score")[["title","granularity","year_min","year_max","intake_score"]]
         if not top.empty:
-            print(f"\nTop candidati:\n{top.to_string(index=False)}")
+            logger.info("Top candidates:\n%s", top.to_string(index=False))
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     results.to_parquet(args.out, index=False)
-    print(f"\nRisultati: {args.out}")
+    logger.info("Results: %s", args.out)
 
 
 if __name__ == "__main__":

--- a/scripts/discover_portals.py
+++ b/scripts/discover_portals.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import logging
 import requests
+import sys
 import time
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -24,9 +25,10 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote, urlparse
 
-from collectors.base import observatory_get
-
 logger = logging.getLogger(__name__)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from collectors.base import observatory_get  # noqa: E402
 
 OUT_DEFAULT = Path(__file__).resolve().parents[1] / "data" / "portal_scout" / "discovered_portals.parquet"
 

--- a/scripts/discover_portals.py
+++ b/scripts/discover_portals.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import requests
-import sys
 import time
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -24,8 +24,9 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote, urlparse
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
 from collectors.base import observatory_get
+
+logger = logging.getLogger(__name__)
 
 OUT_DEFAULT = Path(__file__).resolve().parents[1] / "data" / "portal_scout" / "discovered_portals.parquet"
 
@@ -229,7 +230,7 @@ def search_ddg(queries: list[str], max_per_query: int) -> list[dict]:
                 results.extend(hits)
                 time.sleep(1.5)  # rate limit
             except Exception as exc:
-                print(f"  [warn] query '{query}': {exc}", file=sys.stderr)
+                logger.warning("query '%s' failed: %s", query, exc)
     return results
 
 
@@ -532,6 +533,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    logging.basicConfig(format="%(levelname)s %(message)s", level=logging.INFO)
     args = parse_args()
 
     if args.refresh_summary:
@@ -542,8 +544,8 @@ def main() -> int:
         summary_path, shortlist_path = _write_summary_artifacts(
             df, args.out, datetime.now(timezone.utc).isoformat()
         )
-        print(f"Shortlist scritta in {shortlist_path}")
-        print(f"Summary scritto in {summary_path}")
+        logger.info("Shortlist written to %s", shortlist_path)
+        logger.info("Summary written to %s", summary_path)
         return 0
 
     # Seleziona query in base ai protocolli richiesti
@@ -555,24 +557,25 @@ def main() -> int:
     # Limita i probe ai protocolli richiesti
     active_probe_paths = {k: v for k, v in PROBE_PATHS.items() if k in protocols}
 
-    print(f"Ricerca su {len(queries)} query DDG (max {args.max_results} risultati ciascuna)"
-          + (f" — protocolli: {', '.join(sorted(protocols))}" if args.protocols else "") + "...")
+    logger.info("Searching %d DDG queries (max %d results each)%s",
+                len(queries), args.max_results,
+                (f" — protocols: {', '.join(sorted(protocols))}" if args.protocols else ""))
     results = search_ddg(queries, args.max_results)
-    print(f"  {len(results)} risultati grezzi")
+    logger.info("  %d raw results", len(results))
 
     domains = extract_domains(results)
     # Aggiungi sempre i portali nazionali tier-1
     for tier1_domain in TIER1_DOMAINS:
         if tier1_domain not in domains:
             domains[tier1_domain] = {"tier1-allowlist"}
-    print(f"  {len(domains)} domini unici estratti (inclusi {len(TIER1_DOMAINS)} tier-1)")
+    logger.info("  %d unique domains extracted (including %d tier-1)", len(domains), len(TIER1_DOMAINS))
 
     def _probe_domain(domain: str, sources: set[str]) -> dict:
         if args.no_probe:
             protocol, probe_url = "unknown", None
         else:
             protocol, probe_url = detect_protocol(domain, active_probe_paths)
-            print(f"  probe {domain} ... {protocol}", flush=True)
+            logger.debug("probe %s ... %s", domain, protocol)
 
         in_registry = domain in KNOWN_REGISTRY_DOMAINS or any(
             domain.endswith("." + kd) or kd.endswith("." + domain)
@@ -614,7 +617,7 @@ def main() -> int:
     if args.only_matched:
         confirmed = args.protocols if args.protocols else list(PROBE_PATHS.keys())
         df = df[df["protocol"].isin(confirmed)]
-        print(f"  filtrati a {len(df)} portali con protocollo confermato ({', '.join(confirmed)})")
+        logger.info("  filtered to %d portals with confirmed protocol (%s)", len(df), ", ".join(confirmed))
 
     # Filtra per soglia minima dataset (solo per portali con sample_count noto)
     if args.min_datasets > 0:
@@ -623,7 +626,7 @@ def main() -> int:
         below = (~mask).sum()
         df = df[mask]
         if below > 0:
-            print(f"  rimossi {below} portali con < {args.min_datasets} dataset")
+            logger.info("  removed %d portals with < %d datasets", below, args.min_datasets)
 
     df.to_parquet(args.out, index=False)
 
@@ -632,17 +635,16 @@ def main() -> int:
     if not new_candidates.empty:
         new_candidates_path = args.out.with_name("new_candidates.parquet")
         new_candidates.to_parquet(new_candidates_path, index=False)
-        print(f"  {len(new_candidates)} nuovi candidati -> {new_candidates_path}")
+        logger.info("  %d new candidates -> %s", len(new_candidates), new_candidates_path)
 
-    print(f"  di cui {len(new_candidates)} nuovi candidati (non nel registry)")
+    logger.info("  of which %d new candidates (not in registry)", len(new_candidates))
 
     summary_path, shortlist_path = _write_summary_artifacts(
         df, args.out, datetime.now(timezone.utc).isoformat()
     )
-    print(f"Shortlist scritta in {shortlist_path}")
-    print(f"Summary scritto in {summary_path}")
-
-    print(f"\nScritti {len(rows)} portali in {args.out}")
+    logger.info("Shortlist written to %s", shortlist_path)
+    logger.info("Summary written to %s", summary_path)
+    logger.info("Wrote %d portals to %s", len(rows), args.out)
     return 0
 
 


### PR DESCRIPTION
## Summary
- Converte tutti i `print()` in `logging.getLogger(__name__)` nei due script principali
- Aggiunge `logging.basicConfig()` in `main()` per entrambi
- Corregge bug tracciamento index nel thread pool di `bulk_source_check.py`
- Sostituisce `str(exc)[:200]` con `logger.exception()` per stack trace completo
- Rimuove `import sys` non usato da `discover_portals.py`

## Changes

| File | before | after |
|---|---|---|
| `scripts/bulk_source_check.py` | 22 print | logger.info/warning/exception |
| `scripts/discover_portals.py` | 13 print | logger.info/debug |

## Testing
- `ruff check`: all clean
- `bulk_source_check.py --source-ids inps --limit 2`: log strutturato OK
- `discover_portals.py --no-probe --max-results 3`: log OK

## Notes
- Probe progress in `discover_portals.py` degradato a `logger.debug` (troppo verbose per output normale)
- Log level default: INFO (configurato da `basicConfig`)