### PR TITLE
feat(html): page_url_template per csv_magnet + OpenCivitas entry

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -337,3 +337,26 @@ mef_irpef:
     homepage: https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
     delay_seconds: 0.2
   datasets_in_use: []
+opencivitas:
+  source_kind: catalog
+  protocol: html
+  observation_mode: catalog-watch
+  base_url: https://www.opencivitas.it/it/open-data
+  last_probed: '2026-05-07'
+  catalog_baseline:
+    captured_at: '2026-05-07'
+    metric: csv_magnet_total_links
+    value: 1084
+    method: csv_magnet_area_pages_paginated
+    reliability: medium
+    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback necessario per cert invalido.
+  verdict: go
+  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL fallback attivo. ZIP con CSV/XLSX dentro.
+  html_portal:
+    topic_hint: trasparenza
+    page_url_template: https://www.opencivitas.it/it/open-data?page={page}
+    page_start: 0
+    page_max: 100
+    page_stop_on_empty: true
+    delay_seconds: 0.3
+  datasets_in_use: []

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -385,6 +385,11 @@ def _scan_area_pages(
     enumera le pagine automaticamente partendo da page_start, fermandosi
     quando trova una pagina vuota (nessun link data) o raggiunge page_max.
 
+    Error handling: nel branch paginato si usa break su errore (perché le
+    pagine sono URL sequenziali sullo stesso server — se una cade, cadono
+    tutte). Nel branch area_pages legacy si usa continue (ogni URL è
+    indipendente, un errore non implica gli altri).
+
     Returns:
         summary dict, rows list
     """

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -371,28 +371,58 @@ def _scan_area_pages(
     base_url: str,
     *,
     page_delay: float = 0.2,
+    page_url_template: str | None = None,
+    page_start: int = 0,
+    page_max: int = 200,
+    page_stop_on_empty: bool = True,
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Scan portale HTML via area_pages (nessun second-level crawl).
 
     Fetch ogni area page direttamente → estrae tutti i link data.
     Tutto il contenido è sulla pagina area, no pagine figlie.
 
+    Se page_url_template è impostato (es. "https://site.it/page={page}"),
+    enumera le pagine automaticamente partendo da page_start, fermandosi
+    quando trova una pagina vuota (nessun link data) o raggiunge page_max.
+
     Returns:
         summary dict, rows list
     """
     all_data_links: list[dict[str, str]] = []
     seen_data_urls: set[str] = set()
+    pages_scanned = 0
 
-    for area_url in area_pages:
-        time.sleep(page_delay)
-        response, err = observatory_ssl_fallback_get(area_url, timeout=15)
-        if err or response is None:
-            continue
-        parser = _DataLinksParser(area_url, response.text)
-        for link in parser.links:
-            if link["url"] not in seen_data_urls:
+    if page_url_template:
+        page = page_start
+        while page <= page_max:
+            area_url = page_url_template.format(page=page)
+            time.sleep(page_delay)
+            response, err = observatory_ssl_fallback_get(area_url, timeout=15)
+            if err or response is None:
+                break
+            parser = _DataLinksParser(area_url, response.text)
+            links_this_page = [link for link in parser.links if link["url"] not in seen_data_urls]
+            if not links_this_page:
+                if page_stop_on_empty:
+                    break
+            for link in links_this_page:
                 seen_data_urls.add(link["url"])
                 all_data_links.append(link)
+            pages_scanned += 1
+            page += 1
+        area_pages_scanned = pages_scanned
+    else:
+        for area_url in area_pages:
+            time.sleep(page_delay)
+            response, err = observatory_ssl_fallback_get(area_url, timeout=15)
+            if err or response is None:
+                continue
+            parser = _DataLinksParser(area_url, response.text)
+            for link in parser.links:
+                if link["url"] not in seen_data_urls:
+                    seen_data_urls.add(link["url"])
+                    all_data_links.append(link)
+        area_pages_scanned = len(area_pages)
 
     # Stats
     prefix_matrix: dict[str, int] = {}
@@ -465,13 +495,13 @@ def _scan_area_pages(
 
     summary = {
         "total_links_exact": len(all_data_links),
-        "area_pages_scanned": len(area_pages),
+        "area_pages_scanned": area_pages_scanned,
         "by_format": by_format,
         "prefix_matrix": prefix_matrix,
         "series": series_serializable,
         "years_range": [min(years_set), max(years_set)] if years_set else [],
         "topics": dict(Counter(_guess_topic(link["url"], topic_hint) for link in all_data_links)),
-        "method": "csv_magnet_area_pages_direct",
+        "method": "csv_magnet_area_pages_paginated" if page_url_template else "csv_magnet_area_pages_direct",
     }
 
     return summary, rows
@@ -503,6 +533,10 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
     area_pages = html_portal_cfg.get("area_pages", [])
     topic_hint = html_portal_cfg.get("topic_hint")
     delay = html_portal_cfg.get("delay_seconds", 0.2)
+    page_url_template = html_portal_cfg.get("page_url_template")
+    page_start = html_portal_cfg.get("page_start", 0)
+    page_max = html_portal_cfg.get("page_max", 200)
+    page_stop_on_empty = html_portal_cfg.get("page_stop_on_empty", True)
 
     if sitemap_url:
         sample = html_portal_cfg.get("sample_pages", 30)
@@ -514,13 +548,17 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
             sample_pages=sample,
             page_delay=delay,
         )
-    elif area_pages:
+    elif area_pages or page_url_template:
         summary, rows = _scan_area_pages(
             area_pages,
             topic_hint,
             source_id,
             base_url,
             page_delay=delay,
+            page_url_template=page_url_template,
+            page_start=page_start,
+            page_max=page_max,
+            page_stop_on_empty=page_stop_on_empty,
         )
     else:
         # Homepage only probe

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -394,7 +394,7 @@ def _scan_area_pages(
 
     if page_url_template:
         page = page_start
-        while page <= page_max:
+        while pages_scanned < page_max:
             area_url = page_url_template.format(page=page)
             time.sleep(page_delay)
             response, err = observatory_ssl_fallback_get(area_url, timeout=15)
@@ -402,9 +402,9 @@ def _scan_area_pages(
                 break
             parser = _DataLinksParser(area_url, response.text)
             links_this_page = [link for link in parser.links if link["url"] not in seen_data_urls]
-            if not links_this_page:
-                if page_stop_on_empty:
-                    break
+            if not parser.links and page_stop_on_empty:
+                pages_scanned += 1
+                break
             for link in links_this_page:
                 seen_data_urls.add(link["url"])
                 all_data_links.append(link)

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -568,3 +568,122 @@ class TestErrorToStaleReason:
     def test_unknown_fallback(self):
         exc = Exception("Something completely unexpected")
         assert self._call(exc) == "unknown"
+
+
+class TestScanAreaPagesPagination:
+    """Tests for _scan_area_pages with page_url_template (pagination)."""
+
+    def test_page_url_template_stops_on_empty_page(self, monkeypatch):
+        """Collector stops when a page has no links at all (empty HTML, no <a> tags)."""
+        import collectors.html as html_collector
+
+        call_count = [0]
+
+        def fake_ssl_fallback_get(url, **kwargs):
+            call_count[0] += 1
+            page = call_count[0]
+            if page == 1:
+                # Page 0: has links
+                html = '<a href="https://docs.example.com/file1.csv">file1.csv</a>'
+            elif page == 2:
+                # Page 1: has links (different from page 0)
+                html = '<a href="https://docs.example.com/file2.csv">file2.csv</a>'
+            else:
+                # Page 2+: empty — no <a> tags at all
+                html = "<html><body><p>No results</p></body></html>"
+            response = FakeJsonResponse(payload=None, text=html, headers={"content-type": "text/html"})
+            return response, None
+
+        monkeypatch.setattr(html_collector, "observatory_ssl_fallback_get", fake_ssl_fallback_get)
+
+        summary, rows = html_collector._scan_area_pages(
+            area_pages=[],
+            topic_hint=None,
+            source_id="test_source",
+            base_url="https://example.com",
+            page_delay=0,
+            page_url_template="https://example.com/data?page={page}",
+            page_start=0,
+            page_max=10,
+            page_stop_on_empty=True,
+        )
+
+        # page 0 (links) + page 1 (links) + page 2 (empty, stop) = 3 pages scanned
+        assert summary["area_pages_scanned"] == 3
+        assert summary["method"] == "csv_magnet_area_pages_paginated"
+        assert summary["total_links_exact"] == 2
+        assert len(rows) == 2
+        urls = {r["url"] for r in rows}
+        assert urls == {"https://docs.example.com/file1.csv", "https://docs.example.com/file2.csv"}
+
+    def test_page_url_template_continues_when_all_links_are_duplicates(self, monkeypatch):
+        """Collector continues past pages where all links are duplicates of previous pages
+        (because parser.links is non-empty even if all are duplicates)."""
+        import collectors.html as html_collector
+
+        call_count = [0]
+
+        def fake_ssl_fallback_get(url, **kwargs):
+            call_count[0] += 1
+            page = call_count[0]
+            if page == 1:
+                html = '<a href="https://docs.example.com/file1.csv">file1.csv</a>'
+            elif page == 2:
+                # Page 1: same links as page 0 — all duplicates, page NOT empty
+                html = '<a href="https://docs.example.com/file1.csv">file1.csv</a>'
+            elif page == 3:
+                # Page 2: new link
+                html = '<a href="https://docs.example.com/file2.csv">file2.csv</a>'
+            else:
+                html = "<html><body></body></html>"
+            response = FakeJsonResponse(payload=None, text=html, headers={"content-type": "text/html"})
+            return response, None
+
+        monkeypatch.setattr(html_collector, "observatory_ssl_fallback_get", fake_ssl_fallback_get)
+
+        summary, rows = html_collector._scan_area_pages(
+            area_pages=[],
+            topic_hint=None,
+            source_id="test_source",
+            base_url="https://example.com",
+            page_delay=0,
+            page_url_template="https://example.com/data?page={page}",
+            page_start=0,
+            page_max=10,
+            page_stop_on_empty=True,
+        )
+
+        # page 0 (links) + page 1 (duplicates, continue) + page 2 (new links) + page 3 (empty, stop) = 4
+        assert summary["area_pages_scanned"] == 4
+        assert summary["total_links_exact"] == 2
+        assert len(rows) == 2
+
+    def test_page_url_template_respects_page_max(self, monkeypatch):
+        """Collector stops at page_max even if pages still have links."""
+        import collectors.html as html_collector
+
+        call_count = [0]
+
+        def fake_ssl_fallback_get(url, **kwargs):
+            call_count[0] += 1
+            html = f'<a href="https://docs.example.com/file{call_count[0]}.csv">file.csv</a>'
+            response = FakeJsonResponse(payload=None, text=html, headers={"content-type": "text/html"})
+            return response, None
+
+        monkeypatch.setattr(html_collector, "observatory_ssl_fallback_get", fake_ssl_fallback_get)
+
+        summary, rows = html_collector._scan_area_pages(
+            area_pages=[],
+            topic_hint=None,
+            source_id="test_source",
+            base_url="https://example.com",
+            page_delay=0,
+            page_url_template="https://example.com/data?page={page}",
+            page_start=0,
+            page_max=3,
+            page_stop_on_empty=True,
+        )
+
+        # Should have scanned exactly page_max pages
+        assert summary["area_pages_scanned"] == 3
+        assert len(rows) == 3


### PR DESCRIPTION
## Summary
- `_scan_area_pages` ora supporta `page_url_template` con placeholder `{page}`. Il collector enumera automaticamente le pagine da `page_start` fino a `page_max` o fino a pagina vuota (se `page_stop_on_empty: true`).
- OpenCivitas aggiunto al registry con 1 URL template invece di 55 URL esplicite.

## Config esempio
```yaml
html_portal:
  page_url_template: https://www.opencivitas.it/it/open-data?page={page}
  page_start: 0
  page_max: 100
  page_stop_on_empty: true
  delay_seconds: 0.3
```

## Verifiche
- 122 test passano ✅
- ruff clean ✅
- Registry YAML valido ✅