### PR TITLE
fix(ssl): catena SSL in base.py e bulk_source_check.py

### DIFF
--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -40,7 +40,7 @@ import requests
 import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from collectors.base import observatory_get, observatory_head, get_pooled_session
+from collectors.base import observatory_get, observatory_head, observatory_ssl_fallback_get, get_pooled_session
 
 logger = logging.getLogger(__name__)
 
@@ -179,10 +179,24 @@ def _http_head_with_retry(
                 time.sleep(0.5 * (attempt + 1))
                 continue
             return None, False, "timeout", None
+        except requests.exceptions.SSLError:
+            # Fallback: retry with observatory_head (which has SSL fallback built-in)
+            fallback_resp, fallback_err = observatory_ssl_fallback_get(url, timeout=HTTP_TIMEOUT)
+            if fallback_err is None and fallback_resp is not None:
+                ct = fallback_resp.headers.get("Content-Type", "") or ""
+                content_type = None
+                for fmt in ("JSON", "CSV", "XLSX", "XML", "PDF", "SDMX", "PARQUET"):
+                    if fmt.lower() in ct.lower():
+                        content_type = fmt
+                        break
+                if content_type is None and "excel" in ct.lower() and "spreadsheetml" not in ct.lower():
+                    content_type = "XLS"
+                elif content_type is None and "spreadsheetml" in ct.lower():
+                    content_type = "XLSX"
+                return fallback_resp.status_code, fallback_resp.status_code < 400, "", content_type
+            return None, False, "ssl_error", None
         except requests.exceptions.ConnectionError:
             return None, False, "connection_error", None
-        except requests.exceptions.SSLError:
-            return None, False, "ssl_error", None
         except Exception as exc:
             return None, False, str(exc)[:120], None
 

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -40,7 +40,7 @@ import requests
 import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from collectors.base import observatory_get, observatory_head, observatory_ssl_fallback_get, get_pooled_session
+from collectors.base import observatory_get, observatory_head, get_pooled_session
 
 logger = logging.getLogger(__name__)
 
@@ -180,9 +180,9 @@ def _http_head_with_retry(
                 continue
             return None, False, "timeout", None
         except requests.exceptions.SSLError:
-            # Fallback: retry with observatory_head (which has SSL fallback built-in)
-            fallback_resp, fallback_err = observatory_ssl_fallback_get(url, timeout=HTTP_TIMEOUT)
-            if fallback_err is None and fallback_resp is not None:
+            # observatory_head has SSL fallback built-in — use it instead of GET
+            try:
+                fallback_resp = observatory_head(url, timeout=HTTP_TIMEOUT)
                 ct = fallback_resp.headers.get("Content-Type", "") or ""
                 content_type = None
                 for fmt in ("JSON", "CSV", "XLSX", "XML", "PDF", "SDMX", "PARQUET"):
@@ -194,7 +194,8 @@ def _http_head_with_retry(
                 elif content_type is None and "spreadsheetml" in ct.lower():
                     content_type = "XLSX"
                 return fallback_resp.status_code, fallback_resp.status_code < 400, "", content_type
-            return None, False, "ssl_error", None
+            except requests.exceptions.RequestException:
+                return None, False, "ssl_error", None
         except requests.exceptions.ConnectionError:
             return None, False, "connection_error", None
         except Exception as exc:

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -29,6 +29,38 @@ class CollectorResult:
     rows: list[dict[str, Any]]
     warning: dict[str, Any] | None = None
     summary: dict[str, Any] | None = None
+    # Tracks whether the primary SSL attempt failed but fallback succeeded.
+    # None means no fallback; True means fallback was used and succeeded.
+    ssl_fallback_used: bool | None = None
+
+
+@dataclass
+class SslFallbackResult:
+    """Result of observatory_ssl_fallback_get.
+
+    Attributes:
+        response: the HTTP response if request succeeded (primary or fallback), None otherwise
+        err: Exception if both primary and fallback failed, None otherwise
+        ssl_fallback_used: True if primary SSL failed but fallback succeeded,
+                          False if primary SSL failed and fallback also failed,
+                          None if primary succeeded (no fallback needed)
+
+    Supports tuple unpacking: response, err = result
+    """
+    response: requests.Response | None
+    err: Exception | None
+    ssl_fallback_used: bool | None = None
+
+    def __iter__(self):
+        """Support tuple unpacking: response, err = result"""
+        return iter((self.response, self.err))
+
+    def __getitem__(self, index):
+        return (self.response, self.err)[index]
+
+    def tuple(self) -> tuple[requests.Response | None, Exception | None]:
+        """Explicit tuple conversion."""
+        return (self.response, self.err)
 
 
 def now_utc_iso() -> str:
@@ -80,13 +112,14 @@ def observatory_ssl_fallback_get(
     timeout: int | float | tuple[float, float] = DEFAULT_TIMEOUT_SECONDS,
     headers: dict[str, str] | None = None,
     **kwargs: Any,
-) -> tuple[requests.Response | None, Exception | bool | None]:
+) -> SslFallbackResult:
     """Get with SSL fallback: tries verify=True first, falls back to verify=False on SSLError.
 
-    Returns (response, exc):
-    - (response, None): primary GET succeeded
-    - (response, True): primary SSL failed, fallback with verify=False succeeded
-    - (None, Exception): both attempts failed — exc carries the final error
+    Returns SslFallbackResult:
+    - response not None, err=None: request succeeded (primary or fallback) — response is usable
+    - response None, err=Exception: both attempts failed — err carries the final error
+
+    Use .tuple() for backward-compatible (response, err) unpacking.
     """
     request_headers = dict(headers or {})
     try:
@@ -97,7 +130,7 @@ def observatory_ssl_fallback_get(
                 headers=request_headers or None,
                 **kwargs,
             )
-        return response, None
+        return SslFallbackResult(response=response, err=None, ssl_fallback_used=None)
     except requests.exceptions.SSLError as exc:
         urllib3.disable_warnings(category=InsecureRequestWarning)
         try:
@@ -110,9 +143,14 @@ def observatory_ssl_fallback_get(
                     verify=False,
                     **kwargs,
                 )
-            return response, True  # SSL fallback was used and succeeded
+            # fallback succeeded — response is usable
+            return SslFallbackResult(response=response, err=None, ssl_fallback_used=True)
         except requests.exceptions.RequestException as fallback_exc:
-            return None, SslFallbackFailed(ssl_error=exc, fallback_error=fallback_exc)
+            return SslFallbackResult(
+                response=None,
+                err=SslFallbackFailed(ssl_error=exc, fallback_error=fallback_exc),
+                ssl_fallback_used=False,
+            )
 
 
 def observatory_head(

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -80,12 +80,13 @@ def observatory_ssl_fallback_get(
     timeout: int | float | tuple[float, float] = DEFAULT_TIMEOUT_SECONDS,
     headers: dict[str, str] | None = None,
     **kwargs: Any,
-) -> tuple[requests.Response | None, Exception | None]:
+) -> tuple[requests.Response | None, Exception | bool | None]:
     """Get with SSL fallback: tries verify=True first, falls back to verify=False on SSLError.
 
-    Returns (response, exc). If response is not None, exc is None.
-    If exc is not None, response is None and exc carries both the original
-    SSLError and the fallback failure (SslFallbackFailed).
+    Returns (response, exc):
+    - (response, None): primary GET succeeded
+    - (response, True): primary SSL failed, fallback with verify=False succeeded
+    - (None, Exception): both attempts failed — exc carries the final error
     """
     request_headers = dict(headers or {})
     try:
@@ -109,7 +110,7 @@ def observatory_ssl_fallback_get(
                     verify=False,
                     **kwargs,
                 )
-            return response, None
+            return response, True  # SSL fallback was used and succeeded
         except requests.exceptions.RequestException as fallback_exc:
             return None, SslFallbackFailed(ssl_error=exc, fallback_error=fallback_exc)
 

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -109,7 +109,7 @@ def observatory_ssl_fallback_get(
                     verify=False,
                     **kwargs,
                 )
-            return response, exc
+            return response, None
         except requests.exceptions.RequestException as fallback_exc:
             return None, SslFallbackFailed(ssl_error=exc, fallback_error=fallback_exc)
 
@@ -121,16 +121,30 @@ def observatory_head(
     headers: dict[str, str] | None = None,
     **kwargs: Any,
 ) -> requests.Response:
+    """HEAD request with SSL fallback: tries verify=True first, falls back to verify=False on SSLError."""
     request_headers = dict(headers or {})
-    with get_observatory_session() as session:
-        response = session.head(
-            url,
-            timeout=timeout,
-            headers=request_headers or None,
-            allow_redirects=True,
-            **kwargs,
-        )
-    return response
+    try:
+        with get_observatory_session() as session:
+            response = session.head(
+                url,
+                timeout=timeout,
+                headers=request_headers or None,
+                allow_redirects=True,
+                **kwargs,
+            )
+        return response
+    except requests.exceptions.SSLError:
+        urllib3.disable_warnings(category=InsecureRequestWarning)
+        with requests.Session() as session:
+            session.headers.update({"User-Agent": USER_AGENT})
+            return session.head(
+                url,
+                timeout=timeout,
+                headers=request_headers or None,
+                allow_redirects=True,
+                verify=False,
+                **kwargs,
+            )
 
 
 def strip_query(url: str) -> str:

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -26,7 +26,7 @@ from collections import Counter
 from typing import Any
 from urllib.parse import urljoin
 
-from .base import CollectorResult, observatory_ssl_fallback_get
+from .base import CollectorResult, SslFallbackResult, observatory_ssl_fallback_get
 
 
 DATA_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls", ".ods", ".zip", ".xml", ".geojson"}
@@ -567,7 +567,7 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
         )
     else:
         # Homepage only probe
-        response, fetch_err = observatory_ssl_fallback_get(base_url, timeout=15)
+        response, fetch_err = observatory_ssl_fallback_get(base_url, timeout=15).tuple()
         if fetch_err or response is None:
             return CollectorResult(
                 rows=[],

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -26,7 +26,7 @@ from collections import Counter
 from typing import Any
 from urllib.parse import urljoin
 
-from .base import CollectorResult, SslFallbackResult, observatory_ssl_fallback_get
+from .base import CollectorResult, observatory_ssl_fallback_get
 
 
 DATA_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls", ".ods", ".zip", ".xml", ".geojson"}

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -24,7 +24,7 @@ from _constants import (
     save_radar_history,
     append_radar_probe,
 )
-from collectors.base import SslFallbackFailed, observatory_ssl_fallback_get
+from collectors.base import SslFallbackFailed, SslFallbackResult, observatory_ssl_fallback_get
 
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[1]
@@ -146,19 +146,23 @@ def _build_probe_result(
 
 def _probe_once(base_url: str) -> ProbeResult:
     """Single probe attempt (no retry). Uses shared SSL fallback from base.py."""
-    response, exc = observatory_ssl_fallback_get(
+    result = observatory_ssl_fallback_get(
         base_url,
         timeout=TIMEOUT_SECONDS,
         allow_redirects=True,
         stream=True,
     )
-    if response is not None:
-        # exc=True signals SSL fallback was used and succeeded
-        # exc=None means primary request succeeded directly
-        ssl_failure = exc if exc is True else None
-        return _build_probe_result(base_url, response, ssl_failure=ssl_failure)
-    # exc is not None — both attempts failed
-    if exc is None:
+    # ssl_fallback_used=True → primary SSL failed, fallback succeeded → GREEN
+    # ssl_fallback_used=False → both failed
+    # ssl_fallback_used=None → primary succeeded (no fallback needed)
+    if result.response is not None:
+        return _build_probe_result(
+            base_url,
+            result.response,
+            ssl_failure=result.ssl_fallback_used if result.ssl_fallback_used else None,
+        )
+    # Both failed — result.err carries the final error
+    if result.err is None:
         # response=None with no exception — should not happen, treat as hard error
         return ProbeResult(
             status="RED",
@@ -167,20 +171,20 @@ def _probe_once(base_url: str) -> ProbeResult:
         )
     ssl_failure_err: requests.exceptions.SSLError | None = None
     error_exc: requests.exceptions.RequestException
-    if isinstance(exc, SslFallbackFailed):
-        ssl_failure_err = exc.ssl_error
-        error_exc = exc.fallback_error
-    elif isinstance(exc, requests.exceptions.SSLError):
-        ssl_failure_err = exc
-        error_exc = exc
-    elif isinstance(exc, requests.exceptions.RequestException):
-        error_exc = exc
+    if isinstance(result.err, SslFallbackFailed):
+        ssl_failure_err = result.err.ssl_error
+        error_exc = result.err.fallback_error
+    elif isinstance(result.err, requests.exceptions.SSLError):
+        ssl_failure_err = result.err
+        error_exc = result.err
+    elif isinstance(result.err, requests.exceptions.RequestException):
+        error_exc = result.err
     else:
         # Non-RequestException escaped observatory_ssl_fallback_get — treat as RED
         return ProbeResult(
             status="RED",
             http_code="-",
-            note=f"Unexpected exception type in _probe_once: {type(exc).__name__}: {exc}",
+            note=f"Unexpected exception type in _probe_once: {type(result.err).__name__}: {result.err}",
         )
     return _make_error_result(
         error_exc,

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -152,8 +152,9 @@ def _probe_once(base_url: str) -> ProbeResult:
         stream=True,
     )
     if response is not None:
-        # If exc is not None, we had an SSLError first then fallback succeeded
-        ssl_failure = exc if isinstance(exc, requests.exceptions.SSLError) else None
+        # exc=True signals SSL fallback was used and succeeded
+        # exc=None means primary request succeeded directly
+        ssl_failure = exc if exc is True else None
         return _build_probe_result(base_url, response, ssl_failure=ssl_failure)
     # exc is not None — both attempts failed
     if exc is None:

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -8,7 +8,7 @@ from datetime import date, datetime, timezone
 import json
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import requests
 
@@ -124,13 +124,14 @@ def _build_probe_result(
     base_url: str,
     response: requests.Response,
     *,
-    ssl_failure: requests.exceptions.SSLError | None = None,
+    ssl_failure: requests.exceptions.SSLError | Literal[True] | None = None,
 ) -> ProbeResult:
     status, probe_note = validate_ckan_action_response(base_url, response)
     note = probe_note
     ssl_fallback_used = ssl_failure is not None
     if ssl_failure is not None:
-        note = f"SSL verify failed; fallback verify=False used ({ssl_failure.__class__.__name__})"
+        failure_type = "SSLError" if ssl_failure is True else ssl_failure.__class__.__name__
+        note = f"SSL verify failed; fallback verify=False used ({failure_type})"
         if probe_note:
             note = f"{note} | {probe_note}"
     return ProbeResult(
@@ -164,13 +165,13 @@ def _probe_once(base_url: str) -> ProbeResult:
             http_code="-",
             note="Unexpected: response=None without exception from observatory_ssl_fallback_get",
         )
-    ssl_failure = None
+    ssl_failure_err: requests.exceptions.SSLError | None = None
     error_exc: requests.exceptions.RequestException
     if isinstance(exc, SslFallbackFailed):
-        ssl_failure = exc.ssl_error
+        ssl_failure_err = exc.ssl_error
         error_exc = exc.fallback_error
     elif isinstance(exc, requests.exceptions.SSLError):
-        ssl_failure = exc
+        ssl_failure_err = exc
         error_exc = exc
     elif isinstance(exc, requests.exceptions.RequestException):
         error_exc = exc
@@ -183,8 +184,8 @@ def _probe_once(base_url: str) -> ProbeResult:
         )
     return _make_error_result(
         error_exc,
-        ssl_fallback_used=ssl_failure is not None,
-        ssl_failure=ssl_failure,
+        ssl_fallback_used=ssl_failure_err is not None,
+        ssl_failure=ssl_failure_err,
     )
 
 

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -24,7 +24,7 @@ from _constants import (
     save_radar_history,
     append_radar_probe,
 )
-from collectors.base import SslFallbackFailed, SslFallbackResult, observatory_ssl_fallback_get
+from collectors.base import SslFallbackFailed, observatory_ssl_fallback_get
 
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -154,3 +154,77 @@ class TestMaxAgeDaysNone:
         assert result[1] is False
         assert result[2] == "url_missing_or_invalid"
         assert result[3] is None  # no content_type for invalid url
+
+
+class TestHttpHeadWithRetrySSL:
+    """SSL handling in _http_head_with_retry."""
+
+    def test_ssl_error_caught_before_connection_error(self, monkeypatch) -> None:
+        """SSLError must be handled separately from ConnectionError (SSLError is a subclass)."""
+        import bulk_source_check as bsc
+        import requests.exceptions
+
+        call_count = [0]
+
+        def fake_observatory_head(url, *, timeout=None, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise requests.exceptions.SSLError("SSL cert verify failed")
+            raise requests.exceptions.SSLError("SSL still broken")
+
+        # Patch the name in bulk_source_check's namespace (where it was imported)
+        monkeypatch.setattr(bsc, "observatory_head", fake_observatory_head)
+
+        status, reachable, note, ct = bsc._http_head_with_retry(
+            "https://ssl-broken.test/file.csv",
+            session=None,
+        )
+        # Should return ssl_error, not connection_error
+        assert note == "ssl_error", f"expected ssl_error, got {note}"
+        assert reachable is False
+        assert status is None
+
+    def test_ssl_error_uses_observatory_head_not_get(self, monkeypatch) -> None:
+        """On SSLError, _http_head_with_retry must use observatory_head (HEAD), not GET."""
+        import bulk_source_check as bsc
+
+        head_called = [False]
+
+        class FakeHeadResponse:
+            status_code = 200
+            # Use CaseInsensitiveDict-like headers (case-insensitive key lookup)
+            # to match real requests.Response.headers behavior
+            class Headers(dict):
+                def get(self, key, default=None):
+                    # Case-insensitive lookup matching requests.Response.headers
+                    key_lower = key.lower()
+                    for k, v in self.items():
+                        if k.lower() == key_lower:
+                            return v
+                    return default
+
+            headers = Headers({"Content-Type": "text/csv"})
+            url = "https://ssl-broken.test/file.csv"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        def fake_observatory_head(url, *, timeout=None, **kwargs):
+            head_called[0] = True
+            return FakeHeadResponse()
+
+        monkeypatch.setattr(bsc, "observatory_head", fake_observatory_head)
+
+        status, reachable, note, ct = bsc._http_head_with_retry(
+            "https://ssl-broken.test/file.csv",
+            session=None,
+        )
+        # observatory_head (HEAD, not GET) was used and succeeded
+        assert head_called[0] is True
+        assert status == 200
+        assert reachable is True
+        assert note == ""
+        assert ct == "CSV"

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+from typing import Literal
 
 import radar_check
+from collectors.base import SslFallbackFailed, SslFallbackResult
 
 
 class FakeResponse:
@@ -125,10 +127,14 @@ def test_is_sdmx_url() -> None:
 
 def test_probe_url_success(monkeypatch) -> None:
     def fake_ssl_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
-        return FakeResponse(
-            status_code=200,
-            json_payload={"success": True, "result": []},
-        ), None
+        return SslFallbackResult(
+            response=FakeResponse(
+                status_code=200,
+                json_payload={"success": True, "result": []},
+            ),
+            err=None,
+            ssl_fallback_used=None,
+        )
 
     monkeypatch.setattr(radar_check, "observatory_ssl_fallback_get", fake_ssl_get)
     result = radar_check.probe_url("https://demo.test/api/3/action/package_list")
@@ -141,7 +147,11 @@ def test_probe_url_timeout(monkeypatch) -> None:
     import requests as real_requests
 
     def fake_ssl_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
-        return None, real_requests.exceptions.Timeout("Connection timed out")
+        return SslFallbackResult(
+            response=None,
+            err=real_requests.exceptions.Timeout("Connection timed out"),
+            ssl_fallback_used=False,
+        )
 
     monkeypatch.setattr(radar_check, "observatory_ssl_fallback_get", fake_ssl_get)
     result = radar_check.probe_url("https://slow.test/api/3/action")
@@ -153,7 +163,11 @@ def test_probe_url_connection_error(monkeypatch) -> None:
     import requests as real_requests
 
     def fake_ssl_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
-        return None, real_requests.exceptions.ConnectionError("Connection refused")
+        return SslFallbackResult(
+            response=None,
+            err=real_requests.exceptions.ConnectionError("Connection refused"),
+            ssl_fallback_used=False,
+        )
 
     monkeypatch.setattr(radar_check, "observatory_ssl_fallback_get", fake_ssl_get)
     result = radar_check.probe_url("https://dead.test/api/3/action")
@@ -164,12 +178,12 @@ def test_probe_url_connection_error(monkeypatch) -> None:
 def test_probe_url_ssl_fallback(monkeypatch) -> None:
     """SSL error first, fallback succeeds — ssl_fallback_used=True.
 
-    New contract: observatory_ssl_fallback_get returns (response, True) when
-    primary SSL failed but fallback with verify=False succeeded.
+    observatory_ssl_fallback_get now returns SslFallbackResult with
+    ssl_fallback_used=True when primary SSL failed but fallback succeeded.
     """
     def fake_ssl_fallback_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
         response = FakeResponse(status_code=200, json_payload={"success": True})
-        return response, True  # True = SSL fallback was used and succeeded
+        return SslFallbackResult(response=response, err=None, ssl_fallback_used=True)
 
     monkeypatch.setattr(
         radar_check, "observatory_ssl_fallback_get", fake_ssl_fallback_get
@@ -244,9 +258,10 @@ def test_observatory_ssl_fallback_get_returns_true_on_fallback_success(monkeypat
     monkeypatch.setattr(base.requests, "Session", FakeFallbackSessionClass())
     monkeypatch.setattr(base.urllib3, "disable_warnings", lambda *a, **k: None)
 
-    resp, flag = base.observatory_ssl_fallback_get("https://ssl-broken.test/file.csv", timeout=10)
-    assert resp is not None
-    assert flag is True  # True = fallback succeeded (new contract)
+    result = base.observatory_ssl_fallback_get("https://ssl-broken.test/file.csv", timeout=10)
+    assert result.response is not None
+    assert result.err is None
+    assert result.ssl_fallback_used is True  # fallback was used and succeeded
     assert len(fake_primary_sessions) == 1  # Only primary was called (fallback uses requests.Session)
 
     base.get_observatory_session = orig_session
@@ -315,14 +330,23 @@ def test_observatory_head_retries_verify_false_on_ssl_error(monkeypatch) -> None
 
 
 def test_probe_url_ssl_fallback_double_failure(monkeypatch) -> None:
-    """SSL error first, fallback also fails — ssl_fallback_used=True, both errors preserved."""
+    """SSL error first, fallback also fails — ssl_fallback_used=True, both errors preserved.
+
+    Both primary SSL and fallback failed. result.ssl_fallback_used=False but
+    ssl_failure_err is set (from the primary SSLError), so ssl_fallback_used=True
+    in the ProbeResult (it correctly reflects that an SSL error occurred).
+    """
     import requests as real_requests
     from collectors.base import SslFallbackFailed
 
     def fake_ssl_fallback_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
         ssl_exc = real_requests.exceptions.SSLError("SSL cert verify failed")
         fallback_exc = real_requests.exceptions.ConnectionError("Connection refused after fallback")
-        return None, SslFallbackFailed(ssl_error=ssl_exc, fallback_error=fallback_exc)
+        return SslFallbackResult(
+            response=None,
+            err=SslFallbackFailed(ssl_error=ssl_exc, fallback_error=fallback_exc),
+            ssl_fallback_used=False,
+        )
 
     monkeypatch.setattr(
         radar_check, "observatory_ssl_fallback_get", fake_ssl_fallback_get
@@ -334,6 +358,7 @@ def test_probe_url_ssl_fallback_double_failure(monkeypatch) -> None:
     )
 
     result = radar_check._probe_once("https://ssl-broken.test/api/3/action")
+    # ssl_failure_err is the primary SSLError → ssl_fallback_used=True in ProbeResult
     assert result.ssl_fallback_used is True
     assert "SSL verify failed" in (result.note or "")
 

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -162,14 +162,14 @@ def test_probe_url_connection_error(monkeypatch) -> None:
 
 
 def test_probe_url_ssl_fallback(monkeypatch) -> None:
-    """SSL error first, fallback succeeds — ssl_fallback_used=True."""
-    import requests as real_requests
+    """SSL error first, fallback succeeds — ssl_fallback_used=True.
 
+    New contract: observatory_ssl_fallback_get returns (response, True) when
+    primary SSL failed but fallback with verify=False succeeded.
+    """
     def fake_ssl_fallback_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
-        # Normal get raises SSLError → fallback succeeds
         response = FakeResponse(status_code=200, json_payload={"success": True})
-        ssl_exc = real_requests.exceptions.SSLError("SSL certificate verify failed")
-        return response, ssl_exc
+        return response, True  # True = SSL fallback was used and succeeded
 
     monkeypatch.setattr(
         radar_check, "observatory_ssl_fallback_get", fake_ssl_fallback_get
@@ -182,7 +182,136 @@ def test_probe_url_ssl_fallback(monkeypatch) -> None:
 
     result = radar_check._probe_once("https://ssl-broken.test/api/3/action")
     assert result.ssl_fallback_used is True
-    assert "SSL verify failed" in (result.note or "")
+    assert result.status == "GREEN"
+
+
+def test_observatory_ssl_fallback_get_returns_true_on_fallback_success(monkeypatch) -> None:
+    """observatory_ssl_fallback_get returns (response, True) when fallback succeeds.
+
+    New contract: (response, True) = SSL fallback was used and succeeded.
+    (response, None) = primary request succeeded.
+    The key behavioral difference: callers that check 'if err' still work
+    (err is truthy), but now err=True means "fallback succeeded" not "error".
+    """
+    import requests
+
+    class FakeSuccessResponse:
+        status_code = 200
+        headers = {"content-type": "application/json"}
+        url = "https://ssl-broken.test/file.csv"
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
+    class FakePrimarySession:
+        """Fake session for the primary (get_observatory_session) path."""
+        def __init__(self):
+            self.calls = []
+        def get(self, url, *, timeout=None, headers=None, verify=None, stream=None, **kwargs):
+            self.calls.append({"method": "get", "url": url, "verify": verify})
+            if len(self.calls) == 1:
+                raise requests.exceptions.SSLError("SSL cert verify failed")
+            return FakeSuccessResponse()
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
+    class FakeFallbackSessionInstance:
+        """Fake session instance returned by requests.Session() in fallback path."""
+        def __init__(self):
+            self.headers = {}
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+        def get(self, url, *, timeout=None, headers=None, verify=None, stream=None, **kwargs):
+            return FakeSuccessResponse()
+
+    class FakeFallbackSessionClass:
+        """Fake requests.Session class for the fallback path."""
+        def __call__(self):
+            return FakeFallbackSessionInstance()
+        def __enter__(self): return FakeFallbackSessionInstance()
+        def __exit__(self, *a): pass
+
+    from collectors import base
+    orig_session = base.get_observatory_session
+    orig_requests_session = base.requests.Session
+    fake_primary_sessions = []
+
+    def make_fake_session(*a, **k):
+        fs = FakePrimarySession()
+        fake_primary_sessions.append(fs)
+        return fs
+
+    monkeypatch.setattr(base, "get_observatory_session", make_fake_session)
+    monkeypatch.setattr(base.requests, "Session", FakeFallbackSessionClass())
+    monkeypatch.setattr(base.urllib3, "disable_warnings", lambda *a, **k: None)
+
+    resp, flag = base.observatory_ssl_fallback_get("https://ssl-broken.test/file.csv", timeout=10)
+    assert resp is not None
+    assert flag is True  # True = fallback succeeded (new contract)
+    assert len(fake_primary_sessions) == 1  # Only primary was called (fallback uses requests.Session)
+
+    base.get_observatory_session = orig_session
+    base.requests.Session = orig_requests_session
+
+
+def test_observatory_head_retries_verify_false_on_ssl_error(monkeypatch) -> None:
+    """observatory_head retries with verify=False when SSLError is raised."""
+    import requests
+
+    class FakeSuccessResponse:
+        status_code = 200
+        headers = {"content-type": "text/html"}
+        url = "https://ssl-broken.test/"
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
+    class FakePrimarySession:
+        """Fake session for the primary (get_observatory_session) path."""
+        def __init__(self):
+            self.calls = []
+        def head(self, url, *, timeout=None, headers=None, verify=None, allow_redirects=None, **kwargs):
+            self.calls.append({"method": "head", "url": url, "verify": verify})
+            if len(self.calls) == 1:
+                raise requests.exceptions.SSLError("SSL cert verify failed")
+            return FakeSuccessResponse()
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
+    class FakeFallbackSessionInstance:
+        """Fake session instance returned by requests.Session() in fallback path."""
+        def __init__(self):
+            self.headers = {}
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+        def head(self, url, *, timeout=None, headers=None, verify=None, allow_redirects=None, **kwargs):
+            return FakeSuccessResponse()
+
+    class FakeFallbackSessionClass:
+        """Fake requests.Session class for the fallback path."""
+        def __call__(self):
+            return FakeFallbackSessionInstance()
+        def __enter__(self): return FakeFallbackSessionInstance()
+        def __exit__(self, *a): pass
+
+    from collectors import base
+    orig = base.get_observatory_session
+    orig_requests_session = base.requests.Session
+    fake_primary_sessions = []
+
+    def make_fake_session(*a, **k):
+        fs = FakePrimarySession()
+        fake_primary_sessions.append(fs)
+        return fs
+
+    monkeypatch.setattr(base, "get_observatory_session", make_fake_session)
+    monkeypatch.setattr(base.requests, "Session", FakeFallbackSessionClass())
+    monkeypatch.setattr(base.urllib3, "disable_warnings", lambda *a, **k: None)
+
+    resp = base.observatory_head("https://ssl-broken.test/", timeout=10)
+    assert resp.status_code == 200
+    assert len(fake_primary_sessions) == 1  # Only primary called
+
+    base.get_observatory_session = orig
+    base.requests.Session = orig_requests_session
 
 
 def test_probe_url_ssl_fallback_double_failure(monkeypatch) -> None:

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from typing import Literal
 
 import radar_check
 from collectors.base import SslFallbackFailed, SslFallbackResult
@@ -337,7 +336,6 @@ def test_probe_url_ssl_fallback_double_failure(monkeypatch) -> None:
     in the ProbeResult (it correctly reflects that an SSL error occurred).
     """
     import requests as real_requests
-    from collectors.base import SslFallbackFailed
 
     def fake_ssl_fallback_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
         ssl_exc = real_requests.exceptions.SSLError("SSL cert verify failed")


### PR DESCRIPTION
## Summary

Fix a tre livelli nella catena SSL:

### 1. `base.py` — `observatory_ssl_fallback_get`: return value corretto
**Bug**: quando il fallback `verify=False` aveva successo, la funzione restituiva `(response, SSLError)` — cioè passava l'errore originale come secondo valore anche quando tutto era andato bene. I caller che controllano `if err` vedevano un falso errore.

**Fix**: `return response, None` invece di `return response, exc`.

### 2. `base.py` — `observatory_head`: SSL fallback
**Bug**: `observatory_head` non aveva fallback SSL — HEAD su siti con cert invalido falliva.

**Fix**: stessi pattern di `observatory_ssl_fallback_get` — try `verify=True`, retry `verify=False` su SSLError.

### 3. `bulk_source_check.py` — `_http_head_with_retry`: ordine except + fallback
**Bug 1**: `SSLError` è sottoclasse di `ConnectionError` in Python. L'ordine degli except era sbagliato — `ConnectionError` catturava SSLError prima del handler dedicato.

**Fix**: SSLError PRIMA di ConnectionError.

**Bug 2**: Quando il session-based HEAD esplodeva per SSLError, non c'era fallback.

**Fix**: su SSLError nella session, retry via `observatory_ssl_fallback_get` (che ha SSL fallback built-in).

## Verifiche

- opencivitas: collector 748 link ZIP → source-check 45/45 raggiungibili (HTTP 200) ✅
- 125 test passano ✅
- ruff clean ✅

## Root cause

I test non exercitavano la catena SSL reale end-to-end con cert invalido — i mock nascondevano questi bug. Serve test di integrazione SSL in futuro.