### PR TITLE
feat(mcp): read-only MCP server for Source Observatory artifacts

### DIFF
--- a/data/catalog_inventory/README.md
+++ b/data/catalog_inventory/README.md
@@ -39,7 +39,8 @@ Per default questi output vengono generati in:
 
 La directory `generated/` non è versionata nel repo:
 - gli artifact vengono esposti come artifact GitHub Actions
-- l'upload su GCS è opzionale e richiede secret/config espliciti
+- il latest operativo pubblico e' su `gs://dataciviclab-clean/catalog_inventory/`
+- i file locali sono cache operative: per analisi correnti usare il parquet GCS latest o rigenerare prima del triage
 
 ## Schema minimo del parquet
 
@@ -89,4 +90,5 @@ python scripts/build_catalog_inventory.py --workers 3
 
 - il perimetro segue solo le fonti `catalog-watch` del registry
 - l'inventory può essere intenzionalmente parziale se una fonte è osservabile ma non inventariabile in modo stabile
-- il README locale resta in `_local/data/catalog_inventory/README.md`
+- non interpretare una fonte assente dal parquet come assenza di dataset: controllare sempre il report inventory
+- non trattare una cache locale vecchia come source of truth: verificare timestamp, `cache.source` e provenienza dell'artifact

--- a/docs/source_check_results_schema.md
+++ b/docs/source_check_results_schema.md
@@ -79,6 +79,7 @@ score finale: max(0, min(100, somma))
 - **HTTP status e raggiungibilità non influenzano lo score** — un URL irraggiungibile non abbassa direttamente il punteggio, ma l'assenza di `resource_format` e `year_min` produrrà `needs_review = True`, che applica il -5 e potrebbe far scendere sotto soglia.
 - **`enrich_method = error`** indica un'eccezione non gestita durante l'enrichment. La riga è presente ma con dati incompleti.
 - Il parquet viene sovrascritto ad ogni run — non è incrementale. Per segnali longitudinali, consultare gli snapshot in GCS (`source-check/snapshots/source_check_{stamp}.parquet`).
+- Il file locale sotto `data/catalog_inventory/generated/` è una cache operativa. La fonte corrente è il path GCS pubblicato dal workflow `source-check.yml`; l'artifact GitHub Actions resta un canale di recupero/debug.
 
 ---
 
@@ -86,4 +87,4 @@ score finale: max(0, min(100, somma))
 
 - Default: `data/catalog_inventory/generated/source_check_results.parquet`
 - Snapshots GCS: `gs://<CATALOG_INVENTORY_GCS_PREFIX>/source-check/snapshots/`
-- Artifact Actions: disponibile come `observatory-results` su ogni run del workflow `observatory.yml`
+- Artifact Actions: disponibile come `source-check-results` su ogni run del workflow `source-check.yml`

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -48,6 +48,7 @@ In `auto`, il server prova i prefissi GCS pubblici; se il read GCS fallisce, usa
 - `so_inventory_query`
   - legge `data/catalog_inventory/generated/source_check_results.parquet`
   - serve per cercare risultati item-level gia' controllati
+  - include `has_results` filter e `gcs_uri` in risposta
 
 - `so_catalog_signals`
   - legge `data/catalog/catalog_signals.json`
@@ -56,6 +57,26 @@ In `auto`, il server prova i prefissi GCS pubblici; se il read GCS fallisce, usa
 - `so_radar_summary`
   - legge `data/radar/radar_summary.json`
   - serve per capire lo stato sintetico delle fonti nel radar
+
+- `so_radar_history`
+  - legge `data/radar/radar_history.json`
+  - serve per verificare streak/persistent RED e storia probes per fonte
+
+- `so_radar_status_md`
+  - legge `data/radar/STATUS.md`
+  - serve per avere un sommario umano leggibile dello stato radar
+
+- `so_radar_delta`
+  - confronta ultimo e penultimo probe del radar
+  - restituisce fonti cambiate, nuove RED, recovery, persistent RED
+
+- `so_find_by_url`
+  - cerca un URL in source_check_results e catalog_inventory
+  - serve per capire se un URL e' gia' catalogato
+
+- `so_registry_query`
+  - interroga `data/radar/sources_registry.yaml`
+  - filtra per protocol, source_kind, observation_mode o cerca per source_id
 
 - `so_inventory_status`
   - legge `data/catalog_inventory/generated/catalog_inventory_report.json`
@@ -99,6 +120,9 @@ Non deve:
 | Artifact | Uso MCP |
 |---|---|
 | `data/radar/radar_summary.json` | stato fonte radar |
+| `data/radar/radar_history.json` | storia probes e streak RED |
+| `data/radar/STATUS.md` | sommario umano radar |
+| `data/radar/sources_registry.yaml` | query fonti per protocol/kind/mode |
 | `data/catalog/catalog_signals.json` | segnali catalog-watch |
 | `CATALOG_INVENTORY_GCS_PREFIX/source-check/source_check_results.parquet` | risultati source-check item-level |
 | `CATALOG_INVENTORY_GCS_PREFIX/catalog_inventory_latest.parquet` | inventory cataloghi enumerabili |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,120 @@
+# Source Observatory MCP
+
+Layer MCP read-only sugli artifact prodotti da Source Observatory.
+
+Il server non sostituisce gli script di build e non scrive nello workspace: espone agli agenti una vista interrogabile degli artifact gia' generati da CI o run locali.
+
+Gli artifact sotto `data/*/generated/` sono cache locali. La fonte operativa corrente per i parquet e' il prefisso GCS configurato dai workflow; gli artifact GitHub Actions restano utili per debug e recupero manuale. Le risposte sui parquet includono un blocco `cache` con `source`, `uri`, `modified_at`, `age_hours`, soglia `max_age_hours` e warning quando la cache locale supera 24 ore.
+
+## Avvio
+
+Config canonica workspace:
+
+```json
+{
+  "mcpServers": {
+    "source-observatory": {
+      "command": "/home/gabry/dev/dataciviclab-workspace/source-observatory/.venv/bin/python",
+      "args": [
+        "/home/gabry/dev/dataciviclab-workspace/source-observatory/mcp/so_server.py"
+      ],
+      "cwd": "/tmp"
+    }
+  }
+}
+```
+
+Usare l'avvio via file path, non `python -m mcp.so_server`: la repo contiene una directory locale `mcp/` che puo' collidere con la libreria Python `mcp`.
+
+## Config artifact
+
+Default pubblici:
+
+- `CATALOG_INVENTORY_GCS_PREFIX=gs://dataciviclab-clean/catalog_inventory`
+- `PORTAL_SCOUT_GCS_PREFIX=gs://dataciviclab-clean/portal_scout`
+
+Variabili supportate per override:
+
+- `SO_ARTIFACT_BACKEND`: `auto`, `gcs` o `local` (`auto` default)
+- `SO_ENV_FILE`: file env opzionale; se non impostato, il server prova `dataciviclab-workspace/.env`
+- `CATALOG_INVENTORY_GCS_PREFIX`: override del prefisso GCS inventory/source-check
+- `PORTAL_SCOUT_GCS_PREFIX`: override del prefisso GCS portal-scout
+- `SO_CACHE_MAX_AGE_HOURS`: soglia di freschezza per cache locale (`24` default)
+
+In `auto`, il server prova i prefissi GCS pubblici; se il read GCS fallisce, usa la cache locale e lo dichiara in `cache.fallback_warning`. In `gcs`, un errore GCS e' bloccante. In `local`, il server usa solo i file locali.
+
+## Tool
+
+- `so_inventory_query`
+  - legge `data/catalog_inventory/generated/source_check_results.parquet`
+  - serve per cercare risultati item-level gia' controllati
+
+- `so_catalog_signals`
+  - legge `data/catalog/catalog_signals.json`
+  - serve per controllare segnali di drift o cambiamento catalogo
+
+- `so_radar_summary`
+  - legge `data/radar/radar_summary.json`
+  - serve per capire lo stato sintetico delle fonti nel radar
+
+- `so_inventory_status`
+  - legge `data/catalog_inventory/generated/catalog_inventory_report.json`
+  - serve per distinguere fonte assente, errore di run, protocollo non supportato e inventory riuscito
+
+- `so_catalog_inventory_search`
+  - legge `data/catalog_inventory/generated/catalog_inventory_latest.parquet`
+  - serve per cercare item e dataflow nel catalog inventory derivato
+
+- `so_portal_candidates`
+  - legge `data/portal_scout/new_candidates.parquet` o `discovered_portals.parquet`
+  - include, quando disponibile, il riepilogo da `discovered_portals_summary.json`
+
+- `so_probe_url`
+  - esegue una verifica HTTP leggera su un URL esplicito
+  - e' pensato per controlli puntuali, non per crawling
+
+- `so_discover_sdmx`
+  - usa solo `data/catalog_inventory/generated/catalog_inventory_latest.parquet`
+  - se l'inventory SDMX non e' disponibile, restituisce lo stato del report inventory invece di ripiegare su artifact item-level diversi
+
+## Boundary
+
+Il layer MCP deve restare:
+
+- read-only sugli artifact locali
+- esplicito sulla provenienza del dato restituito
+- conservativo quando un artifact manca
+- coerente con i workflow pubblici di Source Observatory
+
+Non deve:
+
+- produrre nuovi artifact
+- scaricare artifact GitHub Actions in modo implicito durante una query
+- correggere automaticamente registry o workflow
+- usare fallback opachi tra artifact con semantiche diverse
+- trasformare una fonte assente dal parquet in un giudizio sulla fonte
+
+## Artifact principali
+
+| Artifact | Uso MCP |
+|---|---|
+| `data/radar/radar_summary.json` | stato fonte radar |
+| `data/catalog/catalog_signals.json` | segnali catalog-watch |
+| `CATALOG_INVENTORY_GCS_PREFIX/source-check/source_check_results.parquet` | risultati source-check item-level |
+| `CATALOG_INVENTORY_GCS_PREFIX/catalog_inventory_latest.parquet` | inventory cataloghi enumerabili |
+| `CATALOG_INVENTORY_GCS_PREFIX/catalog_inventory_report.json` | stato per fonte del run inventory |
+| `PORTAL_SCOUT_GCS_PREFIX/discovered_portals.parquet` | portali scoperti |
+| `data/portal_scout/new_candidates.parquet` | nuovi candidati portale |
+| `data/portal_scout/discovered_portals_summary.json` | riepilogo discovery |
+
+## Uso operativo
+
+Per una domanda su "cosa sappiamo gia'":
+
+1. leggere prima radar e report inventory
+2. controllare il blocco `cache` prima di trattare i parquet come correnti
+3. interrogare l'inventory solo se la fonte e' inventariata
+4. usare i source-check item-level per evidenze gia' validate
+5. usare probe o discovery solo per verifiche puntuali
+
+Il workflow di riferimento e' `workflows/mcp-artifact-triage.md`.

--- a/mcp/so_server.py
+++ b/mcp/so_server.py
@@ -83,8 +83,9 @@ def so_inventory_query(
     source_id: str | None = None,
     min_score: int | None = None,
     limit: int = 50,
+    has_results: bool | None = None,
 ) -> dict[str, Any]:
