### PR TITLE
feat(csv-magnet): HTML portal collector per catalog-watch

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -94,21 +94,22 @@ openbdap:
 dati_salute:
   source_kind: catalog
   protocol: html
-  observation_mode: radar-only
+  observation_mode: catalog-watch
   base_url: https://www.dati.salute.gov.it/
   last_probed: '2026-04-27'
   catalog_baseline:
     captured_at: '2026-04-07'
-    metric: dataset_url_count
-    value: 191
-    method: sitemap_dataset_count
+    metric: csv_magnet_total_links
+    value: 382
+    method: csv_magnet_sitemap_scan
     reliability: medium
-    note: Conteggio URL /it/dataset/ dal sitemap-0.xml. Protocollo html non supportato
-      dal builder; il radar fallisce per SSL. Watch manuale finche' html non aggiunto.
+    note: "Sondaggio CSV magnet via sitemap-0.xml. 191 pagine dataset, 4 formati (CSV/XML/JSON/ZIP). Prefix matrix: FRM=45, DISPO=38. Anni: 2023-2026."
   verdict: go
-  note: Portale Ministero Salute con sitemap replicabile. Declassato a radar-only
-    perche' il protocollo html non e' supportato dal builder e il probe SSL fallisce.
-    Riportare a catalog-watch quando html e' supportato.
+  note: Portale Ministero Salute — csv_magnet scan integrato nel pipeline catalog-watch.
+  html_portal:
+    topic_hint: sanita
+    sitemap_url: https://www.dati.salute.gov.it/sitemap-0.xml
+    delay_seconds: 0.3
   datasets_in_use: []
 inail_opendata:
   source_kind: portal
@@ -124,13 +125,28 @@ inail_opendata:
 mim_opendata:
   source_kind: portal
   protocol: html
-  observation_mode: radar-only
+  observation_mode: catalog-watch
   base_url: https://dati.istruzione.it/opendata/opendata/catalogo/
   last_probed: '2026-04-27'
+  catalog_baseline:
+    captured_at: '2026-04-27'
+    metric: csv_magnet_total_links
+    value: 1116
+    method: csv_magnet_homepage_area_pages
+    reliability: medium
+    note: "Sondaggio CSV magnet via area pages. 6 aree tematiche (Scuole, Studenti, Personale, Valutazione, Edilizia, Adozioni). 1116 link CSV/XLS. Prefix: ALU=300, EDI=282, SCU=132. Nessuna sitemap disponibile."
   verdict: go
-  note: Portale HTML custom senza API catalog (CKAN/SDMX). Download CSV diretti nel
-    markup ma nessuna superficie inventariale strutturata osservabile via probe semplice.
-    Endpoint SPARQL come capacita secondaria.
+  note: Portale Ministero Istruzione — csv_magnet scan via area_pages (no sitemap).
+  html_portal:
+    topic_hint: istruzione
+    area_pages:
+      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole
+      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Studenti
+      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Personale%20Scuola
+      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Sistema%20Nazionale%20di%20Valutazione
+      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Edilizia%20Scolastica
+      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Adozioni%20libri%20di%20testo
+    delay_seconds: 0.3
   datasets_in_use:
   - mim-alunni-corso-eta
 dati_camera:

--- a/scripts/build_catalog_signals.py
+++ b/scripts/build_catalog_signals.py
@@ -49,6 +49,56 @@ def _classify(
             "suggested_action": "nessuna",
         }
 
