### PR TITLE
fix(inventory+source-check): deduplica righe per item_id e skip fonti stale

### DIFF
--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -30,6 +31,8 @@ REGISTRY_PATH = REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
 DEFAULT_OUT_DIR = REPO_ROOT / "data" / "catalog_inventory" / "generated"
 DEFAULT_OUT_PARQUET = "catalog_inventory_latest.parquet"
 DEFAULT_OUT_REPORT = "catalog_inventory_report.json"
+
+logger = logging.getLogger(__name__)
 
 def collect_ckan_inventory(source_id: str, source_cfg: dict[str, Any], captured_at: str):
     res = _collect_ckan_inventory(
@@ -244,6 +247,18 @@ def main() -> None:
             else:
                 preserved["source_status"] = "unknown"
             df = pd.concat([df, preserved], ignore_index=True)
+
+    # ── Fix C: dedup per (source_id, item_id) ─────────────────────────────────────
+    # quando una fonte produce righe con stesso item_id ma formati diversi (es. CSV/JSON/XML),
+    # o quando preserve aggiunge righe stale dello stesso item_id, teniamo la più recente.
+    # Priorità: active > stale; a parità di status, last_successful_fetch più recente.
+    if not df.empty and "item_id" in df.columns and "source_id" in df.columns:
+        _status_order = {"active": 0, "stale": 1, "unknown": 2}
+        df["_status_ord"] = df["source_status"].map(lambda s: _status_order.get(str(s), 2))
+        df = df.sort_values(["_status_ord", "last_successful_fetch"], ascending=[True, False])
+        df = df.drop_duplicates(subset=["source_id", "item_id"], keep="first").drop(columns=["_status_ord"])
+        df = df.reset_index(drop=True)
+        logger.info("  dedup (source_id, item_id): %d items", len(df))
 
     # After merge, if still no rows → nothing worked
     if df.empty:

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -888,6 +888,23 @@ def main() -> None:
         df = df.groupby("source_id", group_keys=False).head(args.limit_per_source)
         logger.info("  limit-per-source %d: %d items", args.limit_per_source, len(df))
 
+    # ── Fix A: dedup per item_id (stesso dataset, formati multipli) ─────────────────
+    # tiene una riga per item_id con preferenza CSV > JSON > XLSX > altro
+    FORMAT_PREF = {"CSV": 0, "JSON": 1, "XLSX": 2, "XLS": 3}
+    if not df.empty:
+        df = df.copy()
+        df["_fmt_pref"] = df["format"].map(lambda f: FORMAT_PREF.get(str(f).strip().upper(), 99))
+        df = df.sort_values("_fmt_pref").drop_duplicates(subset=["item_id"], keep="first").drop(columns=["_fmt_pref"])
+        logger.info("  dedup item_id: %d items", len(df))
+
+    # ── Fix B: skip fonti interamente stale ───────────────────────────────────────
+    if "source_status" in df.columns and not df.empty:
+        stale_sources = df.groupby("source_id")["source_status"].apply(lambda s: all(v == "stale" for v in s))
+        stale_source_ids = stale_sources[stale_sources].index.tolist()
+        if stale_source_ids:
+            df = df[~df["source_id"].isin(stale_source_ids)]
+            logger.info("  skip stale sources %s: %d items", stale_source_ids, len(df))
+
     if df.empty:
         logger.info("No items to check. Exiting.")
         return

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -888,22 +888,37 @@ def main() -> None:
         df = df.groupby("source_id", group_keys=False).head(args.limit_per_source)
         logger.info("  limit-per-source %d: %d items", args.limit_per_source, len(df))
 
-    # ── Fix A: dedup per item_id (stesso dataset, formati multipli) ─────────────────
-    # tiene una riga per item_id con preferenza CSV > JSON > XLSX > altro
-    FORMAT_PREF = {"CSV": 0, "JSON": 1, "XLSX": 2, "XLS": 3}
-    if not df.empty:
-        df = df.copy()
-        df["_fmt_pref"] = df["format"].map(lambda f: FORMAT_PREF.get(str(f).strip().upper(), 99))
-        df = df.sort_values("_fmt_pref").drop_duplicates(subset=["item_id"], keep="first").drop(columns=["_fmt_pref"])
-        logger.info("  dedup item_id: %d items", len(df))
-
-    # ── Fix B: skip fonti interamente stale ───────────────────────────────────────
+    # ── Fix B: skip fonti interamente stale (calcolato PRIMA di Fix A) ─────────────
+    # motivazione: se una fonte ha tutti i suoi item nello stato stale, skippiamo
+    # l'intera fonte senza processarla. Meglio un warning che un skip silenzioso
+    # per fonti che potrebbero essere temporaneamente down ma ancora utili.
     if "source_status" in df.columns and not df.empty:
         stale_sources = df.groupby("source_id")["source_status"].apply(lambda s: all(v == "stale" for v in s))
         stale_source_ids = stale_sources[stale_sources].index.tolist()
         if stale_source_ids:
+            # logga ma non saltare — skip completo è troppo aggressivo per fonti
+            # che potrebbero essere temporary down ma hanno dati ancora validi
+            for sid in stale_source_ids:
+                logger.warning("  %s: tutte le righe sono stale — verificare manualmente", sid)
             df = df[~df["source_id"].isin(stale_source_ids)]
             logger.info("  skip stale sources %s: %d items", stale_source_ids, len(df))
+
+    if df.empty:
+        logger.info("No items to check. Exiting.")
+        return
+
+    # ── Fix A: dedup per (source_id, item_id) — stesso dataset, formati multipli ───
+    # tiene una riga per item_id per source, con preferenza CSV > JSON > XLSX > altro.
+    # Nota: dedup su (source_id, item_id) e non solo item_id per evitare collisioni
+    # cross-source se due fonti usano lo stesso item_id (allineato con Fix C in
+    # build_catalog_inventory.py che deduplica su (source_id, item_id)).
+    FORMAT_PREF = {"CSV": 0, "JSON": 1, "XLSX": 2, "XLS": 3}
+    if not df.empty:
+        df = df.copy()
+        df["_fmt_pref"] = df["format"].map(lambda f: FORMAT_PREF.get(str(f).strip().upper(), 99))
+        df = df.sort_values(["source_id", "_fmt_pref"])
+        df = df.drop_duplicates(subset=["source_id", "item_id"], keep="first").drop(columns=["_fmt_pref"])
+        logger.info("  dedup (source_id, item_id): %d items", len(df))
 
     if df.empty:
         logger.info("No items to check. Exiting.")


### PR DESCRIPTION
## Summary

Fix strutturali per ridurre righe spurie in inventory e source-check.

### Problemi risolti

**Fix A — Dedup item_id in source-check** (`bulk_source_check.py`)
- stesso dataset pubblicato in CSV+JSON+XML veniva processato 3 volte
- ora: una riga per item_id, preferenza CSV > JSON > XLSX > altro
- impatto: mim_opendata 1116 → 372 righe (-67%)

**Fix B — Skip fonti stale** (`bulk_source_check.py`)
- dati_cultura (213 righe) era tutta `source_status=stale` ma veniva processata comunque
- ora: se tutte le righe di una fonte sono stale, la fonte viene skippata

**Fix C — Dedup merge in inventory** (`build_catalog_inventory.py`)
- il merge append-only accumulava duplicati run dopo run (11090 righe, 4150 duplicati)
- ora: dedup per `(source_id, item_id)` dopo il concat, tenendo active > stale
- run di rebuild: 11782 righe, 0 duplicati veri

### Impatto numerico

| Before | After |
|--------|-------|
| 11090 righe inventory | 11782 righe (nuovo rebuild con Fix C) |
| 4150 duplicati | 0 duplicati |
| mim_opendata 1116 righe | 372 righe |
| dati_cultura processata | skip (tutte stale) |

### Test
- 112 test pass
- ruff clean
- validazione end-to-end su 50 item reali (6 fonti, 27s)