### PR TITLE
fix(mcp): SSL fallback in probe_url e _html_extract_links

### DIFF
--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -206,10 +206,11 @@ _ENV_LOADED = False
 _collectors_base = None
 observatory_get = None
 observatory_head = None
+observatory_ssl_fallback_get = None
 
 
 def _get_observatory_get() -> Any:
-    global _collectors_base, observatory_get, observatory_head
+    global _collectors_base, observatory_get, observatory_head, observatory_ssl_fallback_get
     if _collectors_base is None:
         spec = importlib.util.spec_from_file_location("_so_collectors_base", _COLLECTORS_BASE)
         if spec is None or spec.loader is None:
@@ -219,12 +220,18 @@ def _get_observatory_get() -> Any:
         spec.loader.exec_module(_collectors_base)
         observatory_get = _collectors_base.observatory_get
         observatory_head = _collectors_base.observatory_head
+        observatory_ssl_fallback_get = _collectors_base.observatory_ssl_fallback_get
     return observatory_get
 
 
 def _get_observatory_head() -> Any:
     _get_observatory_get()  # ensure initialized
     return observatory_head
+
+
+def _get_observatory_ssl_fallback_get() -> Any:
+    _get_observatory_get()  # ensure initialized
+    return observatory_ssl_fallback_get
 
 
 @dataclass(frozen=True)
@@ -1042,7 +1049,7 @@ def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
     safe_timeout = max(1, min(int(timeout or 15), 60))
     try:
         response = _get_observatory_head()(clean_url, timeout=safe_timeout)
-    except requests.RequestException as exc:
+    except requests.RequestException:
         try:
             response = _get_observatory_get()(
                 clean_url,
@@ -1051,16 +1058,37 @@ def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
                 stream=True,
             )
         except requests.RequestException as fallback_exc:
-            return {
-                "url": clean_url,
-                "http_status": None,
-                "content_type": None,
-                "format": _guess_format(clean_url, None),
-                "size": None,
-                "is_reachable": False,
-                "error": type(fallback_exc).__name__,
-                "message": str(fallback_exc)[:200] or str(exc)[:200],
-            }
+            # Third attempt: SSL-fallback GET (handles certs expired/invalid)
+            try:
+                ssl_response, ssl_err = _get_observatory_ssl_fallback_get()(
+                    clean_url,
+                    timeout=safe_timeout,
+                    headers={"Range": "bytes=0-0"},
+                )
+                if ssl_response is not None:
+                    response = ssl_response
+                else:
+                    return {
+                        "url": clean_url,
+                        "http_status": None,
+                        "content_type": None,
+                        "format": _guess_format(clean_url, None),
+                        "size": None,
+                        "is_reachable": False,
+                        "error": "ssl_fallback_failed",
+                        "message": str(ssl_err)[:200] if ssl_err else str(fallback_exc)[:200],
+                    }
+            except Exception as ssl_third_exc:
+                return {
+                    "url": clean_url,
+                    "http_status": None,
+                    "content_type": None,
+                    "format": _guess_format(clean_url, None),
+                    "size": None,
+                    "is_reachable": False,
+                    "error": type(ssl_third_exc).__name__,
+                    "message": str(ssl_third_exc)[:200] or str(fallback_exc)[:200],
+                }
 
     content_type = response.headers.get("content-type")
     content_length = response.headers.get("content-length")
@@ -1519,12 +1547,18 @@ def _html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
         response = _get_observatory_get()(url, timeout=safe_timeout)
         content_type = response.headers.get("content-type", "")
     except Exception as exc:
-        return {
-            "url": url,
-            "is_reachable": False,
-            "error": type(exc).__name__,
-            "message": str(exc)[:200],
-        }
+        # Retry with SSL fallback
+        ssl_response, ssl_err = _get_observatory_ssl_fallback_get()(url, timeout=safe_timeout)
+        if ssl_response is not None:
+            response = ssl_response
+            content_type = response.headers.get("content-type", "")
+        else:
+            return {
+                "url": url,
+                "is_reachable": False,
+                "error": type(exc).__name__,
+                "message": str(exc)[:200],
+            }
 
     text_html = "text/html" in content_type.lower()
     try:

--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -1047,6 +1047,7 @@ def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
         }
 
     safe_timeout = max(1, min(int(timeout or 15), 60))
+    ssl_fallback_used = False
     try:
         response = _get_observatory_head()(clean_url, timeout=safe_timeout)
     except requests.RequestException:
@@ -1067,6 +1068,7 @@ def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
                 )
                 if ssl_response is not None:
                     response = ssl_response
+                    ssl_fallback_used = True
                 else:
                     return {
                         "url": clean_url,
@@ -1104,6 +1106,7 @@ def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
         "format": _guess_format(clean_url, content_type),
         "size": size,
         "is_reachable": response.status_code < 400,
+        "ssl_fallback_used": ssl_fallback_used,
     }
 
 