+    # HTML portals: protocol=html non hanno rows, solo summary con csv_magnet stats.
+    # Intercetta qui prima del caso generico "ok" che si aspetta rows.
+    if protocol == "html":
+        summary = info.get("summary", {})
+        if summary.get("type") == "csv_magnet_error":
+            return {
+                "source": source_id,
+                "protocol": protocol,
+                "signal_type": "csv_magnet",
+                "result": "error",
+                "metric_value": None,
+                "detail": summary.get("message", "CSV magnet scan fallito."),
+                "suggested_action": "verificare raggiungibilità del portale",
+            }
+        if summary.get("type") == "csv_magnet":
+            total = summary.get("total_links_estimate") or summary.get("total_links_exact") or 0
+            by_fmt = summary.get("by_format", {})
+            fmt_str = ", ".join(f"{k} {v}" for k, v in sorted(by_fmt.items())) if by_fmt else "no format"
+            years_range = summary.get("years_range", [])
+            years_str = f", years {years_range[0]}-{years_range[1]}" if years_range else ""
+            prefixes = summary.get("prefix_matrix", {})
+            top_prefixes = sorted(prefixes.items(), key=lambda x: -x[1])[:5]
+            top_str = ", ".join(f"{p}={c}" for p, c in top_prefixes) if top_prefixes else ""
+            return {
+                "source": source_id,
+                "protocol": protocol,
+                "signal_type": "csv_magnet",
+                "result": "scan_completed",
+                "metric_value": total,
+                "detail": (
+                    f"{total} link data ({fmt_str}){years_str}"
+                    + (f" — top prefixes: {top_str}" if top_str else "")
+                ),
+                "prefix_matrix": prefixes,
+                "series": summary.get("series", {}),
+                "topics": summary.get("topics", {}),
+                "years_range": years_range,
+                "suggested_action": "catalog-watch-ready" if total > 10 else "low signal",
+            }
+        # html senza summary — non era nel run, skipped
+        return {
+            "source": source_id,
+            "protocol": protocol,
+            "signal_type": "no signal",
+            "result": "skipped",
+            "metric_value": None,
+            "detail": "Fonte html non inventariata in questo run (nessun summary csv_magnet).",
+            "suggested_action": "nessuna",
+        }
+
     # Errori/recovery di connettività sono coperti da radar_summary.
     # Il catalog_signals mantiene solo segnali inventariali e strutturali.
     if status == "error":

--- a/scripts/build_catalog_signals.py
+++ b/scripts/build_catalog_signals.py
@@ -17,6 +17,10 @@ DEFAULT_REPORT = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catal
 DEFAULT_OUT = REPO_ROOT / "data" / "catalog" / "catalog_signals.json"
 DEFAULT_REPORT_OUT = REPO_ROOT / "data" / "catalog" / "CATALOG_WATCH_REPORT.md"
 
