### PR TITLE
fix(#151): add logger.debug to silent except blocks

### DIFF
--- a/scripts/discover_portals.py
+++ b/scripts/discover_portals.py
@@ -123,6 +123,7 @@ def _sync_from_registry(registry_path: Path | None = None) -> None:
         with open(registry_path, encoding="utf-8") as f:
             registry = yaml.safe_load(f)
     except Exception:
+        logger.debug("bootstrap: registry load failed, skipping tier1")
         return
 
     tier1: dict[str, str] = {}
@@ -142,7 +143,7 @@ def _sync_from_registry(registry_path: Path | None = None) -> None:
                     if protocol in ("ckan", "sdmx", "sparql"):
                         tier1[domain] = protocol
             except Exception:
-                pass
+                logger.debug("bootstrap: skipping domain with parse error")
 
     TIER1_DOMAINS = tier1
     KNOWN_REGISTRY_DOMAINS = known
@@ -195,6 +196,7 @@ def _retry_get(url: str, timeout: tuple[float, float]) -> requests.Response | No
         except Exception:
             if attempt < _PROBE_MAX_RETRIES:
                 time.sleep(_PROBE_BASE_DELAY * (2 ** attempt))
+    logger.debug("probe: all retries exhausted")
     return None
 
 
@@ -346,7 +348,7 @@ def _sample_portal(protocol: str, probe_url: str) -> dict:
                                         result["year_min"] = int(created[:4])
                                         break
                         except Exception:
-                            pass
+                            logger.debug("ckan sample: skip, year parse error")
 
         elif protocol == "sdmx":
             # Count da dataflow list
@@ -365,7 +367,7 @@ def _sample_portal(protocol: str, probe_url: str) -> dict:
                         if name:
                             result["sample_titles"].append(name)
                 except Exception:
-                    pass
+                    logger.debug("sdmx sample: skip, year parse error")
 
         elif protocol == "sparql":
             # Count via SELECT COUNT su graph default
@@ -379,7 +381,7 @@ def _sample_portal(protocol: str, probe_url: str) -> dict:
                     if bindings:
                         result["sample_count"] = int(bindings[0].get("callret-0", {}).get("value", 0))
                 except Exception:
-                    pass
+                    logger.debug("sparql sample: skip, count parse error")
                 # Titoli campione da dataset titling query
                 title_query = (
                     "SELECT DISTINCT ?title WHERE { ?s a <http://www.w3.org/ns/dcat#Dataset> . "
@@ -394,7 +396,7 @@ def _sample_portal(protocol: str, probe_url: str) -> dict:
                             if t:
                                 result["sample_titles"].append(t)
                 except Exception:
-                    pass
+                    logger.debug("sparql sample: skip, title parse error")
 
     except Exception as exc:
         result["sample_error"] = str(exc)[:80]

--- a/scripts/portal_scout.py
+++ b/scripts/portal_scout.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import sys
 import xml.etree.ElementTree as ET
 from collections import defaultdict
@@ -28,11 +29,13 @@ from typing import Any
 
 import yaml
 
+logger = logging.getLogger(__name__)
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from collectors.base import observatory_get, now_utc_iso, sparql_binding_value
-from collectors.ckan import ckan_action_endpoint, ckan_get_json
-from collectors.sdmx import parse_sdmx_name, _sdmx_api_base
-from collectors.sparql import SPARQL_QUERY_TEMPLATES
+from collectors.base import observatory_get, now_utc_iso, sparql_binding_value  # noqa: E402
+from collectors.ckan import ckan_action_endpoint, ckan_get_json  # noqa: E402
+from collectors.sdmx import parse_sdmx_name, _sdmx_api_base  # noqa: E402
+from collectors.sparql import SPARQL_QUERY_TEMPLATES  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REGISTRY_PATH = REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
@@ -102,7 +105,7 @@ def scout_ckan(source_id: str, source_cfg: dict[str, Any]) -> dict[str, Any]:
                     if item:
                         items.append(item)
                 except Exception:
-                    pass
+                    logger.debug("ckan fallback: skip package_show error")
         except Exception as exc:
             errors.append(f"package_list fallback failed: {exc}")
 
@@ -319,6 +322,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    logging.basicConfig(format="%(levelname)s %(message)s", level=logging.WARNING)
     args = parse_args()
     with args.registry_path.open(encoding="utf-8") as fh:
         registry: dict[str, dict] = yaml.safe_load(fh) or {}


### PR DESCRIPTION
## Summary
- Aggiunge `logger.debug()` a 6 blocchi `except Exception: pass` in `discover_portals.py` (5) e `portal_scout.py` (1)
- `portal_scout.py` ottiene `import logging` + `logging.basicConfig(level=WARNING)` per tenere debug disattivo di default

## Changes

| File | Silenziati | Fix |
|---|---|---|
| `discover_portals.py` | bootstrap registry load, tier1 parse, ckan sample year, sdmx sample year, sparql count, sparql title | → `logger.debug(...)` |
| `portal_scout.py` | ckan fallback package_show | → `logger.debug(...)` |

## Testing
- `ruff check`: all clean
- `python scripts/portal_scout.py --help`: OK

## Context
Chiude parzialmente #151. Il fix copre i 6 silenziati in path di campionamento. Il thread pool (caso critico) era già fixed in #150 con `logger.exception()`.