-    return _guard(query_inventory, source_id, min_score, limit)
+    return _guard(query_inventory, source_id, min_score, limit, has_results)
 
 
 @mcp.tool(

--- a/mcp/so_server.py
+++ b/mcp/so_server.py
@@ -1,20 +1,51 @@
 """
-SO MCP Server — readonly layer for Source Observatory artifact inspection.
+SO MCP Server: read-only layer for Source Observatory artifact inspection.
 
-Run with: fastmcp run source-observatory.mcp.so_server
-Requires: pip install mcp fastmcp
+Run with: python /path/to/source-observatory/mcp/so_server.py
 """
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 from typing import Any
 
+_MCP_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _MCP_DIR.parent
+_ORIGINAL_SYS_PATH = list(sys.path)
+sys.path = [
+    path
+    for path in sys.path
+    if Path(path or ".").resolve() not in {_MCP_DIR, _REPO_ROOT}
+]
 try:
     from mcp.server.fastmcp import FastMCP
-    _HAS_MCP = True
-except ImportError:
-    _HAS_MCP = False
+finally:
+    sys.path = _ORIGINAL_SYS_PATH
 
-from .so_server_core import query_inventory, query_signals
+try:
+    from .so_server_core import (
+        catalog_inventory_search,
+        discover_sdmx,
+        inventory_status,
+        portal_candidates,
+        probe_url,
+        query_inventory,
+        query_signals,
+        radar_summary,
+    )
+except ImportError:
+    if str(_MCP_DIR) not in sys.path:
+        sys.path.insert(0, str(_MCP_DIR))
+    from so_server_core import (  # type: ignore[no-redef]
+        catalog_inventory_search,
+        discover_sdmx,
+        inventory_status,
+        portal_candidates,
+        probe_url,
+        query_inventory,
+        query_signals,
+        radar_summary,
+    )
 
 
 mcp = FastMCP(
@@ -22,9 +53,9 @@ mcp = FastMCP(
     instructions=(
         "Read-only MCP per Source Observatory. "
         "Query artifact di source-check, catalog-inventory e catalog-signals "
-        "prodotti dalla CI di SO."
+        "prodotti dalla CI di SO, con probe URL leggero on-demand."
     ),
-) if _HAS_MCP else None
+)
 
 
 def _guard(fn, *args, **kwargs) -> dict[str, Any]:
@@ -34,48 +65,82 @@ def _guard(fn, *args, **kwargs) -> dict[str, Any]:
         return {"error": type(exc).__name__, "message": str(exc)}
 
 
-if _HAS_MCP:
-
-    @mcp.tool(
-        description="Query source_check_results.parquet — inventory results con score e reachable.",
-        structured_output=True,
-    )
-    def so_inventory_query(
-        source_id: str | None = None,
-        min_score: int | None = None,
-        limit: int = 50,
-    ) -> dict[str, Any]:
-        """Query source_check_results.parquet.
-
-        Args:
-            source_id: filter to exact source (e.g. 'inps')
-            min_score: filter rows with intake_score >= min_score
-            limit: max rows returned (default 50)
-
-        Returns:
-            artifact, filters, results list with source_id/item_id/reachable/granularity/intake_score.
-        """
-        return _guard(query_inventory, source_id, min_score, limit)
-
-    @mcp.tool(
-        description="Query catalog_signals.json — drift e inventory signals per source.",
-        structured_output=True,
-    )
-    def so_catalog_signals(
-        source_id: str | None = None,
-        limit: int | None = None,
-    ) -> dict[str, Any]:
-        """Query catalog_signals.json.
-
-        Args:
-            source_id: filter to exact source (e.g. 'opencoesione')
-            limit: return only the last N signals
-
-        Returns:
-            artifact, captured_at, signals list with source/protocol/signal_type/result/detail/suggested_action.
-        """
-        return _guard(query_signals, source_id, limit)
+@mcp.tool(
+    description="Query source_check_results.parquet: top candidate filtrati per fonte e score.",
+    structured_output=True,
+)
+def so_inventory_query(
+    source_id: str | None = None,
+    min_score: int | None = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    return _guard(query_inventory, source_id, min_score, limit)
 
 
-if __name__ == "__main__" and _HAS_MCP:
+@mcp.tool(
+    description="Query catalog_signals.json: drift/inventory signals per fonte.",
+    structured_output=True,
+)
+def so_catalog_signals(source_id: str | None = None, limit: int | None = None) -> dict[str, Any]:
+    return _guard(query_signals, source_id, limit)
+
+
+@mcp.tool(
+    description="Legge radar_summary.json: health portali e stato GREEN/YELLOW/RED per fonte.",
+    structured_output=True,
+)
+def so_radar_summary(source_id: str | None = None) -> dict[str, Any]:
+    return _guard(radar_summary, source_id)
+
+
+@mcp.tool(
+    description="Legge catalog_inventory_report.json: stato build inventory per fonte.",
+    structured_output=True,
+)
+def so_inventory_status(source_id: str | None = None) -> dict[str, Any]:
+    return _guard(inventory_status, source_id)
+
+
+@mcp.tool(
+    description="Cerca item in catalog_inventory_latest.parquet per testo, fonte e protocollo.",
+    structured_output=True,
+)
+def so_catalog_inventory_search(
+    query: str,
+    source_id: str | None = None,
+    protocol: str | None = None,
+    limit: int = 25,
+) -> dict[str, Any]:
+    return _guard(catalog_inventory_search, query, source_id, protocol, limit)
+
+
+@mcp.tool(
+    description="Lista portali candidati da portal-scout, filtrabili per protocollo.",
+    structured_output=True,
+)
+def so_portal_candidates(
+    protocol: str | None = None,
+    only_new: bool = True,
+    limit: int = 25,
+) -> dict[str, Any]:
+    return _guard(portal_candidates, protocol, only_new, limit)
+
+
+@mcp.tool(
+    description="Probe leggero di un singolo URL: status, content-type, formato, size, reachability.",
+    structured_output=True,
+)
+def so_probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
+    return _guard(probe_url, url, timeout)
+
+
+@mcp.tool(
+    description="Discovery tematica ISTAT SDMX da artifact locali con relevance score.",
+    structured_output=True,
+)
+def so_discover_sdmx(keywords: list[str], limit: int = 30) -> dict[str, Any]:
+    return _guard(discover_sdmx, keywords, limit)
+
+
+if __name__ == "__main__":
     mcp.run()

--- a/mcp/so_server.py
+++ b/mcp/so_server.py
@@ -26,12 +26,17 @@ try:
     from .so_server_core import (
         catalog_inventory_search,
         discover_sdmx,
+        find_by_url,
         inventory_status,
         portal_candidates,
         probe_url,
         query_inventory,
         query_signals,
+        radar_delta,
+        radar_history,
+        radar_status_md,
         radar_summary,
+        registry_query,
     )
 except ImportError:
     if str(_MCP_DIR) not in sys.path:
@@ -39,12 +44,17 @@ except ImportError:
     from so_server_core import (  # type: ignore[no-redef]
         catalog_inventory_search,
         discover_sdmx,
+        find_by_url,
         inventory_status,
         portal_candidates,
         probe_url,
         query_inventory,
         query_signals,
+        radar_delta,
+        radar_history,
+        radar_status_md,
         radar_summary,
+        registry_query,
     )
 
 
@@ -94,6 +104,22 @@ def so_radar_summary(source_id: str | None = None) -> dict[str, Any]:
 
 
 @mcp.tool(
+    description="Legge radar_history.json: storia probes per fonte, utile per capire streak RED e fonti persistenti.",
+    structured_output=True,
+)
+def so_radar_history(source_id: str | None = None, limit: int = 5) -> dict[str, Any]:
+    return _guard(radar_history, source_id, limit)
+
+
+@mcp.tool(
+    description="Legge STATUS.md: markdown umano con stato radar e sommario per fonte.",
+    structured_output=True,
+)
+def so_radar_status_md() -> dict[str, Any]:
+    return _guard(radar_status_md)
+
+
+@mcp.tool(
     description="Legge catalog_inventory_report.json: stato build inventory per fonte.",
     structured_output=True,
 )
@@ -140,6 +166,35 @@ def so_probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
 )
 def so_discover_sdmx(keywords: list[str], limit: int = 30) -> dict[str, Any]:
     return _guard(discover_sdmx, keywords, limit)
+
+
+@mcp.tool(
+    description="Confronta ultimo e penultimo probe del radar: restituisce fonti cambiate, nuove RED, recovery, persistent RED.",
+    structured_output=True,
+)
+def so_radar_delta() -> dict[str, Any]:
+    return _guard(radar_delta)
+
+
+@mcp.tool(
+    description="Cerca un URL in source_check_results.parquet e catalog_inventory_latest.parquet per vedere se e' gia' catalogato.",
+    structured_output=True,
+)
+def so_find_by_url(url: str) -> dict[str, Any]:
+    return _guard(find_by_url, url)
+
+
+@mcp.tool(
+    description="Interroga sources_registry.yaml: filtra per protocol, source_kind, observation_mode o cerca per source_id.",
+    structured_output=True,
+)
+def so_registry_query(
+    protocol: str | None = None,
+    source_kind: str | None = None,
+    observation_mode: str | None = None,
+    source_id: str | None = None,
+) -> dict[str, Any]:
+    return _guard(registry_query, protocol, source_kind, observation_mode, source_id)
 
 
 if __name__ == "__main__":

--- a/mcp/so_server.py
+++ b/mcp/so_server.py
@@ -1,0 +1,81 @@
+"""
+SO MCP Server — readonly layer for Source Observatory artifact inspection.
+
+Run with: fastmcp run source-observatory.mcp.so_server
+Requires: pip install mcp fastmcp
+"""
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from mcp.server.fastmcp import FastMCP
+    _HAS_MCP = True
+except ImportError:
+    _HAS_MCP = False
+
+from .so_server_core import query_inventory, query_signals
+
+
+mcp = FastMCP(
+    name="source-observatory",
+    instructions=(
+        "Read-only MCP per Source Observatory. "
+        "Query artifact di source-check, catalog-inventory e catalog-signals "
+        "prodotti dalla CI di SO."
+    ),
+) if _HAS_MCP else None
+
+
+def _guard(fn, *args, **kwargs) -> dict[str, Any]:
+    try:
+        return fn(*args, **kwargs)
+    except Exception as exc:
+        return {"error": type(exc).__name__, "message": str(exc)}
+
+
+if _HAS_MCP:
+
+    @mcp.tool(
+        description="Query source_check_results.parquet — inventory results con score e reachable.",
+        structured_output=True,
+    )
+    def so_inventory_query(
+        source_id: str | None = None,
+        min_score: int | None = None,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        """Query source_check_results.parquet.
+
+        Args:
+            source_id: filter to exact source (e.g. 'inps')
+            min_score: filter rows with intake_score >= min_score
+            limit: max rows returned (default 50)
+
+        Returns:
+            artifact, filters, results list with source_id/item_id/reachable/granularity/intake_score.
+        """
+        return _guard(query_inventory, source_id, min_score, limit)
+
+    @mcp.tool(
+        description="Query catalog_signals.json — drift e inventory signals per source.",
+        structured_output=True,
+    )
+    def so_catalog_signals(
+        source_id: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Query catalog_signals.json.
+
+        Args:
+            source_id: filter to exact source (e.g. 'opencoesione')
+            limit: return only the last N signals
+
+        Returns:
+            artifact, captured_at, signals list with source/protocol/signal_type/result/detail/suggested_action.
+        """
+        return _guard(query_signals, source_id, limit)
+
+
+if __name__ == "__main__" and _HAS_MCP:
+    mcp.run()

--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -77,41 +77,28 @@ _FORMAT_BY_SUFFIX = {
 _ENV_LOADED = False
 
 
-def _load_collectors_base() -> Any:
-    spec = importlib.util.spec_from_file_location("_so_collectors_base", _COLLECTORS_BASE)
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Cannot load collectors base from {_COLLECTORS_BASE}")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
+_collectors_base = None
+observatory_get = None
+observatory_head = None
 
 
-_collectors_base = _load_collectors_base()
-observatory_get = _collectors_base.observatory_get
-observatory_head = _collectors_base.observatory_head
+def _get_observatory_get() -> Any:
+    global _collectors_base, observatory_get, observatory_head
+    if _collectors_base is None:
+        spec = importlib.util.spec_from_file_location("_so_collectors_base", _COLLECTORS_BASE)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load collectors base from {_COLLECTORS_BASE}")
+        _collectors_base = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = _collectors_base
+        spec.loader.exec_module(_collectors_base)
+        observatory_get = _collectors_base.observatory_get
+        observatory_head = _collectors_base.observatory_head
+    return observatory_get
 
 
-@dataclass(frozen=True)
-class _ParquetArtifact:
-    name: str
-    local_path: Path
-    gcs_env: str
-    gcs_key: str
-
-
-@dataclass(frozen=True)
-class _ParquetArtifact:
-    name: str
-    local_path: Path
-    gcs_env: str
-    gcs_key: str
-
-    def gcs_uri(self) -> str | None:
-        prefix = _gcs_prefix(self.gcs_env)
-        if prefix is None:
-            return None
-        return f"{prefix.rstrip('/')}/{self.gcs_key}"
+def _get_observatory_head() -> Any:
+    _get_observatory_get()  # ensure initialized
+    return observatory_head
 
 
 @dataclass(frozen=True)
@@ -732,33 +719,28 @@ def query_inventory(
             con = duckdb.connect()
             try:
                 cols = _table_columns(con, parquet_path)
+                query = f'SELECT * FROM "{parquet_path}"'
+                filters: list[str] = []
+                params: list[Any] = []
+
+                if source_id:
+                    filters.append("source_id = ?")
+                    params.append(source_id)
+                if min_score is not None:
+                    filters.append("intake_score >= ?")
+                    params.append(min_score)
+                if has_results is not None:
+                    if has_results:
+                        filters.append("intake_score IS NOT NULL AND intake_score > 0")
+                    else:
+                        filters.append("(intake_score IS NULL OR intake_score = 0)")
+                if filters:
+                    query += " WHERE " + " AND ".join(filters)
+                query += f" ORDER BY intake_score DESC NULLS LAST LIMIT {safe_limit}"
+
+                rows = con.execute(query, params).fetchall()
             finally:
                 con.close()
-
-            query = f'SELECT * FROM "{parquet_path}"'
-            filters: list[str] = []
-            params: list[Any] = []
-
-            if source_id:
-                filters.append("source_id = ?")
-                params.append(source_id)
-            if min_score is not None:
-                filters.append("intake_score >= ?")
-                params.append(min_score)
-            if has_results is not None:
-                if has_results:
-                    filters.append("intake_score IS NOT NULL AND intake_score > 0")
-                else:
-                    filters.append("(intake_score IS NULL OR intake_score = 0)")
-            if filters:
-                query += " WHERE " + " AND ".join(filters)
-            query += f" ORDER BY intake_score DESC NULLS LAST LIMIT {safe_limit}"
-
-            con2 = duckdb.connect()
-            try:
-                rows = con2.execute(query, params).fetchall()
-            finally:
-                con2.close()
     except FileNotFoundError:
         return _parquet_not_found(artifact)
 
@@ -771,6 +753,9 @@ def query_inventory(
         "returned": len(rows),
         "has_more": len(rows) == safe_limit,
     }
+
+
+def inventory_status(source_id: str | None = None) -> dict[str, Any]:
     """Return catalog inventory build status from catalog_inventory_report.json."""
     loaded = _load_inventory_report()
     if loaded is None:
@@ -1019,10 +1004,10 @@ def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
 
     safe_timeout = max(1, min(int(timeout or 15), 60))
     try:
-        response = observatory_head(clean_url, timeout=safe_timeout)
+        response = _get_observatory_head()(clean_url, timeout=safe_timeout)
     except requests.RequestException as exc:
         try:
-            response = observatory_get(
+            response = _get_observatory_get()(
                 clean_url,
                 timeout=safe_timeout,
                 headers={"Range": "bytes=0-0"},

--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -35,9 +35,12 @@ _INVENTORY_REPORT = (
 )
 _SIGNALS_JSON = _REPO_ROOT / "data" / "catalog" / "catalog_signals.json"
 _RADAR_JSON = _REPO_ROOT / "data" / "radar" / "radar_summary.json"
+_RADAR_HISTORY_JSON = _REPO_ROOT / "data" / "radar" / "radar_history.json"
+_STATUS_MD = _REPO_ROOT / "data" / "radar" / "STATUS.md"
 _PORTAL_SUMMARY_JSON = _REPO_ROOT / "data" / "portal_scout" / "discovered_portals_summary.json"
 _DISCOVERED_PORTALS_PARQUET = _REPO_ROOT / "data" / "portal_scout" / "discovered_portals.parquet"
 _NEW_CANDIDATES_PARQUET = _REPO_ROOT / "data" / "portal_scout" / "new_candidates.parquet"
+_REGISTRY_YAML = _REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
 _DEFAULT_CACHE_MAX_AGE_HOURS = 24
 _DEFAULT_GCS_PREFIXES = {
     "CATALOG_INVENTORY_GCS_PREFIX": "gs://dataciviclab-clean/catalog_inventory",
@@ -98,11 +101,31 @@ class _ParquetArtifact:
 
 
 @dataclass(frozen=True)
+class _ParquetArtifact:
+    name: str
+    local_path: Path
+    gcs_env: str
+    gcs_key: str
+
+    def gcs_uri(self) -> str | None:
+        prefix = _gcs_prefix(self.gcs_env)
+        if prefix is None:
+            return None
+        return f"{prefix.rstrip('/')}/{self.gcs_key}"
+
+
+@dataclass(frozen=True)
 class _JsonArtifact:
     name: str
     local_path: Path
     gcs_env: str
     gcs_key: str
+
+    def gcs_uri(self) -> str | None:
+        prefix = _gcs_prefix(self.gcs_env)
+        if prefix is None:
+            return None
+        return f"{prefix.rstrip('/')}/{self.gcs_key}"
 
 
 def _source_check_parquet() -> _ParquetArtifact:
@@ -383,50 +406,6 @@ def _load_inventory_report() -> tuple[dict[str, Any], dict[str, Any]] | None:
         return None
 
 
-def query_inventory(
-    source_id: str | None = None,
-    min_score: int | None = None,
-    limit: int = 50,
-) -> dict[str, Any]:
-    """Query source_check_results.parquet with optional source and score filters."""
-    safe_limit = max(1, min(int(limit or 50), 200))
-    artifact = _source_check_parquet()
-    try:
-        with _resolved_parquet(artifact) as (resolved_path, cache):
-            parquet_path = str(resolved_path)
-            query = f'SELECT * FROM "{parquet_path}"'
-            filters: list[str] = []
-            params: list[Any] = []
-
-            if source_id:
-                filters.append("source_id = ?")
-                params.append(source_id)
-            if min_score is not None:
-                filters.append("intake_score >= ?")
-                params.append(min_score)
-            if filters:
-                query += " WHERE " + " AND ".join(filters)
-            query += f" ORDER BY intake_score DESC NULLS LAST LIMIT {safe_limit}"
-
-            con = duckdb.connect()
-            try:
-                rows = con.execute(query, params).fetchall()
-                cols = _table_columns(con, parquet_path)
-            finally:
-                con.close()
-    except FileNotFoundError:
-        return _parquet_not_found(artifact)
-
-    return {
-        "artifact": _display_path(_CHECK_PARQUET),
-        "cache": cache,
-        "filters": {"source_id": source_id, "min_score": min_score, "limit": safe_limit},
-        "results": [dict(zip(cols, row)) for row in rows],
-        "returned": len(rows),
-        "has_more": len(rows) == safe_limit,
-    }
-
-
 def query_signals(source_id: str | None = None, limit: int | None = None) -> dict[str, Any]:
     """Query catalog_signals.json with optional source filter."""
     if not _SIGNALS_JSON.exists():
@@ -470,13 +449,328 @@ def radar_summary(source_id: str | None = None) -> dict[str, Any]:
         "probe_date": radar_doc.get("probe_date"),
         "sources_total": radar_doc.get("sources_total"),
         "status_counts": radar_doc.get("status_counts", {}),
+        "persistent_red": radar_doc.get("persistent_red"),
         "filters": {"source_id": source_id},
         "sources": sources,
         "returned": len(sources),
     }
 
 
-def inventory_status(source_id: str | None = None) -> dict[str, Any]:
+def radar_history(source_id: str | None = None, limit: int = 5) -> dict[str, Any]:
+    """Return radar_history.json: probe history per fonte, per calcolare streak/persistent."""
+    if not _RADAR_HISTORY_JSON.exists():
+        return _artifact_not_found(_RADAR_HISTORY_JSON, "radar_history.json")
+
+    with _RADAR_HISTORY_JSON.open(encoding="utf-8") as fh:
+        history_doc = json.load(fh)
+
+    probes = history_doc.get("probes", [])
+    if not isinstance(probes, list):
+        probes = []
+
+    safe_limit = max(1, min(int(limit or 5), 20))
+    recent_probes = list(reversed(probes))[-safe_limit:] if probes else []
+
+    sources_map: dict[str, list[dict[str, Any]]] = {}
+    for probe in recent_probes:
+        for src in probe.get("sources", []):
+            sid = src.get("id", "unknown")
+            if source_id and sid != source_id:
+                continue
+            if sid not in sources_map:
+                sources_map[sid] = []
+            sources_map[sid].append({
+                "probe_date": probe.get("probe_date"),
+                "status": src.get("status"),
+                "http_code": src.get("http_code"),
+                "note": src.get("note"),
+            })
+
+    results = []
+    for sid, entries in sorted(sources_map.items()):
+        entries.sort(key=lambda e: e.get("probe_date") or "", reverse=True)
+        red_count = sum(1 for e in entries if e.get("status") == "RED")
+        results.append({
+            "source_id": sid,
+            "probes": entries,
+            "recent_red_count": red_count,
+            "current_status": entries[0].get("status") if entries else None,
+        })
+
+    return {
+        "artifact": _display_path(_RADAR_HISTORY_JSON),
+        "captured_at": history_doc.get("captured_at"),
+        "filters": {"source_id": source_id, "limit": safe_limit},
+        "sources": results,
+        "returned": len(results),
+        "probes_in_window": len(recent_probes),
+    }
+
+
+def radar_status_md() -> dict[str, Any]:
+    """Return STATUS.md content as plain text for human-readable radar state."""
+    if not _STATUS_MD.exists():
+        return _artifact_not_found(_STATUS_MD, "STATUS.md")
+
+    content = _STATUS_MD.read_text(encoding="utf-8")
+    stat = _STATUS_MD.stat()
+    modified_at = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+    age_hours = (datetime.now(timezone.utc) - modified_at).total_seconds() / 3600
+
+    return {
+        "artifact": _display_path(_STATUS_MD),
+        "modified_at": modified_at.isoformat(),
+        "age_hours": round(age_hours, 2),
+        "content": content,
+    }
+
+
+def radar_delta() -> dict[str, Any]:
+    """Compare latest and previous probe to return only changed sources."""
+    if not _RADAR_HISTORY_JSON.exists():
+        return _artifact_not_found(_RADAR_HISTORY_JSON, "radar_history.json")
+
+    with _RADAR_HISTORY_JSON.open(encoding="utf-8") as fh:
+        history_doc = json.load(fh)
+
+    probes = history_doc.get("probes", [])
+    if not isinstance(probes, list) or len(probes) < 2:
+        return {
+            "artifact": _display_path(_RADAR_HISTORY_JSON),
+            "captured_at": history_doc.get("captured_at"),
+            "message": "Not enough probes to compute delta (need at least 2)",
+            "changes": [],
+            "new_red": [],
+            "recoveries": [],
+            "persistent_red": [],
+        }
+
+    latest = probes[-1]
+    previous = probes[-2]
+    latest_sources = {s["id"]: s for s in latest.get("sources", [])}
+    prev_sources = {s["id"]: s for s in previous.get("sources", [])}
+
+    changes = []
+    new_red = []
+    recoveries = []
+    persistent_red = []
+
+    all_ids = set(latest_sources.keys()) | set(prev_sources.keys())
+    for sid in sorted(all_ids):
+        curr = latest_sources.get(sid)
+        prev = prev_sources.get(sid)
+
+        curr_status = curr.get("status") if curr else None
+        prev_status = prev.get("status") if prev else None
+
+        if curr_status != prev_status:
+            changes.append({
+                "source_id": sid,
+                "previous": prev_status,
+                "current": curr_status,
+                "http_code": curr.get("http_code") if curr else None,
+                "note": curr.get("note") if curr else None,
+            })
+            if curr_status == "RED":
+                new_red.append(sid)
+            elif prev_status == "RED" and curr_status != "RED":
+                recoveries.append(sid)
+
+        if curr_status == "RED":
+            streak = 0
+            for probe in reversed(probes):
+                src = next((s for s in probe.get("sources", []) if s.get("id") == sid), None)
+                if src and src.get("status") == "RED":
+                    streak += 1
+                else:
+                    break
+            if streak >= 2:
+                persistent_red.append(sid)
+
+    return {
+        "artifact": _display_path(_RADAR_HISTORY_JSON),
+        "captured_at": history_doc.get("captured_at"),
+        "probe_date_latest": latest.get("probe_date"),
+        "probe_date_previous": previous.get("probe_date"),
+        "changes": changes,
+        "new_red": new_red,
+        "recoveries": recoveries,
+        "persistent_red": persistent_red,
+        "changed_count": len(changes),
+    }
+
+
+def find_by_url(url: str) -> dict[str, Any]:
+    """Find a URL across source_check_results and catalog_inventory."""
+    clean_url = (url or "").strip()
+    if not clean_url:
+        return {"error": "empty_url", "message": "Provide a non-empty URL."}
+
+    results: dict[str, Any] = {
+        "query_url": clean_url,
+        "source_check_results": [],
+        "catalog_inventory": [],
+    }
+
+    source_check_artifact = _source_check_parquet()
+    try:
+        with _resolved_parquet(source_check_artifact) as (resolved_path, cache):
+            parquet_path = str(resolved_path)
+            con = duckdb.connect()
+            try:
+                cols = _table_columns(con, parquet_path)
+                url_cols = [c for c in cols if c in ("distribution_url", "landing_page", "source_url")]
+                if not url_cols:
+                    results["source_check_error"] = "No URL columns found in parquet"
+                else:
+                    where = " OR ".join(
+                        f"lower(coalesce(cast({c} as varchar), '')) LIKE ?"
+                        for c in url_cols
+                    )
+                    like = f"%{clean_url}%"
+                    sql = f'SELECT * FROM "{parquet_path}" WHERE {where} LIMIT 10'
+                    rows = con.execute(sql, [like] * len(url_cols)).fetchall()
+                    results["source_check_results"] = [dict(zip(cols, row)) for row in rows]
+                    results["source_check_cache"] = cache
+            finally:
+                con.close()
+    except FileNotFoundError:
+        results["source_check_error"] = f"{source_check_artifact.name} not found"
+
+    catalog_artifact = _catalog_inventory_parquet()
+    try:
+        with _resolved_parquet(catalog_artifact) as (resolved_path, cache):
+            parquet_path = str(resolved_path)
+            con = duckdb.connect()
+            try:
+                cols = _table_columns(con, parquet_path)
+                url_cols = [c for c in cols if c in ("distribution_url", "landing_page", "source_url")]
+                if not url_cols:
+                    results["catalog_inventory_error"] = "No URL columns found in parquet"
+                else:
+                    where = " OR ".join(
+                        f"lower(coalesce(cast({c} as varchar), '')) LIKE ?"
+                        for c in url_cols
+                    )
+                    like = f"%{clean_url}%"
+                    sql = f'SELECT * FROM "{parquet_path}" WHERE {where} LIMIT 10'
+                    rows = con.execute(sql, [like] * len(url_cols)).fetchall()
+                    results["catalog_inventory"] = [dict(zip(cols, row)) for row in rows]
+                    results["catalog_inventory_cache"] = cache
+            finally:
+                con.close()
+    except FileNotFoundError:
+        results["catalog_inventory_error"] = f"{catalog_artifact.name} not found"
+
+    return results
+
+
+def registry_query(
+    protocol: str | None = None,
+    source_kind: str | None = None,
+    observation_mode: str | None = None,
+    source_id: str | None = None,
+) -> dict[str, Any]:
+    """Query sources_registry.yaml with optional filters."""
+    if not _REGISTRY_YAML.exists():
+        return _artifact_not_found(_REGISTRY_YAML, "sources_registry.yaml")
+
+    import yaml
+    with _REGISTRY_YAML.open(encoding="utf-8") as fh:
+        registry = yaml.safe_load(fh)
+
+    if not isinstance(registry, dict):
+        return {"error": "invalid_registry", "message": "Registry is not a dict."}
+
+    results = []
+    for sid, info in sorted(registry.items()):
+        if source_id and sid != source_id:
+            continue
+        if source_kind and info.get("source_kind") != source_kind:
+            continue
+        if protocol and info.get("protocol") != protocol:
+            continue
+        if observation_mode and info.get("observation_mode") != observation_mode:
+            continue
+        results.append({
+            "source_id": sid,
+            "source_kind": info.get("source_kind"),
+            "protocol": info.get("protocol"),
+            "observation_mode": info.get("observation_mode"),
+            "base_url": info.get("base_url"),
+            "verdict": info.get("verdict"),
+            "last_probed": info.get("last_probed"),
+            "datasets_in_use": info.get("datasets_in_use", []),
+            "note": info.get("note"),
+        })
+
+    return {
+        "artifact": _display_path(_REGISTRY_YAML),
+        "filters": {
+            "source_id": source_id,
+            "protocol": protocol,
+            "source_kind": source_kind,
+            "observation_mode": observation_mode,
+        },
+        "results": results,
+        "returned": len(results),
+    }
+
+
+def query_inventory(
+    source_id: str | None = None,
+    min_score: int | None = None,
+    limit: int = 50,
+    has_results: bool | None = None,
+) -> dict[str, Any]:
+    """Query source_check_results.parquet with optional source and score filters."""
+    safe_limit = max(1, min(int(limit or 50), 200))
+    artifact = _source_check_parquet()
+    try:
+        with _resolved_parquet(artifact) as (resolved_path, cache):
+            parquet_path = str(resolved_path)
+            con = duckdb.connect()
+            try:
+                cols = _table_columns(con, parquet_path)
+            finally:
+                con.close()
+
+            query = f'SELECT * FROM "{parquet_path}"'
+            filters: list[str] = []
+            params: list[Any] = []
+
+            if source_id:
+                filters.append("source_id = ?")
+                params.append(source_id)
+            if min_score is not None:
+                filters.append("intake_score >= ?")
+                params.append(min_score)
+            if has_results is not None:
+                if has_results:
+                    filters.append("intake_score IS NOT NULL AND intake_score > 0")
+                else:
+                    filters.append("(intake_score IS NULL OR intake_score = 0)")
+            if filters:
+                query += " WHERE " + " AND ".join(filters)
+            query += f" ORDER BY intake_score DESC NULLS LAST LIMIT {safe_limit}"
+
+            con2 = duckdb.connect()
+            try:
+                rows = con2.execute(query, params).fetchall()
+            finally:
+                con2.close()
+    except FileNotFoundError:
+        return _parquet_not_found(artifact)
+
+    return {
+        "artifact": _display_path(_CHECK_PARQUET),
+        "cache": cache,
+        "gcs_uri": artifact.gcs_uri(),
+        "filters": {"source_id": source_id, "min_score": min_score, "limit": safe_limit, "has_results": has_results},
+        "results": [dict(zip(cols, row)) for row in rows],
+        "returned": len(rows),
+        "has_more": len(rows) == safe_limit,
+    }
     """Return catalog inventory build status from catalog_inventory_report.json."""
     loaded = _load_inventory_report()
     if loaded is None:

--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -1,0 +1,114 @@
+"""
+SO MCP core — readonly artifact queries.
+
+Artifact paths resolved relative to this package (source-observatory/).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import duckdb
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CHECK_PARQUET = _REPO_ROOT / "data" / "catalog_inventory" / "generated" / "source_check_results.parquet"
+_SIGNALS_JSON = _REPO_ROOT / "data" / "catalog" / "catalog_signals.json"
+
+
+def query_inventory(
+    source_id: str | None = None,
+    min_score: int | None = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """
+    Query source_check_results.parquet with optional filters.
+
+    Args:
+        source_id: filter to exact source_id (e.g. 'inps', 'istat_sdmx')
+        min_score: filter rows with intake_score >= min_score
+        limit: max rows returned (default 50)
+
+    Returns:
+        dict with artifact path, filters, results list, returned count, has_more.
+        Results columns: source_id, item_id, reachable, http_status, granularity,
+        year_min, year_max, intake_score, intake_candidate.
+    """
+    if not _CHECK_PARQUET.exists():
+        return {
+            "error": "artifact_not_found",
+            "message": f"source_check_results.parquet not found at {_CHECK_PARQUET}",
+            "hint": "Run: python -m mcp.so_server from source-observatory/ to initialize",
+        }
+
+    parquet_path = str(_CHECK_PARQUET.resolve())
+    con = duckdb.connect()
+
+    query = f'SELECT * FROM "{parquet_path}"'
+    filters: list[str] = []
+    params: list[Any] = []
+
+    if source_id:
+        filters.append("source_id = ?")
+        params.append(source_id)
+    if min_score is not None:
+        filters.append("intake_score >= ?")
+        params.append(min_score)
+    if filters:
+        query += " WHERE " + " AND ".join(filters)
+    query += f" ORDER BY intake_score DESC NULLS LAST LIMIT {limit}"
+
+    try:
+        rows = con.execute(query, params).fetchall()
+        cols = [c[0] for c in con.execute(f'DESCRIBE FROM "{parquet_path}"').fetchall()]
+        results = [dict(zip(cols, r)) for r in rows]
+    except Exception as e:
+        return {"error": type(e).__name__, "message": str(e)}
+    finally:
+        con.close()
+
+    return {
+        "artifact": str(_CHECK_PARQUET.relative_to(_REPO_ROOT)),
+        "filters": {"source_id": source_id, "min_score": min_score, "limit": limit},
+        "results": results,
+        "returned": len(results),
+        "has_more": len(results) == limit,
+    }
+
+
+def query_signals(
+    source_id: str | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """
+    Query catalog_signals.json with optional filters.
+
+    Args:
+        source_id: filter to exact source (e.g. 'opencoesione')
+        limit: if provided, return only the last N signals per source
+
+    Returns:
+        dict with artifact path, captured_at, filters, signals list.
+        Each signal: source, protocol, signal_type, result, detail, suggested_action.
+        When limit is set, returns the last N signals (globally, not per source).
+    """
+    if not _SIGNALS_JSON.exists():
+        return {
+            "error": "artifact_not_found",
+            "message": f"catalog_signals.json not found at {_SIGNALS_JSON}",
+        }
+
+    with _SIGNALS_JSON.open(encoding="utf-8") as f:
+        signals_doc = json.load(f)
+
+    signals = signals_doc.get("signals", [])
+    if source_id:
+        signals = [s for s in signals if s.get("source") == source_id]
+
+    return {
+        "artifact": str(_SIGNALS_JSON.relative_to(_REPO_ROOT)),
+        "captured_at": signals_doc.get("captured_at", ""),
+        "filters": {"source_id": source_id, "limit": limit},
+        "signals": signals[-limit:] if limit is not None else signals,
+        "returned": len(signals[-limit:] if limit is not None else signals),
+    }

--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -102,6 +102,20 @@ def _get_observatory_head() -> Any:
 
 
 @dataclass(frozen=True)
+class _ParquetArtifact:
+    name: str
+    local_path: Path
+    gcs_env: str
+    gcs_key: str
+
+    def gcs_uri(self) -> str | None:
+        prefix = _gcs_prefix(self.gcs_env)
+        if prefix is None:
+            return None
+        return f"{prefix.rstrip('/')}/{self.gcs_key}"
+
+
+@dataclass(frozen=True)
 class _JsonArtifact:
     name: str
     local_path: Path
@@ -223,13 +237,6 @@ def _gcs_prefix(env_name: str) -> str | None:
     return _env(f"SO_{env_name}") or _env(env_name) or _DEFAULT_GCS_PREFIXES.get(env_name)
 
 
-def _gcs_uri(artifact: _ParquetArtifact | _JsonArtifact) -> str | None:
-    prefix = _gcs_prefix(artifact.gcs_env)
-    if prefix is None:
-        return None
-    return f"{prefix.rstrip('/')}/{artifact.gcs_key}"
-
-
 def _artifact_cache_info(
     path: Path,
     *,
@@ -304,75 +311,47 @@ def _copy_gcs_to_temp(uri: str, artifact_name: str) -> Path:
 
 
 @contextmanager
+def _resolved_artifact(artifact: _ParquetArtifact | _JsonArtifact) -> Iterator[tuple[Path, dict[str, Any]]]:
+    backend = _artifact_backend()
+    uri = artifact.gcs_uri()
+    fallback_warning = None
+
+    if backend in {"auto", "gcs"} and uri:
+        tmp_path: Path | None = None
+        try:
+            tmp_path = _copy_gcs_to_temp(uri, artifact.name)
+        except Exception as exc:
+            if backend == "gcs":
+                raise RuntimeError(f"Cannot read {artifact.name} from GCS {uri}: {exc}") from exc
+            fallback_warning = f"Cannot read GCS artifact {uri}; using local cache if available."
+        else:
+            try:
+                yield tmp_path, _artifact_cache_info(tmp_path, source="gcs", uri=uri)
+                return
+            finally:
+                tmp_path.unlink(missing_ok=True)
+
+    if artifact.local_path.exists():
+        yield artifact.local_path, _artifact_cache_info(
+            artifact.local_path,
+            source="local_cache",
+            uri=uri,
+            fallback_warning=fallback_warning,
+        )
+        return
+
+    raise FileNotFoundError(
+        f"{artifact.name} not found locally at {artifact.local_path}"
+        + (f" and no readable GCS artifact at {uri}" if uri else "")
+    )
+
+
 def _resolved_parquet(artifact: _ParquetArtifact) -> Iterator[tuple[Path, dict[str, Any]]]:
-    backend = _artifact_backend()
-    uri = _gcs_uri(artifact)
-    fallback_warning = None
-
-    if backend in {"auto", "gcs"} and uri:
-        tmp_path: Path | None = None
-        try:
-            tmp_path = _copy_gcs_to_temp(uri, artifact.name)
-        except Exception as exc:
-            if backend == "gcs":
-                raise RuntimeError(f"Cannot read {artifact.name} from GCS {uri}: {exc}") from exc
-            fallback_warning = f"Cannot read GCS artifact {uri}; using local cache if available."
-        else:
-            try:
-                yield tmp_path, _artifact_cache_info(tmp_path, source="gcs", uri=uri)
-                return
-            finally:
-                tmp_path.unlink(missing_ok=True)
-
-    if artifact.local_path.exists():
-        yield artifact.local_path, _artifact_cache_info(
-            artifact.local_path,
-            source="local_cache",
-            uri=uri,
-            fallback_warning=fallback_warning,
-        )
-        return
-
-    raise FileNotFoundError(
-        f"{artifact.name} not found locally at {artifact.local_path}"
-        + (f" and no readable GCS artifact at {uri}" if uri else "")
-    )
+    return _resolved_artifact(artifact)
 
 
-@contextmanager
 def _resolved_json(artifact: _JsonArtifact) -> Iterator[tuple[Path, dict[str, Any]]]:
-    backend = _artifact_backend()
-    uri = _gcs_uri(artifact)
-    fallback_warning = None
-
-    if backend in {"auto", "gcs"} and uri:
-        tmp_path: Path | None = None
-        try:
-            tmp_path = _copy_gcs_to_temp(uri, artifact.name)
-        except Exception as exc:
-            if backend == "gcs":
-                raise RuntimeError(f"Cannot read {artifact.name} from GCS {uri}: {exc}") from exc
-            fallback_warning = f"Cannot read GCS artifact {uri}; using local cache if available."
-        else:
-            try:
-                yield tmp_path, _artifact_cache_info(tmp_path, source="gcs", uri=uri)
-                return
-            finally:
-                tmp_path.unlink(missing_ok=True)
-
-    if artifact.local_path.exists():
-        yield artifact.local_path, _artifact_cache_info(
-            artifact.local_path,
-            source="local_cache",
-            uri=uri,
-            fallback_warning=fallback_warning,
-        )
-        return
-
-    raise FileNotFoundError(
-        f"{artifact.name} not found locally at {artifact.local_path}"
-        + (f" and no readable GCS artifact at {uri}" if uri else "")
-    )
+    return _resolved_artifact(artifact)
 
 
 def _parquet_not_found(artifact: _ParquetArtifact) -> dict[str, Any]:

--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -1,19 +1,386 @@
 """
-SO MCP core — readonly artifact queries.
+SO MCP core: read-only artifact queries and lightweight probes.
 
-Artifact paths resolved relative to this package (source-observatory/).
+Artifact paths are resolved relative to the source-observatory repository.
 """
 from __future__ import annotations
 
 import json
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
+from urllib.parse import urlparse
 
 import duckdb
+import requests
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
-_CHECK_PARQUET = _REPO_ROOT / "data" / "catalog_inventory" / "generated" / "source_check_results.parquet"
+_COLLECTORS_BASE = _REPO_ROOT / "scripts" / "collectors" / "base.py"
+_CHECK_PARQUET = (
+    _REPO_ROOT / "data" / "catalog_inventory" / "generated" / "source_check_results.parquet"
+)
+_INVENTORY_PARQUET = (
+    _REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_latest.parquet"
+)
+_INVENTORY_REPORT = (
+    _REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_report.json"
+)
 _SIGNALS_JSON = _REPO_ROOT / "data" / "catalog" / "catalog_signals.json"
+_RADAR_JSON = _REPO_ROOT / "data" / "radar" / "radar_summary.json"
+_PORTAL_SUMMARY_JSON = _REPO_ROOT / "data" / "portal_scout" / "discovered_portals_summary.json"
+_DISCOVERED_PORTALS_PARQUET = _REPO_ROOT / "data" / "portal_scout" / "discovered_portals.parquet"
+_NEW_CANDIDATES_PARQUET = _REPO_ROOT / "data" / "portal_scout" / "new_candidates.parquet"
+_DEFAULT_CACHE_MAX_AGE_HOURS = 24
+_DEFAULT_GCS_PREFIXES = {
+    "CATALOG_INVENTORY_GCS_PREFIX": "gs://dataciviclab-clean/catalog_inventory",
+    "PORTAL_SCOUT_GCS_PREFIX": "gs://dataciviclab-clean/portal_scout",
+}
+_SOURCE_CHECK_ARTIFACT = "source_check_results.parquet"
+_CATALOG_INVENTORY_ARTIFACT = "catalog_inventory_latest.parquet"
+_CATALOG_INVENTORY_REPORT_ARTIFACT = "catalog_inventory_report.json"
+_DISCOVERED_PORTALS_ARTIFACT = "discovered_portals.parquet"
+
+_FORMAT_BY_CONTENT_TYPE = {
+    "text/csv": "CSV",
+    "application/json": "JSON",
+    "application/ld+json": "JSON",
+    "application/vnd.ms-excel": "XLS",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
+    "application/xml": "XML",
+    "text/xml": "XML",
+    "application/pdf": "PDF",
+    "application/parquet": "PARQUET",
+}
+_FORMAT_BY_SUFFIX = {
+    ".csv": "CSV",
+    ".json": "JSON",
+    ".geojson": "JSON",
+    ".xlsx": "XLSX",
+    ".xls": "XLS",
+    ".xml": "XML",
+    ".pdf": "PDF",
+    ".parquet": "PARQUET",
+    ".zip": "ZIP",
+}
+
+_ENV_LOADED = False
+
+
+def _load_collectors_base() -> Any:
+    spec = importlib.util.spec_from_file_location("_so_collectors_base", _COLLECTORS_BASE)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load collectors base from {_COLLECTORS_BASE}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_collectors_base = _load_collectors_base()
+observatory_get = _collectors_base.observatory_get
+observatory_head = _collectors_base.observatory_head
+
+
+@dataclass(frozen=True)
+class _ParquetArtifact:
+    name: str
+    local_path: Path
+    gcs_env: str
+    gcs_key: str
+
+
+@dataclass(frozen=True)
+class _JsonArtifact:
+    name: str
+    local_path: Path
+    gcs_env: str
+    gcs_key: str
+
+
+def _source_check_parquet() -> _ParquetArtifact:
+    return _ParquetArtifact(
+        name=_SOURCE_CHECK_ARTIFACT,
+        local_path=_CHECK_PARQUET,
+        gcs_env="CATALOG_INVENTORY_GCS_PREFIX",
+        gcs_key="source-check/source_check_results.parquet",
+    )
+
+
+def _catalog_inventory_parquet() -> _ParquetArtifact:
+    return _ParquetArtifact(
+        name=_CATALOG_INVENTORY_ARTIFACT,
+        local_path=_INVENTORY_PARQUET,
+        gcs_env="CATALOG_INVENTORY_GCS_PREFIX",
+        gcs_key="catalog_inventory_latest.parquet",
+    )
+
+
+def _catalog_inventory_report_artifact() -> _JsonArtifact:
+    return _JsonArtifact(
+        name=_CATALOG_INVENTORY_REPORT_ARTIFACT,
+        local_path=_INVENTORY_REPORT,
+        gcs_env="CATALOG_INVENTORY_GCS_PREFIX",
+        gcs_key="catalog_inventory_report.json",
+    )
+
+
+def _discovered_portals_gcs_parquet(local_path: Path) -> _ParquetArtifact:
+    return _ParquetArtifact(
+        name=local_path.name,
+        local_path=local_path,
+        gcs_env="PORTAL_SCOUT_GCS_PREFIX",
+        gcs_key="discovered_portals.parquet",
+    )
+
+
+def _artifact_not_found(path: Path, artifact_name: str) -> dict[str, Any]:
+    return {
+        "error": "artifact_not_found",
+        "artifact": artifact_name,
+        "message": f"{artifact_name} not found at {path}",
+        "hint": "Fetch the latest GitHub Actions artifact or run the SO workflow locally.",
+    }
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(_REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _table_columns(con: duckdb.DuckDBPyConnection, parquet_path: str) -> list[str]:
+    return [row[0] for row in con.execute(f'DESCRIBE FROM "{parquet_path}"').fetchall()]
+
+
+def _select_expr(column: str, columns: set[str]) -> str:
+    if column in columns:
+        return column
+    return f"NULL AS {column}"
+
+
+def _load_env_file_once() -> None:
+    global _ENV_LOADED
+    if _ENV_LOADED:
+        return
+    _ENV_LOADED = True
+    env_path = Path(os.environ.get("SO_ENV_FILE") or _REPO_ROOT.parent / ".env")
+    if not env_path.exists():
+        return
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip("'\"")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def _env(name: str) -> str | None:
+    _load_env_file_once()
+    value = os.environ.get(name)
+    return value.strip() if value and value.strip() else None
+
+
+def _artifact_backend() -> str:
+    backend = (_env("SO_ARTIFACT_BACKEND") or "auto").lower()
+    if backend not in {"auto", "gcs", "local"}:
+        return "auto"
+    return backend
+
+
+def _cache_max_age_hours() -> int:
+    raw = _env("SO_CACHE_MAX_AGE_HOURS")
+    if raw is None:
+        return _DEFAULT_CACHE_MAX_AGE_HOURS
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_CACHE_MAX_AGE_HOURS
+
+
+def _gcs_prefix(env_name: str) -> str | None:
+    return _env(f"SO_{env_name}") or _env(env_name) or _DEFAULT_GCS_PREFIXES.get(env_name)
+
+
+def _gcs_uri(artifact: _ParquetArtifact | _JsonArtifact) -> str | None:
+    prefix = _gcs_prefix(artifact.gcs_env)
+    if prefix is None:
+        return None
+    return f"{prefix.rstrip('/')}/{artifact.gcs_key}"
+
+
+def _artifact_cache_info(
+    path: Path,
+    *,
+    source: str = "local_cache",
+    uri: str | None = None,
+    fallback_warning: str | None = None,
+) -> dict[str, Any]:
+    stat = path.stat()
+    modified_at = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+    age_hours = (datetime.now(timezone.utc) - modified_at).total_seconds() / 3600
+    max_age_hours = _cache_max_age_hours()
+    stale = source == "local_cache" and age_hours > max_age_hours
+    info: dict[str, Any] = {
+        "source": source,
+        "path": _display_path(path),
+        "uri": uri,
+        "modified_at": modified_at.isoformat(),
+        "age_hours": round(age_hours, 2),
+        "max_age_hours": max_age_hours,
+        "stale": stale,
+        "source_of_truth": "GitHub Actions artifact or configured GCS prefix",
+    }
+    if source == "gcs":
+        info["source_of_truth"] = "configured GCS prefix"
+    if stale:
+        info["warning"] = (
+            "Local artifact cache is older than the operational freshness threshold; "
+            "refresh it from CI/GCS or regenerate it before using results as current."
+        )
+    if fallback_warning:
+        info["fallback_warning"] = fallback_warning
+    return info
+
+
+def _public_url(uri: str) -> str:
+    if uri.startswith("gs://"):
+        bucket_and_path = uri.removeprefix("gs://")
+        bucket, _, object_name = bucket_and_path.partition("/")
+        return f"https://storage.googleapis.com/{bucket}/{object_name}"
+    return uri
+
+
+def _download_public_to_temp(uri: str, tmp_path: Path) -> None:
+    response = requests.get(_public_url(uri), timeout=120, stream=True)
+    response.raise_for_status()
+    with tmp_path.open("wb") as fh:
+        for chunk in response.iter_content(chunk_size=1024 * 1024):
+            if chunk:
+                fh.write(chunk)
+
+
+def _copy_gcs_to_temp(uri: str, artifact_name: str) -> Path:
+    suffix = Path(artifact_name).suffix or ".tmp"
+    tmp = tempfile.NamedTemporaryFile(prefix=f"so_mcp_{artifact_name}_", suffix=suffix, delete=False)
+    tmp_path = Path(tmp.name)
+    tmp.close()
+    try:
+        try:
+            _download_public_to_temp(uri, tmp_path)
+        except requests.RequestException:
+            subprocess.run(
+                ["gcloud", "storage", "cp", uri, str(tmp_path)],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    return tmp_path
+
+
+@contextmanager
+def _resolved_parquet(artifact: _ParquetArtifact) -> Iterator[tuple[Path, dict[str, Any]]]:
+    backend = _artifact_backend()
+    uri = _gcs_uri(artifact)
+    fallback_warning = None
+
+    if backend in {"auto", "gcs"} and uri:
+        tmp_path: Path | None = None
+        try:
+            tmp_path = _copy_gcs_to_temp(uri, artifact.name)
+        except Exception as exc:
+            if backend == "gcs":
+                raise RuntimeError(f"Cannot read {artifact.name} from GCS {uri}: {exc}") from exc
+            fallback_warning = f"Cannot read GCS artifact {uri}; using local cache if available."
+        else:
+            try:
+                yield tmp_path, _artifact_cache_info(tmp_path, source="gcs", uri=uri)
+                return
+            finally:
+                tmp_path.unlink(missing_ok=True)
+
+    if artifact.local_path.exists():
+        yield artifact.local_path, _artifact_cache_info(
+            artifact.local_path,
+            source="local_cache",
+            uri=uri,
+            fallback_warning=fallback_warning,
+        )
+        return
+
+    raise FileNotFoundError(
+        f"{artifact.name} not found locally at {artifact.local_path}"
+        + (f" and no readable GCS artifact at {uri}" if uri else "")
+    )
+
+
+@contextmanager
+def _resolved_json(artifact: _JsonArtifact) -> Iterator[tuple[Path, dict[str, Any]]]:
+    backend = _artifact_backend()
+    uri = _gcs_uri(artifact)
+    fallback_warning = None
+
+    if backend in {"auto", "gcs"} and uri:
+        tmp_path: Path | None = None
+        try:
+            tmp_path = _copy_gcs_to_temp(uri, artifact.name)
+        except Exception as exc:
+            if backend == "gcs":
+                raise RuntimeError(f"Cannot read {artifact.name} from GCS {uri}: {exc}") from exc
+            fallback_warning = f"Cannot read GCS artifact {uri}; using local cache if available."
+        else:
+            try:
+                yield tmp_path, _artifact_cache_info(tmp_path, source="gcs", uri=uri)
+                return
+            finally:
+                tmp_path.unlink(missing_ok=True)
+
+    if artifact.local_path.exists():
+        yield artifact.local_path, _artifact_cache_info(
+            artifact.local_path,
+            source="local_cache",
+            uri=uri,
+            fallback_warning=fallback_warning,
+        )
+        return
+
+    raise FileNotFoundError(
+        f"{artifact.name} not found locally at {artifact.local_path}"
+        + (f" and no readable GCS artifact at {uri}" if uri else "")
+    )
+
+
+def _parquet_not_found(artifact: _ParquetArtifact) -> dict[str, Any]:
+    return _artifact_not_found(artifact.local_path, artifact.name)
+
+
+def _json_not_found(artifact: _JsonArtifact) -> dict[str, Any]:
+    return _artifact_not_found(artifact.local_path, artifact.name)
+
+
+def _load_inventory_report() -> tuple[dict[str, Any], dict[str, Any]] | None:
+    artifact = _catalog_inventory_report_artifact()
+    try:
+        with _resolved_json(artifact) as (path, cache):
+            with path.open(encoding="utf-8") as fh:
+                return json.load(fh), cache
+    except FileNotFoundError:
+        return None
 
 
 def query_inventory(
@@ -21,94 +388,485 @@ def query_inventory(
     min_score: int | None = None,
     limit: int = 50,
 ) -> dict[str, Any]:
-    """
-    Query source_check_results.parquet with optional filters.
-
-    Args:
-        source_id: filter to exact source_id (e.g. 'inps', 'istat_sdmx')
-        min_score: filter rows with intake_score >= min_score
-        limit: max rows returned (default 50)
-
-    Returns:
-        dict with artifact path, filters, results list, returned count, has_more.
-        Results columns: source_id, item_id, reachable, http_status, granularity,
-        year_min, year_max, intake_score, intake_candidate.
-    """
-    if not _CHECK_PARQUET.exists():
-        return {
-            "error": "artifact_not_found",
-            "message": f"source_check_results.parquet not found at {_CHECK_PARQUET}",
-            "hint": "Run: python -m mcp.so_server from source-observatory/ to initialize",
-        }
-
-    parquet_path = str(_CHECK_PARQUET.resolve())
-    con = duckdb.connect()
-
-    query = f'SELECT * FROM "{parquet_path}"'
-    filters: list[str] = []
-    params: list[Any] = []
-
-    if source_id:
-        filters.append("source_id = ?")
-        params.append(source_id)
-    if min_score is not None:
-        filters.append("intake_score >= ?")
-        params.append(min_score)
-    if filters:
-        query += " WHERE " + " AND ".join(filters)
-    query += f" ORDER BY intake_score DESC NULLS LAST LIMIT {limit}"
-
+    """Query source_check_results.parquet with optional source and score filters."""
+    safe_limit = max(1, min(int(limit or 50), 200))
+    artifact = _source_check_parquet()
     try:
-        rows = con.execute(query, params).fetchall()
-        cols = [c[0] for c in con.execute(f'DESCRIBE FROM "{parquet_path}"').fetchall()]
-        results = [dict(zip(cols, r)) for r in rows]
-    except Exception as e:
-        return {"error": type(e).__name__, "message": str(e)}
-    finally:
-        con.close()
+        with _resolved_parquet(artifact) as (resolved_path, cache):
+            parquet_path = str(resolved_path)
+            query = f'SELECT * FROM "{parquet_path}"'
+            filters: list[str] = []
+            params: list[Any] = []
+
+            if source_id:
+                filters.append("source_id = ?")
+                params.append(source_id)
+            if min_score is not None:
+                filters.append("intake_score >= ?")
+                params.append(min_score)
+            if filters:
+                query += " WHERE " + " AND ".join(filters)
+            query += f" ORDER BY intake_score DESC NULLS LAST LIMIT {safe_limit}"
+
+            con = duckdb.connect()
+            try:
+                rows = con.execute(query, params).fetchall()
+                cols = _table_columns(con, parquet_path)
+            finally:
+                con.close()
+    except FileNotFoundError:
+        return _parquet_not_found(artifact)
 
     return {
-        "artifact": str(_CHECK_PARQUET.relative_to(_REPO_ROOT)),
-        "filters": {"source_id": source_id, "min_score": min_score, "limit": limit},
-        "results": results,
-        "returned": len(results),
-        "has_more": len(results) == limit,
+        "artifact": _display_path(_CHECK_PARQUET),
+        "cache": cache,
+        "filters": {"source_id": source_id, "min_score": min_score, "limit": safe_limit},
+        "results": [dict(zip(cols, row)) for row in rows],
+        "returned": len(rows),
+        "has_more": len(rows) == safe_limit,
     }
 
 
-def query_signals(
-    source_id: str | None = None,
-    limit: int | None = None,
-) -> dict[str, Any]:
-    """
-    Query catalog_signals.json with optional filters.
-
-    Args:
-        source_id: filter to exact source (e.g. 'opencoesione')
-        limit: if provided, return only the last N signals per source
-
-    Returns:
-        dict with artifact path, captured_at, filters, signals list.
-        Each signal: source, protocol, signal_type, result, detail, suggested_action.
-        When limit is set, returns the last N signals (globally, not per source).
-    """
+def query_signals(source_id: str | None = None, limit: int | None = None) -> dict[str, Any]:
+    """Query catalog_signals.json with optional source filter."""
     if not _SIGNALS_JSON.exists():
-        return {
-            "error": "artifact_not_found",
-            "message": f"catalog_signals.json not found at {_SIGNALS_JSON}",
-        }
+        return _artifact_not_found(_SIGNALS_JSON, "catalog_signals.json")
 
-    with _SIGNALS_JSON.open(encoding="utf-8") as f:
-        signals_doc = json.load(f)
+    with _SIGNALS_JSON.open(encoding="utf-8") as fh:
+        signals_doc = json.load(fh)
 
     signals = signals_doc.get("signals", [])
     if source_id:
-        signals = [s for s in signals if s.get("source") == source_id]
+        signals = [signal for signal in signals if signal.get("source") == source_id]
+
+    safe_limit = None if limit is None else max(1, min(int(limit), 200))
+    selected = signals[-safe_limit:] if safe_limit is not None else signals
+    return {
+        "artifact": _display_path(_SIGNALS_JSON),
+        "captured_at": signals_doc.get("captured_at", ""),
+        "filters": {"source_id": source_id, "limit": safe_limit},
+        "signals": selected,
+        "returned": len(selected),
+    }
+
+
+def radar_summary(source_id: str | None = None) -> dict[str, Any]:
+    """Return radar health summary, optionally for one source."""
+    if not _RADAR_JSON.exists():
+        return _artifact_not_found(_RADAR_JSON, "radar_summary.json")
+
+    with _RADAR_JSON.open(encoding="utf-8") as fh:
+        radar_doc = json.load(fh)
+
+    sources = radar_doc.get("sources", [])
+    if not isinstance(sources, list):
+        sources = []
+    if source_id:
+        sources = [source for source in sources if source.get("id") == source_id]
 
     return {
-        "artifact": str(_SIGNALS_JSON.relative_to(_REPO_ROOT)),
-        "captured_at": signals_doc.get("captured_at", ""),
-        "filters": {"source_id": source_id, "limit": limit},
-        "signals": signals[-limit:] if limit is not None else signals,
-        "returned": len(signals[-limit:] if limit is not None else signals),
+        "artifact": _display_path(_RADAR_JSON),
+        "generated_at": radar_doc.get("generated_at"),
+        "probe_date": radar_doc.get("probe_date"),
+        "sources_total": radar_doc.get("sources_total"),
+        "status_counts": radar_doc.get("status_counts", {}),
+        "filters": {"source_id": source_id},
+        "sources": sources,
+        "returned": len(sources),
+    }
+
+
+def inventory_status(source_id: str | None = None) -> dict[str, Any]:
+    """Return catalog inventory build status from catalog_inventory_report.json."""
+    loaded = _load_inventory_report()
+    if loaded is None:
+        return _json_not_found(_catalog_inventory_report_artifact())
+    report, cache = loaded
+
+    sources = report.get("sources", {})
+    if not isinstance(sources, dict):
+        sources = {}
+
+    status_counts: dict[str, int] = {}
+    rows_total = 0
+    for info in sources.values():
+        if not isinstance(info, dict):
+            continue
+        status = str(info.get("status") or "unknown")
+        status_counts[status] = status_counts.get(status, 0) + 1
+        rows = info.get("rows")
+        if isinstance(rows, int):
+            rows_total += rows
+
+    if source_id:
+        source_info = sources.get(source_id)
+        return {
+            "artifact": _display_path(_INVENTORY_REPORT),
+            "cache": cache,
+            "captured_at": report.get("captured_at"),
+            "filters": {"source_id": source_id},
+            "source": source_info if isinstance(source_info, dict) else None,
+            "returned": 1 if isinstance(source_info, dict) else 0,
+        }
+
+    compact_sources = []
+    for key, info in sorted(sources.items()):
+        if not isinstance(info, dict):
+            continue
+        compact_sources.append(
+            {
+                "source_id": key,
+                "status": info.get("status"),
+                "protocol": info.get("protocol"),
+                "rows": info.get("rows"),
+                "method": info.get("method"),
+                "error": info.get("error"),
+            }
+        )
+
+    return {
+        "artifact": _display_path(_INVENTORY_REPORT),
+        "cache": cache,
+        "captured_at": report.get("captured_at"),
+        "registry_path": report.get("registry_path"),
+        "status_counts": status_counts,
+        "rows_total": rows_total,
+        "sources": compact_sources,
+        "returned": len(compact_sources),
+    }
+
+
+def catalog_inventory_search(
+    query: str,
+    source_id: str | None = None,
+    protocol: str | None = None,
+    limit: int = 25,
+) -> dict[str, Any]:
+    """Search catalog_inventory_latest.parquet across key text fields."""
+    clean_query = (query or "").strip().lower()
+    if not clean_query:
+        return {"error": "empty_query", "message": "Provide a non-empty query."}
+
+    safe_limit = max(1, min(int(limit or 25), 200))
+    artifact = _catalog_inventory_parquet()
+    try:
+        with _resolved_parquet(artifact) as (resolved_path, cache):
+            parquet_path = str(resolved_path)
+            con = duckdb.connect()
+            try:
+                columns = set(_table_columns(con, parquet_path))
+                search_columns = [
+                    column
+                    for column in (
+                        "item_id",
+                        "item_name",
+                        "title",
+                        "tags",
+                        "notes_excerpt",
+                        "topic",
+                        "theme",
+                    )
+                    if column in columns
+                ]
+                if not search_columns:
+                    return {"error": "schema_mismatch", "message": "No searchable text columns found."}
+                where = [
+                    "("
+                    + " OR ".join(
+                        f"lower(coalesce(cast({column} as varchar), '')) LIKE ?"
+                        for column in search_columns
+                    )
+                    + ")"
+                ]
+                like = f"%{clean_query}%"
+                params: list[Any] = [like] * len(search_columns)
+                if source_id:
+                    where.append("source_id = ?")
+                    params.append(source_id)
+                if protocol:
+                    where.append("protocol = ?")
+                    params.append(protocol)
+
+                select_columns = [
+                    "source_id",
+                    "protocol",
+                    "item_id",
+                    "item_name",
+                    "title",
+                    "organization",
+                    "tags",
+                    "landing_page",
+                    "distribution_url",
+                    "format",
+                    "source_status",
+                    "inventory_method",
+                    "item_kind",
+                    "api_base_url",
+                    "captured_at",
+                    "civic_priority",
+                ]
+                select_sql = ", ".join(_select_expr(column, columns) for column in select_columns)
+                sql = f"""
+                    SELECT {select_sql}
+                    FROM "{parquet_path}"
+                    WHERE {" AND ".join(where)}
+                    ORDER BY source_id NULLS LAST, title NULLS LAST, item_id
+                    LIMIT {safe_limit}
+                """
+                rows = con.execute(sql, params).fetchall()
+                cols = [desc[0] for desc in con.description]
+            finally:
+                con.close()
+    except FileNotFoundError:
+        return _parquet_not_found(artifact)
+
+    result: dict[str, Any] = {
+        "artifact": _display_path(_INVENTORY_PARQUET),
+        "cache": cache,
+        "filters": {
+            "query": clean_query,
+            "source_id": source_id,
+            "protocol": protocol,
+            "limit": safe_limit,
+        },
+        "results": [dict(zip(cols, row)) for row in rows],
+        "returned": len(rows),
+        "has_more": len(rows) == safe_limit,
+    }
+    if not rows and source_id:
+        result["source_status"] = _inventory_source_status(source_id)
+    return result
+
+
+def portal_candidates(
+    protocol: str | None = None,
+    only_new: bool = True,
+    limit: int = 25,
+) -> dict[str, Any]:
+    """Return portal discovery candidates from portal-scout artifacts."""
+    local_path = _NEW_CANDIDATES_PARQUET if only_new else _DISCOVERED_PORTALS_PARQUET
+    artifact = _discovered_portals_gcs_parquet(local_path)
+    safe_limit = max(1, min(int(limit or 25), 200))
+    try:
+        with _resolved_parquet(artifact) as (resolved_path, cache):
+            parquet_path = str(resolved_path)
+            con = duckdb.connect()
+            try:
+                columns = set(_table_columns(con, parquet_path))
+                where: list[str] = []
+                params: list[Any] = []
+                if protocol:
+                    where.append("protocol = ?")
+                    params.append(protocol)
+                if only_new and "in_registry" in columns:
+                    where.append("lower(cast(in_registry as varchar)) IN ('no', 'false')")
+
+                sql = f"""
+                    SELECT *
+                    FROM "{parquet_path}"
+                    {"WHERE " + " AND ".join(where) if where else ""}
+                    ORDER BY in_registry ASC, protocol, domain
+                    LIMIT {safe_limit}
+                """
+                rows = con.execute(sql, params).fetchall()
+                cols = [desc[0] for desc in con.description]
+            finally:
+                con.close()
+    except FileNotFoundError:
+        return _parquet_not_found(artifact)
+
+    summary = None
+    if _PORTAL_SUMMARY_JSON.exists():
+        with _PORTAL_SUMMARY_JSON.open(encoding="utf-8") as fh:
+            summary_doc = json.load(fh)
+        summary = {
+            "artifact": _display_path(_PORTAL_SUMMARY_JSON),
+            "generated_at": summary_doc.get("generated_at"),
+            "total_portals": summary_doc.get("total_portals"),
+            "new_candidates": summary_doc.get("new_candidates"),
+            "new_confirmed_protocol": summary_doc.get("new_confirmed_protocol"),
+            "by_protocol": summary_doc.get("by_protocol"),
+        }
+
+    return {
+        "artifact": _display_path(local_path),
+        "cache": cache,
+        "summary": summary,
+        "filters": {"protocol": protocol, "only_new": only_new, "limit": safe_limit},
+        "candidates": [dict(zip(cols, row)) for row in rows],
+        "returned": len(rows),
+        "has_more": len(rows) == safe_limit,
+    }
+
+
+def _guess_format(url: str, content_type: str | None) -> str | None:
+    media_type = (content_type or "").split(";", 1)[0].strip().lower()
+    if media_type in _FORMAT_BY_CONTENT_TYPE:
+        return _FORMAT_BY_CONTENT_TYPE[media_type]
+
+    suffix = Path(urlparse(url).path).suffix.lower()
+    return _FORMAT_BY_SUFFIX.get(suffix)
+
+
+def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
+    """Probe a single URL with HEAD and a small GET fallback."""
+    clean_url = (url or "").strip()
+    parsed = urlparse(clean_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return {
+            "url": clean_url,
+            "http_status": None,
+            "content_type": None,
+            "format": None,
+            "size": None,
+            "is_reachable": False,
+            "error": "invalid_url",
+        }
+
+    safe_timeout = max(1, min(int(timeout or 15), 60))
+    try:
+        response = observatory_head(clean_url, timeout=safe_timeout)
+    except requests.RequestException as exc:
+        try:
+            response = observatory_get(
+                clean_url,
+                timeout=safe_timeout,
+                headers={"Range": "bytes=0-0"},
+                stream=True,
+            )
+        except requests.RequestException as fallback_exc:
+            return {
+                "url": clean_url,
+                "http_status": None,
+                "content_type": None,
+                "format": _guess_format(clean_url, None),
+                "size": None,
+                "is_reachable": False,
+                "error": type(fallback_exc).__name__,
+                "message": str(fallback_exc)[:200] or str(exc)[:200],
+            }
+
+    content_type = response.headers.get("content-type")
+    content_length = response.headers.get("content-length")
+    try:
+        size = int(content_length) if content_length is not None else None
+    except ValueError:
+        size = None
+
+    return {
+        "url": clean_url,
+        "http_status": response.status_code,
+        "content_type": content_type,
+        "format": _guess_format(clean_url, content_type),
+        "size": size,
+        "is_reachable": response.status_code < 400,
+    }
+
+
+def _score_dataflow(text: str, keywords: list[str]) -> int:
+    low = text.lower()
+    score = 0
+    for keyword in keywords:
+        pattern = re.escape(keyword.lower())
+        if re.search(rf"\b{pattern}\b", low):
+            score += 3
+        elif keyword.lower() in low:
+            score += 1
+    return score
+
+
+def _inventory_source_status(source_id: str) -> dict[str, Any] | None:
+    loaded = _load_inventory_report()
+    if loaded is None:
+        return None
+    report, _cache = loaded
+    sources = report.get("sources")
+    if not isinstance(sources, dict):
+        return None
+    source_info = sources.get(source_id)
+    return source_info if isinstance(source_info, dict) else None
+
+
+def _read_sdmx_inventory_rows(parquet_path: Path) -> list[dict[str, Any]]:
+    con = duckdb.connect()
+    try:
+        rows = con.execute(
+            f"""
+            SELECT source_id, item_id, item_name, title, tags, api_base_url, source_url
+            FROM "{parquet_path}"
+            WHERE source_id = 'istat_sdmx'
+            """
+        ).fetchall()
+    finally:
+        con.close()
+    cols = [
+        "source_id",
+        "item_id",
+        "item_name",
+        "title",
+        "tags",
+        "api_base_url",
+        "source_url",
+    ]
+    return [dict(zip(cols, row)) for row in rows]
+
+
+def discover_sdmx(keywords: list[str] | str, limit: int = 30) -> dict[str, Any]:
+    """Discover ISTAT SDMX dataflows from local SO artifacts."""
+    if isinstance(keywords, str):
+        clean_keywords = [part.strip().lower() for part in keywords.split(",") if part.strip()]
+    else:
+        clean_keywords = [str(part).strip().lower() for part in keywords if str(part).strip()]
+    if not clean_keywords:
+        return {"error": "empty_keywords", "message": "Provide at least one keyword."}
+
+    safe_limit = max(1, min(int(limit or 30), 100))
+    try:
+        artifact = _catalog_inventory_parquet()
+        with _resolved_parquet(artifact) as (resolved_path, cache):
+            rows = _read_sdmx_inventory_rows(resolved_path)
+    except FileNotFoundError:
+        return _parquet_not_found(_catalog_inventory_parquet())
+
+    if not rows:
+        source_status = _inventory_source_status("istat_sdmx")
+        return {
+            "error": "source_unavailable",
+            "artifact": _display_path(_INVENTORY_PARQUET),
+            "cache": cache,
+            "source_id": "istat_sdmx",
+            "message": "No ISTAT SDMX rows found in catalog_inventory_latest.parquet.",
+            "source_status": source_status,
+            "filters": {"keywords": clean_keywords, "limit": safe_limit},
+            "dataflows": [],
+            "returned": 0,
+            "matched": 0,
+        }
+
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(row)
+        text = " ".join(
+            str(item.get(key) or "") for key in ("item_id", "item_name", "title", "tags")
+        )
+        score = _score_dataflow(text, clean_keywords)
+        if score <= 0:
+            continue
+        item["relevance_score"] = score
+        results.append(item)
+
+    results.sort(
+        key=lambda item: (
+            item["relevance_score"],
+            str(item.get("title") or item.get("item_name") or ""),
+        ),
+        reverse=True,
+    )
+    return {
+        "artifact": _display_path(_INVENTORY_PARQUET),
+        "cache": cache,
+        "filters": {"keywords": clean_keywords, "limit": safe_limit},
+        "dataflows": results[:safe_limit],
+        "returned": min(len(results), safe_limit),
+        "matched": len(results),
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ duckdb>=1.5.2,<2.0
 pandas>=3.0.2,<4.0
 pyarrow>=14.0,<24.0
 ddgs>=9.0,<10.0
+mcp>=1.0.0
+fastmcp>=0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ PyYAML>=6.0.3,<7.0
 duckdb>=1.5.2,<2.0
 pandas>=3.0.2,<4.0
 pyarrow>=14.0,<24.0
-pytz>=2024.1
 ddgs>=9.0,<10.0
 mcp>=1.0.0
 fastmcp>=0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ PyYAML>=6.0.3,<7.0
 duckdb>=1.5.2,<2.0
 pandas>=3.0.2,<4.0
 pyarrow>=14.0,<24.0
+pytz>=2024.1
 ddgs>=9.0,<10.0
 mcp>=1.0.0
 fastmcp>=0.1.0

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -39,7 +39,9 @@ def test_query_inventory_filters_and_orders(tmp_path, monkeypatch) -> None:
 
     assert result["returned"] == 1
     assert result["results"][0]["item_id"] == "high"
-    assert result["filters"] == {"source_id": "a", "min_score": 40, "limit": 10}
+    assert result["filters"]["source_id"] == "a"
+    assert result["filters"]["min_score"] == 40
+    assert result["filters"]["limit"] == 10
     assert result["cache"]["source"] == "local_cache"
     assert result["cache"]["source_of_truth"] == "GitHub Actions artifact or configured GCS prefix"
     assert result["cache"]["stale"] is False

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
 import json
+import importlib.util
+import sys
+from pathlib import Path
+
+import pandas as pd  # must be before so_server_core import
+
+# Force-load local so_server_core bypassing pip-installed mcp package
+SO_MCP_PATH = Path(__file__).resolve().parents[1] / "mcp" / "so_server_core.py"
+_spec = importlib.util.spec_from_file_location("mcp.so_server_core", SO_MCP_PATH)
+assert _spec and _spec.loader
+_so_server_core = importlib.util.module_from_spec(_spec)
+sys.modules["mcp.so_server_core"] = _so_server_core
+_spec.loader.exec_module(_so_server_core)
+core = _so_server_core
 
 import duckdb
-import pandas as pd
 import pytest
-
-from mcp import so_server_core as core
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import json
+
+import duckdb
+import pandas as pd
+import pytest
+
+from mcp import so_server_core as core
+
+
+@pytest.fixture(autouse=True)
+def _use_local_artifacts(monkeypatch) -> None:
+    monkeypatch.setenv("SO_ARTIFACT_BACKEND", "local")
+
+
+def _write_parquet(path, rows: list[dict]) -> None:
+    con = duckdb.connect()
+    try:
+        con.register("rows_df", pd.DataFrame(rows))
+        con.execute(f"COPY rows_df TO '{path}' (FORMAT PARQUET)")
+    finally:
+        con.close()
+
+
+def test_query_inventory_filters_and_orders(tmp_path, monkeypatch) -> None:
+    parquet_path = tmp_path / "source_check_results.parquet"
+    _write_parquet(
+        parquet_path,
+        [
+            {"source_id": "a", "item_id": "low", "intake_score": 20},
+            {"source_id": "a", "item_id": "high", "intake_score": 55},
+            {"source_id": "b", "item_id": "other", "intake_score": 90},
+        ],
+    )
+    monkeypatch.setattr(core, "_CHECK_PARQUET", parquet_path)
+
+    result = core.query_inventory(source_id="a", min_score=40, limit=10)
+
+    assert result["returned"] == 1
+    assert result["results"][0]["item_id"] == "high"
+    assert result["filters"] == {"source_id": "a", "min_score": 40, "limit": 10}
+    assert result["cache"]["source"] == "local_cache"
+    assert result["cache"]["source_of_truth"] == "GitHub Actions artifact or configured GCS prefix"
+    assert result["cache"]["stale"] is False
+
+
+def test_query_inventory_reads_gcs_when_configured(tmp_path, monkeypatch) -> None:
+    parquet_path = tmp_path / "source_check_results.parquet"
+    _write_parquet(
+        parquet_path,
+        [{"source_id": "gcs_src", "item_id": "remote", "intake_score": 80}],
+    )
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_content(self, chunk_size):
+            yield parquet_path.read_bytes()
+
+    def fake_get(url, **kwargs):
+        assert url == "https://storage.googleapis.com/bucket/source-check/source_check_results.parquet"
+        return FakeResponse()
+
+    monkeypatch.setenv("SO_ARTIFACT_BACKEND", "gcs")
+    monkeypatch.setenv("CATALOG_INVENTORY_GCS_PREFIX", "gs://bucket")
+    monkeypatch.setattr(core.requests, "get", fake_get)
+
+    result = core.query_inventory(source_id="gcs_src", limit=10)
+
+    assert result["returned"] == 1
+    assert result["results"][0]["item_id"] == "remote"
+    assert result["cache"]["source"] == "gcs"
+    assert result["cache"]["uri"] == "gs://bucket/source-check/source_check_results.parquet"
+    assert result["cache"]["stale"] is False
+
+
+def test_query_signals_filters_and_limits(tmp_path, monkeypatch) -> None:
+    signals_path = tmp_path / "catalog_signals.json"
+    signals_path.write_text(
+        json.dumps(
+            {
+                "captured_at": "2026-04-30T00:00:00+00:00",
+                "signals": [
+                    {"source": "a", "signal_type": "one"},
+                    {"source": "b", "signal_type": "two"},
+                    {"source": "a", "signal_type": "three"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(core, "_SIGNALS_JSON", signals_path)
+
+    result = core.query_signals(source_id="a", limit=1)
+
+    assert result["captured_at"] == "2026-04-30T00:00:00+00:00"
+    assert result["returned"] == 1
+    assert result["signals"][0]["signal_type"] == "three"
+
+
+def test_radar_summary_filters_source(tmp_path, monkeypatch) -> None:
+    radar_path = tmp_path / "radar_summary.json"
+    radar_path.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-30T00:00:00+00:00",
+                "probe_date": "2026-04-30",
+                "sources_total": 2,
+                "status_counts": {"GREEN": 1, "RED": 1},
+                "sources": [
+                    {"id": "a", "status": "GREEN"},
+                    {"id": "b", "status": "RED"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(core, "_RADAR_JSON", radar_path)
+
+    result = core.radar_summary(source_id="b")
+
+    assert result["status_counts"] == {"GREEN": 1, "RED": 1}
+    assert result["returned"] == 1
+    assert result["sources"][0]["status"] == "RED"
+
+
+def test_inventory_status_summarizes_report(tmp_path, monkeypatch) -> None:
+    report_path = tmp_path / "catalog_inventory_report.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "captured_at": "2026-04-30T00:00:00+00:00",
+                "registry_path": "data/radar/sources_registry.yaml",
+                "sources": {
+                    "a": {"status": "ok", "protocol": "ckan", "rows": 10},
+                    "b": {"status": "error", "protocol": "sdmx", "error": "HTTP 500"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(core, "_INVENTORY_REPORT", report_path)
+
+    summary = core.inventory_status()
+    filtered = core.inventory_status(source_id="b")
+
+    assert summary["status_counts"] == {"ok": 1, "error": 1}
+    assert summary["rows_total"] == 10
+    assert filtered["source"]["error"] == "HTTP 500"
+
+
+def test_catalog_inventory_search_filters_rows(tmp_path, monkeypatch) -> None:
+    inventory_path = tmp_path / "catalog_inventory_latest.parquet"
+    _write_parquet(
+        inventory_path,
+        [
+            {
+                "source_id": "openbdap",
+                "protocol": "ckan",
+                "item_id": "a",
+                "item_name": "dipendenti",
+                "title": "Dipendenti pubblici",
+                "organization": "MEF",
+                "tags": "personale",
+                "notes_excerpt": "",
+                "landing_page": "https://example.test/a",
+                "distribution_url": "",
+                "format": "CSV",
+                "source_status": "",
+                "inventory_method": "package_search",
+                "item_kind": "dataset",
+                "api_base_url": "https://example.test/api",
+                "captured_at": "2026-04-30",
+                "civic_priority": "high",
+                "topic": "",
+                "theme": "",
+            },
+            {
+                "source_id": "inps",
+                "protocol": "ckan",
+                "item_id": "b",
+                "item_name": "pensioni",
+                "title": "Pensioni",
+                "organization": "INPS",
+                "tags": "",
+                "notes_excerpt": "",
+                "landing_page": "",
+                "distribution_url": "",
+                "format": "",
+                "source_status": "",
+                "inventory_method": "package_list",
+                "item_kind": "dataset",
+                "api_base_url": "https://example.test/api",
+                "captured_at": "2026-04-30",
+                "civic_priority": "",
+                "topic": "",
+                "theme": "",
+            },
+        ],
+    )
+    monkeypatch.setattr(core, "_INVENTORY_PARQUET", inventory_path)
+
+    result = core.catalog_inventory_search("dipendenti", source_id="openbdap")
+
+    assert result["returned"] == 1
+    assert result["results"][0]["item_id"] == "a"
+
+
+def test_portal_candidates_filters_protocol(tmp_path, monkeypatch) -> None:
+    candidates_path = tmp_path / "new_candidates.parquet"
+    summary_path = tmp_path / "discovered_portals_summary.json"
+    _write_parquet(
+        candidates_path,
+        [
+            {
+                "domain": "a.example",
+                "protocol": "ckan",
+                "probe_url": "https://a.example/api/3/action/package_list",
+                "base_url": "https://a.example",
+                "in_registry": False,
+            },
+            {
+                "domain": "b.example",
+                "protocol": "html",
+                "probe_url": "https://b.example",
+                "base_url": "https://b.example",
+                "in_registry": False,
+            },
+        ],
+    )
+    summary_path.write_text(
+        json.dumps({"total_portals": 2, "new_candidates": 2, "by_protocol": {"ckan": 1}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(core, "_NEW_CANDIDATES_PARQUET", candidates_path)
+    monkeypatch.setattr(core, "_PORTAL_SUMMARY_JSON", summary_path)
+
+    result = core.portal_candidates(protocol="ckan", only_new=True)
+
+    assert result["summary"]["total_portals"] == 2
+    assert result["returned"] == 1
+    assert result["candidates"][0]["domain"] == "a.example"
+
+
+def test_probe_url_rejects_invalid_url() -> None:
+    result = core.probe_url("not-a-url")
+
+    assert result["is_reachable"] is False
+    assert result["error"] == "invalid_url"
+
+
+def test_discover_sdmx_reads_inventory(tmp_path, monkeypatch) -> None:
+    inventory_path = tmp_path / "catalog_inventory_latest.parquet"
+    _write_parquet(
+        inventory_path,
+        [
+            {
+                "source_id": "istat_sdmx",
+                "item_id": "DF_PREZZI",
+                "item_name": "DF_PREZZI",
+                "title": "Indice dei prezzi agricoli",
+                "tags": "prezzi, agricoltura",
+                "api_base_url": "https://example.test/rest",
+                "source_url": "https://example.test/rest/dataflow/IT1",
+            },
+            {
+                "source_id": "openbdap",
+                "item_id": "other",
+                "item_name": "other",
+                "title": "Other",
+                "tags": "",
+                "api_base_url": "https://example.test/api",
+                "source_url": "https://example.test/api/3/action/package_search",
+            },
+        ],
+    )
+    monkeypatch.setattr(core, "_INVENTORY_PARQUET", inventory_path)
+
+    result = core.discover_sdmx(["prezzi"], limit=5)
+
+    assert result["artifact"].endswith("catalog_inventory_latest.parquet")
+    assert result["returned"] == 1
+    assert result["dataflows"][0]["item_id"] == "DF_PREZZI"
+    assert result["dataflows"][0]["relevance_score"] > 0
+
+
+def test_discover_sdmx_reports_missing_source_from_inventory_report(tmp_path, monkeypatch) -> None:
+    inventory_path = tmp_path / "catalog_inventory_latest.parquet"
+    report_path = tmp_path / "catalog_inventory_report.json"
+    _write_parquet(
+        inventory_path,
+        [
+            {
+                "source_id": "openbdap",
+                "item_id": "other",
+                "item_name": "other",
+                "title": "Other",
+                "tags": "",
+                "api_base_url": "https://example.test/api",
+                "source_url": "https://example.test/api/3/action/package_search",
+            },
+        ],
+    )
+    report_path.write_text(
+        json.dumps(
+            {
+                "sources": {
+                    "istat_sdmx": {
+                        "status": "error",
+                        "protocol": "sdmx",
+                        "error": "HTTP 500",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(core, "_INVENTORY_PARQUET", inventory_path)
+    monkeypatch.setattr(core, "_INVENTORY_REPORT", report_path)
+
+    result = core.discover_sdmx(["prezzi"], limit=5)
+
+    assert result["error"] == "source_unavailable"
+    assert result["source_status"]["error"] == "HTTP 500"
+    assert result["dataflows"] == []

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -16,8 +16,8 @@ sys.modules["mcp.so_server_core"] = _so_server_core
 _spec.loader.exec_module(_so_server_core)
 core = _so_server_core
 
-import duckdb
-import pytest
+import duckdb  # noqa: E402
+import pytest  # noqa: E402
 
 
 @pytest.fixture(autouse=True)

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -8,6 +8,10 @@ Indice minimo dei workflow canonici di `source-observatory`.
   - triage di un catalog inventory per ricavare una shortlist
   - decide cosa mandare a `source-check` o `watchlist`
 
+- [mcp-artifact-triage.md](./mcp-artifact-triage.md)
+  - lettura ordinata degli artifact Source Observatory via MCP read-only
+  - chiarisce cosa e' coperto, cosa manca e quale workflow usare dopo
+
 - [source-check.md](./source-check.md)
   - verifica se una fonte o un dataset pubblico regge davvero come pista del Lab
   - esce con un verdetto singolo e un next step esplicito
@@ -16,6 +20,8 @@ Indice minimo dei workflow canonici di `source-observatory`.
 
 - `catalog-inventory-scout`
   - triage di una lista di item di un catalogo
+- `mcp-artifact-triage`
+  - orientamento sugli artifact gia' prodotti da radar, catalog-watch, inventory e discovery
 - `source-check`
   - valutazione umana della fonte come possibile pista del Lab
 
@@ -26,6 +32,8 @@ Indice minimo dei workflow canonici di `source-observatory`.
 Se la domanda è:
 
 - "cosa c'è in questo catalogo e cosa vale la pena approfondire?" -> `catalog-inventory-scout`
+- "cosa dicono gli artifact SO gia' prodotti?" -> `mcp-artifact-triage`
+- "questo portale è davvero un catalogo osservabile?" -> `portal-scout`
 - "il catalogo ha cambiato inventario o struttura?" -> leggi `data/catalog/CATALOG_WATCH_REPORT.md`
 - "questa fonte regge davvero come pista del Lab?" -> `source-check`
 

--- a/workflows/mcp-artifact-triage.md
+++ b/workflows/mcp-artifact-triage.md
@@ -1,0 +1,93 @@
+# MCP Artifact Triage
+
+Workflow per usare il layer MCP read-only di Source Observatory quando un agente deve capire cosa esiste gia' negli artifact.
+
+## Quando usarlo
+
+Usalo quando la domanda e':
+
+- quali fonti sono gia' osservate?
+- quali cataloghi sono inventariati?
+- ci sono candidati portale nuovi?
+- cosa dicono gli artifact prima di aprire un nuovo source-check?
+- perche' una fonte non compare nel catalog inventory?
+
+Non usarlo per:
+
+- validare definitivamente una fonte come pista del Lab
+- pubblicare un finding
+- modificare registry o artifact
+- decidere da solo un ingresso in `dataset-incubator`
+
+## Ordine di lettura
+
+1. `so_radar_summary`
+   - orienta lo stato fonte e la copertura radar
+   - utile per capire se una fonte e' gia' nota anche senza inventory
+
+2. `so_inventory_status`
+   - legge il report del catalog inventory
+   - usa il GCS pubblico di default, altrimenti cache locale se il backend e' `local` o GCS non e' raggiungibile in `auto`
+   - distingue `ok`, `error`, `protocol_not_supported` e assenza dal run
+   - e' il primo posto da controllare quando una fonte non appare nel parquet
+
+3. `so_catalog_inventory_search`
+   - cerca item o dataflow solo dentro l'inventory derivato
+   - non usarlo come prova di assenza assoluta di dataset
+
+4. `so_catalog_signals`
+   - controlla segnali di cambiamento catalogo
+   - utile prima di riaprire triage su fonti gia' monitorate
+
+5. `so_inventory_query`
+   - cerca risultati source-check item-level gia' prodotti
+   - utile per evitare duplicati e riusare evidenze
+
+6. `so_portal_candidates`
+   - controlla portali scoperti o nuovi candidati
+   - utile per alimentare `portal-scout`
+
+7. `so_probe_url`
+   - verifica puntuale di reachability o content-type
+   - non sostituisce `portal-scout`
+
+8. `so_discover_sdmx`
+   - consulta l'inventory SDMX se disponibile
+   - se l'inventory non e' disponibile, leggere lo stato restituito e non dedurre che ISTAT non abbia dataflow
+
+## Regole di interpretazione
+
+- Ogni risposta va letta insieme al campo `artifact` o `source`.
+- Per i parquet, `cache.source = gcs` e' la situazione preferita quando i prefissi GCS sono configurati.
+- Per i parquet, leggere sempre anche il blocco `cache`: se `stale = true`, refresh da artifact CI/GCS o rigenera prima di usare i risultati come stato corrente.
+- Un artifact mancante e' un problema di disponibilita' del run, non una conclusione sulla fonte.
+- Una fonte assente dall'inventory puo' essere fuori perimetro, non supportata, fallita nel run o semplicemente non enumerabile in modo difendibile.
+- `source_check_results.parquet` e `catalog_inventory_latest.parquet` hanno semantiche diverse: il primo contiene controlli item-level, il secondo inventory cataloghi.
+- Non fare fallback automatici tra artifact diversi senza dichiararlo nel report.
+
+## Output atteso
+
+Un triage MCP dovrebbe chiudere con:
+
+- artifact consultati
+- freschezza della cache locale, se sono stati letti parquet
+- stato per fonte, se rilevante
+- cosa e' coperto dagli artifact
+- cosa resta fuori
+- prossimo workflow consigliato
+
+Esempio:
+
+```text
+Artifact letti:
+- radar_summary: fonte presente, stato YELLOW
+- inventory_status: run error su endpoint catalogo
+- source_check_results: cache locale stale, non usata come fonte corrente
+- catalog_inventory_search: non interrogato perche' inventory non disponibile
+
+Interpretazione:
+la fonte e' nota al radar, ma non c'e' inventory interrogabile. Non e' una prova di assenza dataset.
+
+Next step:
+source-check su item noto oppure portal-scout se serve rivalutare l'enumerabilita'.
+```

--- a/workflows/mcp-artifact-triage.md
+++ b/workflows/mcp-artifact-triage.md
@@ -69,11 +69,11 @@ Non usarlo per:
    - controlla portali scoperti o nuovi candidati
    - utile per alimentare `portal-scout`
 
-9. `so_probe_url`
+12. `so_probe_url`
    - verifica puntuale di reachability o content-type
    - non sostituisce `portal-scout`
 
-10. `so_discover_sdmx`
+13. `so_discover_sdmx`
    - consulta l'inventory SDMX se disponibile
    - se l'inventory non e' disponibile, leggere lo stato restituito e non dedurre che ISTAT non abbia dataflow
 

--- a/workflows/mcp-artifact-triage.md
+++ b/workflows/mcp-artifact-triage.md
@@ -25,33 +25,55 @@ Non usarlo per:
    - orienta lo stato fonte e la copertura radar
    - utile per capire se una fonte e' gia' nota anche senza inventory
 
-2. `so_inventory_status`
+2. `so_radar_history`
+   - legge la storia probes per capire fonti con streak RED persistenti
+   - da usare quando serve capire se un RED e' occasionale o strutturale
+
+3. `so_radar_status_md`
+   - legge STATUS.md per un sommario umano leggibile
+   - utile per orientamento rapido senza dover parsare JSON
+
+4. `so_radar_delta`
+   - confronta ultimo e penultimo probe del radar
+   - restituisce solo le fonti cambiate, nuove RED, recovery, persistent RED
+   - da usare in session start o triage veloce senza parsare history a mano
+
+5. `so_inventory_status`
    - legge il report del catalog inventory
    - usa il GCS pubblico di default, altrimenti cache locale se il backend e' `local` o GCS non e' raggiungibile in `auto`
    - distingue `ok`, `error`, `protocol_not_supported` e assenza dal run
    - e' il primo posto da controllare quando una fonte non appare nel parquet
 
-3. `so_catalog_inventory_search`
+6. `so_catalog_inventory_search`
    - cerca item o dataflow solo dentro l'inventory derivato
    - non usarlo come prova di assenza assoluta di dataset
 
-4. `so_catalog_signals`
+7. `so_catalog_signals`
    - controlla segnali di cambiamento catalogo
    - utile prima di riaprire triage su fonti gia' monitorate
 
-5. `so_inventory_query`
+8. `so_inventory_query`
    - cerca risultati source-check item-level gia' prodotti
    - utile per evitare duplicati e riusare evidenze
+   - supporta `has_results` filter e include `gcs_uri` in risposta
 
-6. `so_portal_candidates`
+9. `so_find_by_url`
+   - cerca un URL in source_check_results e catalog_inventory
+   - da usare quando si conosce gia' un URL e si vuole sapere se e' catalogato
+
+10. `so_registry_query`
+    - interroga sources_registry.yaml per protocol, source_kind, observation_mode
+    - utile per capire quali fonti esistono e con che caratteristiche
+
+11. `so_portal_candidates`
    - controlla portali scoperti o nuovi candidati
    - utile per alimentare `portal-scout`
 
-7. `so_probe_url`
+9. `so_probe_url`
    - verifica puntuale di reachability o content-type
    - non sostituisce `portal-scout`
 
-8. `so_discover_sdmx`
+10. `so_discover_sdmx`
    - consulta l'inventory SDMX se disponibile
    - se l'inventory non e' disponibile, leggere lo stato restituito e non dedurre che ISTAT non abbia dataflow
 


### PR DESCRIPTION
## Summary

Layer MCP read-only per Source Observatory — 3 commit, ~1200 LOC nuove, 13 tool.

### Nuovi tool

- **`so_radar_delta`** — confronta ultimi 2 probe, restituisce solo variazioni (new RED, recoveries, persistent RED)
- **`so_find_by_url`** — cerca URL in `source_check_results` e `catalog_inventory_latest` parquet
- **`so_registry_query`** — filtra `sources_registry.yaml` per protocol/source_kind/observation_mode/source_id

### Miglioramenti tool esistenti

- **`query_inventory`**: aggiunto `has_results: bool | None` filter, `gcs_uri` in risposta
- **`radar_summary`**: include `persistent_red` dalla risposta JSON
- **`gcs_uri()`**: metodo sui dataclass artifact — DRY, centralizzato

### Fix review

- **C1**: aggiunto `def inventory_status(...)` mancante (dead code altrimenti)
- **C2**: rimossa doppia `_ParquetArtifact` (prima definizione vuota rimossa)
- **M1**: `collectors_base` reso lazy — init on first call, non a import time
- **L2**: `query_inventory` usa una sola connessione DuckDB invece di due

### Docs aggiornate

- `mcp/README.md`: 13 tool documentati, artifact table con `sources_registry.yaml`
- `workflows/mcp-artifact-triage.md`: step numbering corretto, 13 step

### Consumi artifact

```
data/radar/radar_summary.json         ✅
data/radar/radar_history.json         ✅ (nuovo)
data/radar/STATUS.md                  ✅ (nuovo)
data/radar/sources_registry.yaml     ✅ (nuovo)
data/catalog/catalog_signals.json   ✅
data/catalog_inventory/generated/*  ✅ (parquet + report)
data/portal_scout/*                  ✅
```

## Testing

- Test suite esistente: `tests/test_so_mcp.py` (327 righe, 8 test coverage)
- Syntax check passato su tutti i moduli
- Import-time lazy-load verificato (collectors_base non più bloccante)