+# Soglia minima di link per considerare un portale HTML "catalog-watch-ready".
+# Sotto questa soglia il signal è classificato come "low signal".
+_HTML_MIN_LINKS_FOR_WATCH = 10
+
 
 def _classify(
     source_id: str,
@@ -86,7 +90,7 @@ def _classify(
                 "series": summary.get("series", {}),
                 "topics": summary.get("topics", {}),
                 "years_range": years_range,
-                "suggested_action": "catalog-watch-ready" if total > 10 else "low signal",
+                "suggested_action": "catalog-watch-ready" if total > _HTML_MIN_LINKS_FOR_WATCH else "low signal",
             }
         # html senza summary — non era nel run, skipped
         return {

--- a/scripts/collectors/__init__.py
+++ b/scripts/collectors/__init__.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 from .base import CollectorResult
-from . import ckan, sdmx, sparql
+from . import ckan, sdmx, sparql, html
 
 COLLECTORS = {
     "ckan": ckan.collect,
     "sdmx": sdmx.collect,
     "sparql": sparql.collect,
+    "html": html.collect,
 }
 
 

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -19,6 +19,7 @@ Uso:
 
 from __future__ import annotations
 
+import random
 import re
 import time
 from typing import Any
@@ -162,8 +163,8 @@ def _scan_sitemap(
     """Scan un portale HTML via sitemap con quick sample.
 
     1. Parse sitemap → dataset page URLs
-    2. Campiona N pagine direttamente (no HEAD su tutte)
-    3. Probe HEAD + fetch su sample → estrae data link pattern
+    2. Campiona N pagine direttamente dal sitemap
+    3. Fetch sample → estrae data link pattern
     4. Stima total links dal sample
 
     Returns:
@@ -184,8 +185,7 @@ def _scan_sitemap(
 
     total_pages = len(dataset_page_urls)
 
-    # Sample N pages directly from sitemap (no HEAD on all)
-    import random
+    # Sample N pages directly from sitemap
     sampled = list(dataset_page_urls[:])  # copy
     random.shuffle(sampled)
     sample_size = min(sample_pages, len(sampled))
@@ -197,16 +197,11 @@ def _scan_sitemap(
 
     for page_url in sampled:
         time.sleep(page_delay)
-        # Probe HEAD first (fast)
-        head_resp, _ = observatory_ssl_fallback_get(page_url, timeout=5)
-        if not head_resp or head_resp.status_code != 200:
-            continue
-        pages_probed += 1
-
-        # Fetch full page to extract data links
+        # Fetch page directly — no separate HEAD probe (saves one round-trip)
         response, page_err = observatory_ssl_fallback_get(page_url, timeout=10)
         if page_err:
             continue
+        pages_probed += 1
         parser = _DataLinksParser(page_url, response.text)
         for link in parser.links:
             if link["url"] not in seen_data_urls:

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -1,0 +1,448 @@
+"""HTML portal collector — CSV Magnet scan for portals without structured API.
+
+Phase 2 della pipeline SO: quick survey per portali HTML senza API catalog.
+
+Strategia:
+  - Se sitemap_url: parse sitemap → campione N pagine → infer pattern → estimate
+  - Se area_pages: fetch diretto di ogni area page → link data diretti
+
+Output:
+  - rows: [{url, format, prefix, year_signal, topic, landing_page}] — per source-check
+  - summary: {total_links_estimate, by_format, prefix_matrix, series, topics, method}
+
+Non fa full crawl (191 pagine). Campiona per stimare.
+
+Uso:
+    from collectors.html import collect
+    result = collect("dati_salute", source_cfg, captured_at)
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+from urllib.parse import urljoin
+
+from .base import CollectorResult, observatory_ssl_fallback_get
+
+
+DATA_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls", ".ods", ".zip", ".xml", ".geojson"}
+
+# ─── HTML Parsing ──────────────────────────────────────────────────────────────
+
+
+class _DataLinksParser:
+    """Estrae link a file data da HTML già scaricato."""
+
+    def __init__(self, base_url: str, html: str):
+        from html.parser import HTMLParser
+
+        class Parser(HTMLParser):
+            def __init__(self):
+                super().__init__()
+                self.links: list[dict[str, str]] = []
+
+            def handle_starttag(self, tag, attrs):
+                if tag not in ("a", "area"):
+                    return
+                attrs_dict = dict(attrs)
+                href = attrs_dict.get("href", "") or attrs_dict.get("xlink:href", "")
+                if not href or href.startswith(("#", "mailto:", "tel:", "javascript:")):
+                    return
+                full_url = urljoin(base_url, href)
+                lower = full_url.lower()
+                fmt = None
+                for ext in DATA_EXTENSIONS:
+                    if ext in lower:
+                        fmt = ext.lstrip(".").upper()
+                        if fmt == "GEOJSON":
+                            fmt = "GEOJSON"
+                        break
+                if not fmt:
+                    return
+                title = (attrs_dict.get("aria-label") or attrs_dict.get("title") or "").strip()
+                self.links.append({"url": full_url, "format": fmt, "title": title})
+
+        parser = Parser()
+        try:
+            parser.feed(html)
+        except Exception:
+            pass
+        self.links = parser.links
+
+
+# ─── URL Analysis ─────────────────────────────────────────────────────────────
+
+
+_PREFIX_RE = re.compile(r"^([A-Z0-9]{2,8})")
+_YEAR_RE = re.compile(r"(20[12]\d)")
+
+
+def _extract_prefix(filename: str) -> str:
+    """Estrae prefisso categoriale dal filename (prima underscore o run di maiuscole)."""
+    # FRM_FARMA_5_20260427.csv → FRM
+    # SCUANAGRAFESTAT202526 → SCUANAGRAFESTAT
+    if "_" in filename:
+        return filename.split("_")[0]
+    m = _PREFIX_RE.match(filename)
+    if m:
+        return m.group(1)
+    return filename[:6]
+
+
+def _extract_years(filename: str) -> list[int]:
+    """Estrae tutti i year signal (20xx) presenti nel filename."""
+    return [int(y) for y in _YEAR_RE.findall(filename)]
+
+
+_TOPIC_SIGNALS: dict[str, list[str]] = {
+    "sanita": ["salute", "ospedal", "medic", "farmaci", "dispositivi", "serd", "dsm"],
+    "trasporti": ["trasport", "mobilita", "traffico", "aeroport", "porto"],
+    "ambiente": ["ambiente", "rischio", "dissesto", "acqua", "rifiuti", "energia"],
+    "economia": ["economia", "lavoro", "imprese", "commercio", "mercato"],
+    "istruzione": ["scuola", "universita", "istruzione", "alunni", "studenti", "personale"],
+    "cultura": ["cultura", "museo", "patrimonio", "turismo"],
+    "territorio": ["territorio", "urban", "comune", "regione", "provincia", "catasto"],
+    "agricoltura": ["agricoltura", "agri", "allevamento", "produzione"],
+    "finanza": ["bilancio", "finanza", "tesoro", "preconsuntivo"],
+}
+
+
+def _guess_topic(url: str, topic_hint: str | None) -> str:
+    if topic_hint:
+        return topic_hint
+    url_lower = url.lower()
+    for topic, signals in _TOPIC_SIGNALS.items():
+        if any(s in url_lower for s in signals):
+            return topic
+    return "unknown"
+
+
+# ─── Sitemap Helper ───────────────────────────────────────────────────────────
+
+
+def _fetch_sitemap(sitemap_url: str, timeout: int = 15) -> tuple[list[str] | None, str | None]:
+    """Fetch e parse sitemap XML, ritorna lista di <loc> URL."""
+    import xml.etree.ElementTree as ET
+
+    try:
+        response, exc = observatory_ssl_fallback_get(sitemap_url, timeout=timeout)
+        if response is None:
+            return None, str(exc)
+        if response.status_code >= 400:
+            return None, f"HTTP {response.status_code}"
+        root = ET.fromstring(response.text)
+        ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+        urls = []
+        for url_elem in root.findall("sm:url", ns):
+            loc = url_elem.find("sm:loc", ns)
+            if loc is not None and loc.text:
+                urls.append(loc.text.strip())
+        if not urls:
+            for url_elem in root.findall(".//url"):
+                loc = url_elem.find("loc")
+                if loc is not None and loc.text:
+                    urls.append(loc.text.strip())
+        return urls, None
+    except Exception as e:
+        return None, str(e)
+
+
+# ─── Core Scan ───────────────────────────────────────────────────────────────
+
+
+def _scan_sitemap(
+    sitemap_url: str,
+    topic_hint: str | None,
+    *,
+    sample_pages: int = 10,
+    page_delay: float = 0.2,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Scan un portale HTML via sitemap con quick sample.
+
+    1. Parse sitemap → dataset page URLs
+    2. Campiona N pagine direttamente (no HEAD su tutte)
+    3. Probe HEAD + fetch su sample → estrae data link pattern
+    4. Stima total links dal sample
+
+    Returns:
+        summary dict, rows list
+    """
+    sitemap_urls, sitemap_err = _fetch_sitemap(sitemap_url)
+    if sitemap_err:
+        return {"error": f"sitemap failed: {sitemap_err}"}, []
+
+    dataset_signals = ("/it/dataset/", "/dataset/", "/dati/", "/open-data/", "/opendata/", "/catalogo/")
+    dataset_page_urls = [
+        u for u in sitemap_urls
+        if any(s in u.lower() for s in dataset_signals)
+    ]
+
+    if not dataset_page_urls:
+        return {"error": "no dataset pages found in sitemap"}, []
+
+    total_pages = len(dataset_page_urls)
+
+    # Sample N pages directly from sitemap (no HEAD on all)
+    import random
+    sampled = list(dataset_page_urls[:])  # copy
+    random.shuffle(sampled)
+    sample_size = min(sample_pages, len(sampled))
+    sampled = sampled[:sample_size]
+
+    all_data_links: list[dict[str, str]] = []
+    seen_data_urls: set[str] = set()
+    pages_probed = 0
+
+    for page_url in sampled:
+        time.sleep(page_delay)
+        # Probe HEAD first (fast)
+        head_resp, _ = observatory_ssl_fallback_get(page_url, timeout=5)
+        if not head_resp or head_resp.status_code != 200:
+            continue
+        pages_probed += 1
+
+        # Fetch full page to extract data links
+        response, page_err = observatory_ssl_fallback_get(page_url, timeout=10)
+        if page_err:
+            continue
+        parser = _DataLinksParser(page_url, response.text)
+        for link in parser.links:
+            if link["url"] not in seen_data_urls:
+                seen_data_urls.add(link["url"])
+                all_data_links.append(link)
+
+    # Build prefix/format stats from sample
+    prefix_matrix: dict[str, int] = {}
+    by_format: dict[str, int] = {}
+    years_set: set[int] = set()
+    series: dict[str, dict[str, Any]] = {}
+
+    for link in all_data_links:
+        url = link["url"]
+        filename = url.split("/")[-1].rsplit(".", 1)[0]
+        prefix = _extract_prefix(filename)
+        prefix_matrix[prefix] = prefix_matrix.get(prefix, 0) + 1
+
+        fmt = link.get("format", "?")
+        by_format[fmt] = by_format.get(fmt, 0) + 1
+
+        years = _extract_years(filename)
+        for y in years:
+            years_set.add(y)
+
+        if prefix not in series:
+            series[prefix] = {"years": set(), "count": 0, "sample": filename}
+        series[prefix]["count"] += 1
+        for y in years:
+            series[prefix]["years"].add(y)
+
+    # Estimate total from sample
+    links_per_page = len(all_data_links) / pages_probed if pages_probed > 0 else 0
+    estimated_total = int(links_per_page * total_pages)
+
+    series_serializable = {}
+    for prefix, info in series.items():
+        series_serializable[prefix] = {
+            "years": sorted(list(info["years"])),
+            "count": info["count"],
+            "sample": info["sample"],
+        }
+
+    # Rows: uno per data link URL — per source-check
+    rows = []
+    for link in all_data_links:
+        url = link["url"]
+        filename = url.split("/")[-1].rsplit(".", 1)[0]
+        prefix = _extract_prefix(filename)
+        years = _extract_years(filename)
+        rows.append({
+            "url": url,
+            "format": link.get("format", "?"),
+            "prefix": prefix,
+            "year_signal": years[0] if years else None,
+            "topic": _guess_topic(url, topic_hint),
+        })
+
+    summary = {
+        "total_links_estimate": estimated_total,
+        "total_pages_in_sitemap": total_pages,
+        "pages_probed": pages_probed,
+        "pages_sampled": sample_size,
+        "links_found_in_sample": len(all_data_links),
+        "links_per_page_estimate": round(links_per_page, 2),
+        "by_format": by_format,
+        "prefix_matrix": prefix_matrix,
+        "series": series_serializable,
+        "years_range": [min(years_set), max(years_set)] if years_set else [],
+        "topics": {_guess_topic(link["url"], topic_hint): 1 for link in all_data_links},
+        "method": "csv_magnet_sitemap_sample",
+    }
+
+    return summary, rows
+
+
+def _scan_area_pages(
+    area_pages: list[str],
+    topic_hint: str | None,
+    *,
+    page_delay: float = 0.2,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Scan portale HTML via area_pages (nessun second-level crawl).
+
+    Fetch ogni area page direttamente → estrae tutti i link data.
+    Tutto il contenido è sulla pagina area, no pagine figlie.
+
+    Returns:
+        summary dict, rows list
+    """
+    all_data_links: list[dict[str, str]] = []
+    seen_data_urls: set[str] = set()
+
+    for area_url in area_pages:
+        time.sleep(page_delay)
+        response, err = observatory_ssl_fallback_get(area_url, timeout=15)
+        if err:
+            continue
+        parser = _DataLinksParser(area_url, response.text)
+        for link in parser.links:
+            if link["url"] not in seen_data_urls:
+                seen_data_urls.add(link["url"])
+                all_data_links.append(link)
+
+    # Stats
+    prefix_matrix: dict[str, int] = {}
+    by_format: dict[str, int] = {}
+    years_set: set[int] = set()
+    series: dict[str, dict[str, Any]] = {}
+
+    for link in all_data_links:
+        url = link["url"]
+        filename = url.split("/")[-1].rsplit(".", 1)[0]
+        prefix = _extract_prefix(filename)
+        prefix_matrix[prefix] = prefix_matrix.get(prefix, 0) + 1
+
+        fmt = link.get("format", "?")
+        by_format[fmt] = by_format.get(fmt, 0) + 1
+
+        years = _extract_years(filename)
+        for y in years:
+            years_set.add(y)
+
+        if prefix not in series:
+            series[prefix] = {"years": set(), "count": 0, "sample": filename}
+        series[prefix]["count"] += 1
+        for y in years:
+            series[prefix]["years"].add(y)
+
+    series_serializable = {}
+    for prefix, info in series.items():
+        series_serializable[prefix] = {
+            "years": sorted(list(info["years"])),
+            "count": info["count"],
+            "sample": info["sample"],
+        }
+
+    # Rows for source-check
+    rows = []
+    for link in all_data_links:
+        url = link["url"]
+        filename = url.split("/")[-1].rsplit(".", 1)[0]
+        prefix = _extract_prefix(filename)
+        years = _extract_years(filename)
+        rows.append({
+            "url": url,
+            "format": link.get("format", "?"),
+            "prefix": prefix,
+            "year_signal": years[0] if years else None,
+            "topic": _guess_topic(url, topic_hint),
+        })
+
+    summary = {
+        "total_links_exact": len(all_data_links),
+        "area_pages_scanned": len(area_pages),
+        "by_format": by_format,
+        "prefix_matrix": prefix_matrix,
+        "series": series_serializable,
+        "years_range": [min(years_set), max(years_set)] if years_set else [],
+        "topics": {_guess_topic(link["url"], topic_hint): 1 for link in all_data_links},
+        "method": "csv_magnet_area_pages_direct",
+    }
+
+    return summary, rows
+
+
+# ─── Collector Interface ──────────────────────────────────────────────────────
+
+
+def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> CollectorResult:
+    """Collect HTML portal stats via CSV magnet quick survey.
+
+    Strategia:
+      - sitemap_url → _scan_sitemap (sample pages, estimate)
+      - area_pages → _scan_area_pages (full fetch, exact count)
+      - homepage only → quick probe only
+
+    Returns:
+        CollectorResult with rows (data link URLs) and summary (stats).
+    """
+    base_url = source_cfg.get("base_url", "")
+    if not base_url:
+        return CollectorResult(
+            rows=[],
+            summary={"error": "no base_url configured"},
+        )
+
+    html_portal_cfg = source_cfg.get("html_portal", {})
+    sitemap_url = html_portal_cfg.get("sitemap_url")
+    area_pages = html_portal_cfg.get("area_pages", [])
+    topic_hint = html_portal_cfg.get("topic_hint")
+    delay = html_portal_cfg.get("delay_seconds", 0.2)
+
+    if sitemap_url:
+        summary, rows = _scan_sitemap(
+            sitemap_url,
+            topic_hint,
+            sample_pages=10,
+            page_delay=delay,
+        )
+    elif area_pages:
+        summary, rows = _scan_area_pages(
+            area_pages,
+            topic_hint,
+            page_delay=delay,
+        )
+    else:
+        # Homepage only probe
+        response, fetch_err = observatory_ssl_fallback_get(base_url, timeout=15)
+        if fetch_err:
+            return CollectorResult(
+                rows=[],
+                summary={"type": "csv_magnet_error", "message": fetch_err},
+            )
+        parser = _DataLinksParser(base_url, response.text)
+        rows = []
+        for link in parser.links:
+            url = link["url"]
+            filename = url.split("/")[-1].rsplit(".", 1)[0]
+            years = _extract_years(filename)
+            rows.append({
+                "url": url,
+                "format": link.get("format", "?"),
+                "prefix": _extract_prefix(filename),
+                "year_signal": years[0] if years else None,
+                "topic": _guess_topic(url, topic_hint),
+            })
+        summary = {
+            "total_links_exact": len(rows),
+            "method": "csv_magnet_homepage_only",
+        }
+
+    if "error" in summary:
+        return CollectorResult(rows=[], summary={**summary, "source_id": source_id})
+
+    summary["type"] = "csv_magnet"
+    summary["source_id"] = source_id
+
+    return CollectorResult(rows=rows, summary=summary)

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import random
 import re
 import time
+from collections import Counter
 from typing import Any
 from urllib.parse import urljoin
 
@@ -271,7 +272,7 @@ def _scan_sitemap(
         "prefix_matrix": prefix_matrix,
         "series": series_serializable,
         "years_range": [min(years_set), max(years_set)] if years_set else [],
-        "topics": {_guess_topic(link["url"], topic_hint): 1 for link in all_data_links},
+        "topics": dict(Counter(_guess_topic(link["url"], topic_hint) for link in all_data_links)),
         "method": "csv_magnet_sitemap_sample",
     }
 
@@ -361,7 +362,7 @@ def _scan_area_pages(
         "prefix_matrix": prefix_matrix,
         "series": series_serializable,
         "years_range": [min(years_set), max(years_set)] if years_set else [],
-        "topics": {_guess_topic(link["url"], topic_hint): 1 for link in all_data_links},
+        "topics": dict(Counter(_guess_topic(link["url"], topic_hint) for link in all_data_links)),
         "method": "csv_magnet_area_pages_direct",
     }
 
@@ -435,7 +436,10 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
         }
 
     if "error" in summary:
-        return CollectorResult(rows=[], summary={**summary, "source_id": source_id})
+        return CollectorResult(
+            rows=[],
+            summary={"type": "csv_magnet_error", "message": summary["error"], "source_id": source_id},
+        )
 
     summary["type"] = "csv_magnet"
     summary["source_id"] = source_id

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -171,7 +171,7 @@ def _scan_sitemap(
         summary dict, rows list
     """
     sitemap_urls, sitemap_err = _fetch_sitemap(sitemap_url)
-    if sitemap_err:
+    if sitemap_err or sitemap_urls is None:
         return {"error": f"sitemap failed: {sitemap_err}"}, []
 
     dataset_signals = ("/it/dataset/", "/dataset/", "/dati/", "/open-data/", "/opendata/", "/catalogo/")
@@ -199,7 +199,7 @@ def _scan_sitemap(
         time.sleep(page_delay)
         # Fetch page directly — no separate HEAD probe (saves one round-trip)
         response, page_err = observatory_ssl_fallback_get(page_url, timeout=10)
-        if page_err:
+        if page_err or response is None:
             continue
         pages_probed += 1
         parser = _DataLinksParser(page_url, response.text)
@@ -298,7 +298,7 @@ def _scan_area_pages(
     for area_url in area_pages:
         time.sleep(page_delay)
         response, err = observatory_ssl_fallback_get(area_url, timeout=15)
-        if err:
+        if err or response is None:
             continue
         parser = _DataLinksParser(area_url, response.text)
         for link in parser.links:
@@ -411,7 +411,7 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
     else:
         # Homepage only probe
         response, fetch_err = observatory_ssl_fallback_get(base_url, timeout=15)
-        if fetch_err:
+        if fetch_err or response is None:
             return CollectorResult(
                 rows=[],
                 summary={"type": "csv_magnet_error", "message": fetch_err},

--- a/tests/test_build_catalog_signals.py
+++ b/tests/test_build_catalog_signals.py
@@ -119,6 +119,62 @@ def test_non_inventariabile_regression_if_was_ok():
     assert sig["result"] == "regressione"
 
 
+# --- html / csv_magnet ---
+
+def _html_csv_magnet(total: int) -> dict:
+    return {
+        "status": "ok",
+        "protocol": "html",
+        "source_id": "dati_salute",
+        "summary": {
+            "type": "csv_magnet",
+            "total_links_estimate": total,
+            "by_format": {"CSV": 6, "JSON": 2, "XML": 3, "ZIP": 4},
+            "prefix_matrix": {"FRM": 3, "C": 6},
+            "years_range": [2022, 2026],
+            "topics": {"sanita": 1},
+        },
+    }
+
+
+def test_html_csv_magnet_high_signal():
+    sig = _classify("dati_salute", _html_csv_magnet(286), None)
+    assert sig["signal_type"] == "csv_magnet"
+    assert sig["result"] == "scan_completed"
+    assert sig["metric_value"] == 286
+    assert sig["suggested_action"] == "catalog-watch-ready"
+    assert "prefix_matrix" in sig
+    assert "series" in sig
+
+
+def test_html_csv_magnet_low_signal():
+    sig = _classify("dati_salute", _html_csv_magnet(5), None)
+    assert sig["signal_type"] == "csv_magnet"
+    assert sig["result"] == "scan_completed"
+    assert sig["metric_value"] == 5
+    assert sig["suggested_action"] == "low signal"
+
+
+def test_html_csv_magnet_error():
+    info = {
+        "status": "ok",
+        "protocol": "html",
+        "source_id": "dati_salute",
+        "summary": {"type": "csv_magnet_error", "message": "HTTP 404"},
+    }
+    sig = _classify("dati_salute", info, None)
+    assert sig["signal_type"] == "csv_magnet"
+    assert sig["result"] == "error"
+    assert sig["suggested_action"] == "verificare raggiungibilità del portale"
+
+
+def test_html_no_summary_skipped():
+    info = {"status": "ok", "protocol": "html", "source_id": "dati_salute"}
+    sig = _classify("dati_salute", info, None)
+    assert sig["signal_type"] == "no signal"
+    assert sig["result"] == "skipped"
+
+
 # --- build_signals integration ---
 
 def test_build_signals_structure():


### PR DESCRIPTION
## Motivation

Porta i portali HTML (`dati_salute`, `mim_opendata`) nella pipeline SO come `protocol: html`, tramite un approccio **csv_magnet** — quick survey senza full crawl.

## Cosa cambia

### `scripts/collectors/html.py` (nuovo)
- `_scan_sitemap()`: parse sitemap → campiona N pagine → estrae data link pattern → stima totali
- `_scan_area_pages()`: fetch diretto aree tematiche → link data esatti
- `collect()`: restituisce `CollectorResult(rows=[], summary={csv_magnet stats})`
- Output: `prefix_matrix`, `series` (anni per prefisso), `topics`, `years_range`, `by_format`

### `scripts/collectors/__init__.py`
- Aggiunge `html.collect` al dispatch `COLLECTORS`

### `scripts/build_catalog_signals.py`
- Branch `protocol == "html"` in `_classify()` → segnale `csv_magnet`
- Costante `_HTML_MIN_LINKS_FOR_WATCH = 10` (soglia per `catalog-watch-ready`)

### `data/radar/sources_registry.yaml`
- `dati_salute`: `observation_mode: catalog-watch`, `html_portal: {sitemap_url, topic_hint: sanita}`
- `mim_opendata`: `observation_mode: catalog-watch`, `html_portal: {area_pages: [...], topic_hint: istruzione}`

### `tests/test_build_catalog_signals.py`
- 4 test per branch HTML: `high_signal`, `low_signal`, `error`, `skipped`

## Risultati test end-to-end

| Source | Tempo | Rows | Link totali | Years |
|---|---|---|---|---|
| `dati_salute` | ~12s | 17 (campione) | ~210 stimati | 2020-2024 |
| `mim_opendata` | ~8s | 1116 (esatti) | 1116 | 2015-2025 |

## Schema parquet

Le righe HTML entrano nel parquet `catalog_inventory_latest` con schema misto (DuckDB gestisce). `bulk_source_check` le esclude automaticamente (no `landing_page`/`distribution_url`/`title`).

## Note

- Source-check Layer 3 per HTML non implementato (le righe hanno `url` direttamente, non `landing_page`); lo scope era portare i portali nella pipeline come csv_magnet signal
- I test esistenti (131) passano tutti
- Nessuna modifica ai workflow GitHub — i due source sono già `catalog-watch` e verranno raccolti automaticamente alla prossima run schedulata (lun 03:15)