@@ -1542,16 +1545,26 @@ def _html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
         return {"error": "invalid_url", "message": f"Invalid URL: {url}"}
 
     safe_timeout = max(1, min(int(timeout or 20), 60))
+    ssl_fallback_used = False
 
     try:
         response = _get_observatory_get()(url, timeout=safe_timeout)
         content_type = response.headers.get("content-type", "")
     except Exception as exc:
         # Retry with SSL fallback
-        ssl_response, ssl_err = _get_observatory_ssl_fallback_get()(url, timeout=safe_timeout)
+        try:
+            ssl_response, ssl_err = _get_observatory_ssl_fallback_get()(url, timeout=safe_timeout)
+        except Exception as ssl_exc:
+            return {
+                "url": url,
+                "is_reachable": False,
+                "error": type(ssl_exc).__name__,
+                "message": str(ssl_exc)[:200],
+            }
         if ssl_response is not None:
             response = ssl_response
             content_type = response.headers.get("content-type", "")
+            ssl_fallback_used = True
         else:
             return {
                 "url": url,
@@ -1576,4 +1589,5 @@ def _html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
         "links": links,
         "total": len(links),
         "formats": sorted({link["format"] for link in links}),
+        "ssl_fallback_used": ssl_fallback_used,
     }

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -548,3 +548,66 @@ def test_infer_topic_tasso_not_false_positive(monkeypatch) -> None:
     result = core.infer_topic("tassazione دخل دخل")
     # No topic keywords match "tassazione" - not lavoro, not economia
     assert "lavoro" not in result["topics"]
+
+
+class _FakeSSLFallbackResponse:
+    """Fake response returned by SSL fallback when verify=False succeeds."""
+    status_code = 200
+
+    def __init__(self) -> None:
+        self.headers = {"content-type": "text/html; charset=utf-8", "content-length": "100"}
+
+
+def test_probe_url_ssl_fallback_used_when_fallback_succeeds(monkeypatch) -> None:
+    """When HEAD and GET both fail but SSL-fallback GET succeeds, ssl_fallback_used is True."""
+    ssl_fallback_called = False
+
+    def fake_head_factory():
+        def fake_head(url, **kwargs):
+            raise core.requests.RequestException("head failed")
+        return fake_head
+
+    def fake_get_factory():
+        def fake_get(url, **kwargs):
+            raise core.requests.RequestException("get failed")
+        return fake_get
+
+    def fake_ssl_fallback_factory():
+        def fake_ssl_fallback_get(url, **kwargs):
+            nonlocal ssl_fallback_called
+            ssl_fallback_called = True
+            return _FakeSSLFallbackResponse(), None  # (response, no_error)
+        return fake_ssl_fallback_get
+
+    monkeypatch.setattr(core, "_get_observatory_head", fake_head_factory)
+    monkeypatch.setattr(core, "_get_observatory_get", fake_get_factory)
+    monkeypatch.setattr(core, "_get_observatory_ssl_fallback_get", fake_ssl_fallback_factory)
+
+    result = core.probe_url("https://expired-cert.example.com/file.csv")
+
+    assert ssl_fallback_called, "SSL fallback should have been called"
+    assert result["is_reachable"] is True
+    assert result["ssl_fallback_used"] is True
+    assert result["http_status"] == 200
+
+
+def test_html_extract_links_ssl_fallback_failure_returns_reachable_false(monkeypatch) -> None:
+    """When _get_observatory_get fails and SSL fallback raises non-RequestException, returns is_reachable=False without exploding."""
+    def fake_get_factory():
+        def fake_get(url, **kwargs):
+            raise core.requests.RequestException("get failed")
+        return fake_get
+
+    def fake_ssl_fallback_factory():
+        def fake_ssl_fallback_raises(url, **kwargs):
+            raise ValueError("unexpected internal error")  # non-RequestException
+        return fake_ssl_fallback_raises
+
+    monkeypatch.setattr(core, "_get_observatory_get", fake_get_factory)
+    monkeypatch.setattr(core, "_get_observatory_ssl_fallback_get", fake_ssl_fallback_factory)
+
+    result = core._html_extract_links("https://expired-cert.example.com/page.html")
+
+    assert result["is_reachable"] is False
+    assert "error" in result
+    assert result["message"] == "unexpected internal error"


### PR DESCRIPTION
## Summary
- `probe_url` ora ritenta con `verify=False` su `SSLError` prima di fallire
- `_html_extract_links` ha retry SSL on generic `Exception` (copre anche connessione caduta)
- `_get_observatory_ssl_fallback_get()` carica `observatory_ssl_fallback_get` dai collector, pattern coerente col resto SO

## Verifiche
- `probe_url` OpenCivitas: 200 ✅
- `probe_url` dati_salute: 200 ✅
- SO test suite: 120 pass ✅