### PR TITLE
refactor(http): use lab-connectors HTTP fallback client

### DIFF
--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -220,7 +220,6 @@ def _get_observatory_get() -> Any:
         spec.loader.exec_module(_collectors_base)
         observatory_get = _collectors_base.observatory_get
         observatory_head = _collectors_base.observatory_head
-        observatory_ssl_fallback_get = _collectors_base.observatory_ssl_fallback_get
     return observatory_get
 
 
@@ -230,8 +229,15 @@ def _get_observatory_head() -> Any:
 
 
 def _get_observatory_ssl_fallback_get() -> Any:
-    _get_observatory_get()  # ensure initialized
-    return observatory_ssl_fallback_get
+    from lab_connectors.http import HttpClient
+
+    def ssl_fallback_get(url: str, *, timeout: int | float | tuple[int, int] | None = None, headers: dict | None = None, **kwargs: Any) -> tuple[Any, Any]:
+        client = HttpClient(timeout=timeout or 60)
+        kwargs.pop("timeout", None)
+        result = client.get(url, headers=headers or {}, **kwargs)
+        return (result.response, result.err)
+
+    return ssl_fallback_get
 
 
 @dataclass(frozen=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyarrow>=14.0,<24.0
 ddgs>=9.14.2,<10.0
 mcp>=1.27.0
 fastmcp>=3.2.4
-lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.1.0
+lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyarrow>=14.0,<24.0
 ddgs>=9.14.2,<10.0
 mcp>=1.27.0
 fastmcp>=3.2.4
+lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.1.0

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -6,22 +6,11 @@ from datetime import datetime, timezone
 from urllib.parse import urlsplit, urlunsplit
 
 import requests
-import urllib3
 from requests.adapters import HTTPAdapter
-from urllib3.exceptions import InsecureRequestWarning
 
 
 USER_AGENT = "DataCivicLab-SourceObservatory/1.0"
 DEFAULT_TIMEOUT_SECONDS = 60
-
-
-class SslFallbackFailed(Exception):
-    """Raised when both the SSL attempt and the fallback (verify=False) fail."""
-
-    def __init__(self, ssl_error: requests.exceptions.SSLError, fallback_error: requests.exceptions.RequestException):
-        self.ssl_error = ssl_error
-        self.fallback_error = fallback_error
-        super().__init__(f"SSL failed ({ssl_error}) then fallback failed ({fallback_error})")
 
 
 @dataclass
@@ -32,35 +21,6 @@ class CollectorResult:
     # Tracks whether the primary SSL attempt failed but fallback succeeded.
     # None means no fallback; True means fallback was used and succeeded.
     ssl_fallback_used: bool | None = None
-
-
-@dataclass
-class SslFallbackResult:
-    """Result of observatory_ssl_fallback_get.
-
-    Attributes:
-        response: the HTTP response if request succeeded (primary or fallback), None otherwise
-        err: Exception if both primary and fallback failed, None otherwise
-        ssl_fallback_used: True if primary SSL failed but fallback succeeded,
-                          False if primary SSL failed and fallback also failed,
-                          None if primary succeeded (no fallback needed)
-
-    Supports tuple unpacking: response, err = result
-    """
-    response: requests.Response | None
-    err: Exception | None
-    ssl_fallback_used: bool | None = None
-
-    def __iter__(self):
-        """Support tuple unpacking: response, err = result"""
-        return iter((self.response, self.err))
-
-    def __getitem__(self, index):
-        return (self.response, self.err)[index]
-
-    def tuple(self) -> tuple[requests.Response | None, Exception | None]:
-        """Explicit tuple conversion."""
-        return (self.response, self.err)
 
 
 def now_utc_iso() -> str:
@@ -106,53 +66,6 @@ def observatory_get(
     return response
 
 
-def observatory_ssl_fallback_get(
-    url: str,
-    *,
-    timeout: int | float | tuple[float, float] = DEFAULT_TIMEOUT_SECONDS,
-    headers: dict[str, str] | None = None,
-    **kwargs: Any,
-) -> SslFallbackResult:
-    """Get with SSL fallback: tries verify=True first, falls back to verify=False on SSLError.
-
-    Returns SslFallbackResult:
-    - response not None, err=None: request succeeded (primary or fallback) — response is usable
-    - response None, err=Exception: both attempts failed — err carries the final error
-
-    Use .tuple() for backward-compatible (response, err) unpacking.
-    """
-    request_headers = dict(headers or {})
-    try:
-        with get_observatory_session() as session:
-            response = session.get(
-                url,
-                timeout=timeout,
-                headers=request_headers or None,
-                **kwargs,
-            )
-        return SslFallbackResult(response=response, err=None, ssl_fallback_used=None)
-    except requests.exceptions.SSLError as exc:
-        urllib3.disable_warnings(category=InsecureRequestWarning)
-        try:
-            with requests.Session() as session:
-                session.headers.update({"User-Agent": USER_AGENT})
-                response = session.get(
-                    url,
-                    timeout=timeout,
-                    headers=request_headers or None,
-                    verify=False,
-                    **kwargs,
-                )
-            # fallback succeeded — response is usable
-            return SslFallbackResult(response=response, err=None, ssl_fallback_used=True)
-        except requests.exceptions.RequestException as fallback_exc:
-            return SslFallbackResult(
-                response=None,
-                err=SslFallbackFailed(ssl_error=exc, fallback_error=fallback_exc),
-                ssl_fallback_used=False,
-            )
-
-
 def observatory_head(
     url: str,
     *,
@@ -161,29 +74,14 @@ def observatory_head(
     **kwargs: Any,
 ) -> requests.Response:
     """HEAD request with SSL fallback: tries verify=True first, falls back to verify=False on SSLError."""
-    request_headers = dict(headers or {})
-    try:
-        with get_observatory_session() as session:
-            response = session.head(
-                url,
-                timeout=timeout,
-                headers=request_headers or None,
-                allow_redirects=True,
-                **kwargs,
-            )
-        return response
-    except requests.exceptions.SSLError:
-        urllib3.disable_warnings(category=InsecureRequestWarning)
-        with requests.Session() as session:
-            session.headers.update({"User-Agent": USER_AGENT})
-            return session.head(
-                url,
-                timeout=timeout,
-                headers=request_headers or None,
-                allow_redirects=True,
-                verify=False,
-                **kwargs,
-            )
+    from lab_connectors.http import HttpClient
+
+    client = HttpClient(timeout=timeout, user_agent=USER_AGENT)
+    result = client.head(url, headers=headers or {}, **kwargs)
+    if result.is_ok:
+        return result.response
+    # Should not happen — observatory_head was used when we expected success
+    raise result.err if result.err else RuntimeError(f"HEAD failed for {url}")
 
 
 def strip_query(url: str) -> str:

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -26,7 +26,8 @@ from collections import Counter
 from typing import Any
 from urllib.parse import urljoin
 
-from .base import CollectorResult, observatory_ssl_fallback_get
+from .base import CollectorResult
+from lab_connectors.http import HttpClient
 
 
 DATA_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls", ".ods", ".zip", ".xml", ".geojson"}
@@ -170,9 +171,12 @@ def _fetch_sitemap(sitemap_url: str, timeout: int = 15) -> tuple[list[str] | Non
     import xml.etree.ElementTree as ET
 
     try:
-        response, exc = observatory_ssl_fallback_get(sitemap_url, timeout=timeout)
-        if response is None:
-            return None, str(exc)
+        client = HttpClient(timeout=timeout)
+        result = client.get(sitemap_url)
+        if not result.is_ok or result.response is None:
+            err_str = str(result.err) if result.err else "unknown"
+            return None, err_str
+        response = result.response
         if response.status_code >= 400:
             return None, f"HTTP {response.status_code}"
         root = ET.fromstring(response.text)
@@ -243,15 +247,16 @@ def _scan_sitemap(
     for page_url in sampled:
         time.sleep(page_delay)
         # Fetch page directly — no separate HEAD probe (saves one round-trip)
-        response, page_err = observatory_ssl_fallback_get(page_url, timeout=10)
-        if page_err or response is None:
+        client = HttpClient(timeout=10)
+        result = client.get(page_url)
+        if not result.is_ok or result.response is None:
             continue
         pages_probed += 1
 
         # Extract page metadata (title, description) for enrichment
-        page_meta[page_url] = _extract_page_meta(response.text)
+        page_meta[page_url] = _extract_page_meta(result.response.text)
 
-        parser = _DataLinksParser(page_url, response.text)
+        parser = _DataLinksParser(page_url, result.response.text)
         for link in parser.links:
             if link["url"] not in seen_data_urls:
                 seen_data_urls.add(link["url"])
@@ -402,10 +407,11 @@ def _scan_area_pages(
         while pages_scanned < page_max:
             area_url = page_url_template.format(page=page)
             time.sleep(page_delay)
-            response, err = observatory_ssl_fallback_get(area_url, timeout=15)
-            if err or response is None:
+            client = HttpClient(timeout=15)
+            result = client.get(area_url)
+            if not result.is_ok or result.response is None:
                 break
-            parser = _DataLinksParser(area_url, response.text)
+            parser = _DataLinksParser(area_url, result.response.text)
             links_this_page = [link for link in parser.links if link["url"] not in seen_data_urls]
             if not parser.links and page_stop_on_empty:
                 pages_scanned += 1
@@ -419,10 +425,11 @@ def _scan_area_pages(
     else:
         for area_url in area_pages:
             time.sleep(page_delay)
-            response, err = observatory_ssl_fallback_get(area_url, timeout=15)
-            if err or response is None:
+            client = HttpClient(timeout=15)
+            result = client.get(area_url)
+            if not result.is_ok or result.response is None:
                 continue
-            parser = _DataLinksParser(area_url, response.text)
+            parser = _DataLinksParser(area_url, result.response.text)
             for link in parser.links:
                 if link["url"] not in seen_data_urls:
                     seen_data_urls.add(link["url"])
@@ -567,13 +574,15 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
         )
     else:
         # Homepage only probe
-        response, fetch_err = observatory_ssl_fallback_get(base_url, timeout=15).tuple()
-        if fetch_err or response is None:
+        client = HttpClient(timeout=15)
+        result = client.get(base_url)
+        if not result.is_ok or result.response is None:
+            err_msg = str(result.err) if result.err else "unknown"
             return CollectorResult(
                 rows=[],
-                summary={"type": "csv_magnet_error", "message": fetch_err},
+                summary={"type": "csv_magnet_error", "message": err_msg},
             )
-        parser = _DataLinksParser(base_url, response.text)
+        parser = _DataLinksParser(base_url, result.response.text)
         rows = []
         for link in parser.links:
             url = link["url"]

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -24,7 +24,6 @@ from _constants import (
     save_radar_history,
     append_radar_probe,
 )
-from collectors.base import observatory_get
 from lab_connectors.http import HttpClient, HttpFallbackError
 
 

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -24,7 +24,8 @@ from _constants import (
     save_radar_history,
     append_radar_probe,
 )
-from collectors.base import SslFallbackFailed, observatory_ssl_fallback_get
+from collectors.base import observatory_get
+from lab_connectors.http import HttpClient, HttpFallbackError
 
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[1]
@@ -145,17 +146,17 @@ def _build_probe_result(
 
 
 def _probe_once(base_url: str) -> ProbeResult:
-    """Single probe attempt (no retry). Uses shared SSL fallback from base.py."""
-    result = observatory_ssl_fallback_get(
+    """Single probe attempt (no retry). Uses lab_connectors HttpClient with SSL fallback."""
+    client = HttpClient(timeout=TIMEOUT_SECONDS, user_agent=USER_AGENT)
+    result = client.get(
         base_url,
-        timeout=TIMEOUT_SECONDS,
         allow_redirects=True,
         stream=True,
     )
     # ssl_fallback_used=True → primary SSL failed, fallback succeeded → GREEN
     # ssl_fallback_used=False → both failed
     # ssl_fallback_used=None → primary succeeded (no fallback needed)
-    if result.response is not None:
+    if result.is_ok and result.response is not None:
         return _build_probe_result(
             base_url,
             result.response,
@@ -167,12 +168,12 @@ def _probe_once(base_url: str) -> ProbeResult:
         return ProbeResult(
             status="RED",
             http_code="-",
-            note="Unexpected: response=None without exception from observatory_ssl_fallback_get",
+            note="Unexpected: response=None without exception from HttpClient.get",
         )
     ssl_failure_err: requests.exceptions.SSLError | None = None
     error_exc: requests.exceptions.RequestException
-    if isinstance(result.err, SslFallbackFailed):
-        ssl_failure_err = result.err.ssl_error
+    if isinstance(result.err, HttpFallbackError):
+        ssl_failure_err = result.err.primary_error
         error_exc = result.err.fallback_error
     elif isinstance(result.err, requests.exceptions.SSLError):
         ssl_failure_err = result.err
@@ -180,7 +181,7 @@ def _probe_once(base_url: str) -> ProbeResult:
     elif isinstance(result.err, requests.exceptions.RequestException):
         error_exc = result.err
     else:
-        # Non-RequestException escaped observatory_ssl_fallback_get — treat as RED
+        # Non-RequestException escaped HttpClient.get — treat as RED
         return ProbeResult(
             status="RED",
             http_code="-",

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import build_catalog_inventory
 import collectors.ckan
+import collectors.html as html_collector
 import collectors.sparql
+from lab_connectors.http import HttpResult
 
 
 class FakeJsonResponse:
@@ -26,6 +28,14 @@ class FakeJsonResponse:
         if self._payload is None:
             raise ValueError("invalid json")
         return self._payload
+
+
+class _FakeClient:
+    def __init__(self, result_fn):
+        self._result_fn = result_fn
+
+    def get(self, url, **kwargs):
+        return self._result_fn(url, **kwargs)
 
 
 def test_collect_ckan_inventory_merges_current_list_metadata(monkeypatch) -> None:
@@ -579,22 +589,19 @@ class TestScanAreaPagesPagination:
 
         call_count = [0]
 
-        def fake_ssl_fallback_get(url, **kwargs):
+        def fake_ssl_get(url, **kwargs):
             call_count[0] += 1
             page = call_count[0]
             if page == 1:
-                # Page 0: has links
                 html = '<a href="https://docs.example.com/file1.csv">file1.csv</a>'
             elif page == 2:
-                # Page 1: has links (different from page 0)
                 html = '<a href="https://docs.example.com/file2.csv">file2.csv</a>'
             else:
-                # Page 2+: empty — no <a> tags at all
                 html = "<html><body><p>No results</p></body></html>"
             response = FakeJsonResponse(payload=None, text=html, headers={"content-type": "text/html"})
-            return response, None
+            return HttpResult(response=response, err=None, ssl_fallback_used=None)
 
-        monkeypatch.setattr(html_collector, "observatory_ssl_fallback_get", fake_ssl_fallback_get)
+        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: _FakeClient(fake_ssl_get))
 
         summary, rows = html_collector._scan_area_pages(
             area_pages=[],
@@ -617,29 +624,24 @@ class TestScanAreaPagesPagination:
         assert urls == {"https://docs.example.com/file1.csv", "https://docs.example.com/file2.csv"}
 
     def test_page_url_template_continues_when_all_links_are_duplicates(self, monkeypatch):
-        """Collector continues past pages where all links are duplicates of previous pages
-        (because parser.links is non-empty even if all are duplicates)."""
-        import collectors.html as html_collector
-
+        """Collector continues past pages where all links are duplicates of previous pages."""
         call_count = [0]
 
-        def fake_ssl_fallback_get(url, **kwargs):
+        def fake_ssl_get(url, **kwargs):
             call_count[0] += 1
             page = call_count[0]
             if page == 1:
                 html = '<a href="https://docs.example.com/file1.csv">file1.csv</a>'
             elif page == 2:
-                # Page 1: same links as page 0 — all duplicates, page NOT empty
                 html = '<a href="https://docs.example.com/file1.csv">file1.csv</a>'
             elif page == 3:
-                # Page 2: new link
                 html = '<a href="https://docs.example.com/file2.csv">file2.csv</a>'
             else:
                 html = "<html><body></body></html>"
             response = FakeJsonResponse(payload=None, text=html, headers={"content-type": "text/html"})
-            return response, None
+            return HttpResult(response=response, err=None, ssl_fallback_used=None)
 
-        monkeypatch.setattr(html_collector, "observatory_ssl_fallback_get", fake_ssl_fallback_get)
+        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: _FakeClient(fake_ssl_get))
 
         summary, rows = html_collector._scan_area_pages(
             area_pages=[],
@@ -660,17 +662,15 @@ class TestScanAreaPagesPagination:
 
     def test_page_url_template_respects_page_max(self, monkeypatch):
         """Collector stops at page_max even if pages still have links."""
-        import collectors.html as html_collector
-
         call_count = [0]
 
-        def fake_ssl_fallback_get(url, **kwargs):
+        def fake_ssl_get(url, **kwargs):
             call_count[0] += 1
             html = f'<a href="https://docs.example.com/file{call_count[0]}.csv">file.csv</a>'
             response = FakeJsonResponse(payload=None, text=html, headers={"content-type": "text/html"})
-            return response, None
+            return HttpResult(response=response, err=None, ssl_fallback_used=None)
 
-        monkeypatch.setattr(html_collector, "observatory_ssl_fallback_get", fake_ssl_fallback_get)
+        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: _FakeClient(fake_ssl_get))
 
         summary, rows = html_collector._scan_area_pages(
             area_pages=[],

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 
 import radar_check
-from lab_connectors.http import HttpClient, HttpFallbackError, HttpResult
+from lab_connectors.http import HttpFallbackError, HttpResult
 
 
 class FakeResponse:

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 
 import radar_check
-from collectors.base import SslFallbackFailed, SslFallbackResult
+from lab_connectors.http import HttpClient, HttpFallbackError, HttpResult
 
 
 class FakeResponse:
@@ -40,427 +40,252 @@ class FakeResponse:
         pass
 
 
-def test_classify_response_green() -> None:
-    assert radar_check.classify_response(200) == "GREEN"
-    assert radar_check.classify_response(201) == "GREEN"
-    assert radar_check.classify_response(301) == "GREEN"
-    assert radar_check.classify_response(302) == "GREEN"
+class TestClassify:
+    def test_classify_response_green(self) -> None:
+        assert radar_check.classify_response(200) == "GREEN"
+        assert radar_check.classify_response(201) == "GREEN"
+        assert radar_check.classify_response(301) == "GREEN"
+        assert radar_check.classify_response(302) == "GREEN"
+
+    def test_classify_response_yellow(self) -> None:
+        assert radar_check.classify_response(400) == "YELLOW"
+        assert radar_check.classify_response(404) == "YELLOW"
+        assert radar_check.classify_response(403) == "YELLOW"
+
+    def test_classify_response_red(self) -> None:
+        assert radar_check.classify_response(500) == "RED"
+        assert radar_check.classify_response(502) == "RED"
+        assert radar_check.classify_response(503) == "RED"
 
 
-def test_classify_response_yellow() -> None:
-    assert radar_check.classify_response(400) == "YELLOW"
-    assert radar_check.classify_response(404) == "YELLOW"
-    assert radar_check.classify_response(403) == "YELLOW"
+class TestValidateCkan:
+    def test_validate_ckan_action_response_ok(self) -> None:
+        response = FakeResponse(
+            status_code=200,
+            json_payload={"success": True, "result": []},
+        )
+        status, note = radar_check.validate_ckan_action_response(
+            "https://example.test/api/3/action/package_list", response
+        )
+        assert status == "GREEN"
+        assert note is None
+
+    def test_validate_ckan_action_response_missing_success(self) -> None:
+        response = FakeResponse(
+            status_code=200,
+            json_payload={"result": []},
+        )
+        status, note = radar_check.validate_ckan_action_response(
+            "https://example.test/api/3/action/package_list", response
+        )
+        assert status == "YELLOW"
+        assert "missing" in (note or "").lower()
+
+    def test_validate_ckan_action_response_non_json(self) -> None:
+        response = FakeResponse(
+            status_code=200,
+            content_type="text/html",
+            json_payload=None,
+            headers={"content-type": "text/html"},
+        )
+        status, note = radar_check.validate_ckan_action_response(
+            "https://example.test/api/3/action/package_list", response
+        )
+        assert status == "YELLOW"
+        assert "non-JSON" in (note or "")
 
 
-def test_classify_response_red() -> None:
-    assert radar_check.classify_response(500) == "RED"
-    assert radar_check.classify_response(502) == "RED"
-    assert radar_check.classify_response(503) == "RED"
+class TestProbe:
+    def test_probe_url_success(self, monkeypatch) -> None:
+        """Primary request succeeds — ssl_fallback_used=None."""
+
+        def fake_get(url, **kwargs):
+            return HttpResult(
+                response=FakeResponse(
+                    status_code=200,
+                    json_payload={"success": True, "result": []},
+                ),
+                err=None,
+                ssl_fallback_used=None,
+            )
+
+        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: _FakeClient(fake_get))
+        result = radar_check.probe_url("https://demo.test/api/3/action/package_list")
+        assert result.status == "GREEN"
+        assert result.http_code == "200"
+        assert result.ssl_fallback_used is False
+
+    def test_probe_url_timeout(self, monkeypatch) -> None:
+        """Timeout → YELLOW."""
+        import requests as real_requests
+
+        def fake_get(url, **kwargs):
+            return HttpResult(
+                response=None,
+                err=real_requests.exceptions.Timeout("Connection timed out"),
+                ssl_fallback_used=False,
+            )
+
+        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: _FakeClient(fake_get))
+        result = radar_check.probe_url("https://slow.test/api/3/action")
+        assert result.status == "YELLOW"
+        assert "Timeout" in (result.note or "")
+
+    def test_probe_url_connection_error(self, monkeypatch) -> None:
+        """ConnectionError → RED."""
+        import requests as real_requests
+
+        def fake_get(url, **kwargs):
+            return HttpResult(
+                response=None,
+                err=real_requests.exceptions.ConnectionError("Connection refused"),
+                ssl_fallback_used=False,
+            )
+
+        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: _FakeClient(fake_get))
+        result = radar_check.probe_url("https://dead.test/api/3/action")
+        assert result.status == "RED"
+        assert "Connection error" in (result.note or "")
+
+    def test_probe_url_ssl_fallback_success(self, monkeypatch) -> None:
+        """SSL error first, fallback succeeds — ssl_fallback_used=True."""
+
+        def fake_get(url, **kwargs):
+            return HttpResult(
+                response=FakeResponse(
+                    status_code=200,
+                    json_payload={"success": True},
+                ),
+                err=None,
+                ssl_fallback_used=True,
+            )
+
+        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: _FakeClient(fake_get))
+        result = radar_check._probe_once("https://ssl-broken.test/api/3/action")
+        assert result.ssl_fallback_used is True
+        assert result.status == "GREEN"
+
+    def test_probe_url_ssl_fallback_double_failure(self, monkeypatch) -> None:
+        """SSL error first, fallback also fails — ssl_fallback_used=False in HttpResult.
+
+        But ssl_failure_err is the primary SSLError → ssl_fallback_used=True in ProbeResult.
+        """
+        import requests as real_requests
+
+        def fake_get(url, **kwargs):
+            ssl_exc = real_requests.exceptions.SSLError("SSL cert verify failed")
+            fallback_exc = real_requests.exceptions.ConnectionError(
+                "Connection refused after fallback"
+            )
+            return HttpResult(
+                response=None,
+                err=HttpFallbackError(primary_error=ssl_exc, fallback_error=fallback_exc),
+                ssl_fallback_used=False,
+            )
+
+        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: _FakeClient(fake_get))
+        result = radar_check._probe_once("https://ssl-broken.test/api/3/action")
+        # ssl_failure_err is the primary SSLError → ssl_fallback_used=True in ProbeResult
+        assert result.ssl_fallback_used is True
+        assert "SSL verify failed" in (result.note or "")
 
 
-def test_validate_ckan_action_response_ok() -> None:
-    response = FakeResponse(
-        status_code=200,
-        json_payload={"success": True, "result": []},
-    )
-    status, note = radar_check.validate_ckan_action_response(
-        "https://example.test/api/3/action/package_list", response
-    )
-    assert status == "GREEN"
-    assert note is None
-
-
-def test_validate_ckan_action_response_missing_success() -> None:
-    response = FakeResponse(
-        status_code=200,
-        json_payload={"result": []},
-    )
-    status, note = radar_check.validate_ckan_action_response(
-        "https://example.test/api/3/action/package_list", response
-    )
-    assert status == "YELLOW"
-    assert "missing" in (note or "").lower()
-
-
-def test_validate_ckan_action_response_non_json() -> None:
-    response = FakeResponse(
-        status_code=200,
-        content_type="text/html",
-        json_payload=None,
-        headers={"content-type": "text/html"},
-    )
-    status, note = radar_check.validate_ckan_action_response(
-        "https://example.test/api/3/action/package_list", response
-    )
-    assert status == "YELLOW"
-    assert "non-JSON" in (note or "")
-
-
-def test_validate_ckan_action_response_invalid_json() -> None:
-    response = FakeResponse(status_code=200, json_payload=None)
-    status, note = radar_check.validate_ckan_action_response(
-        "https://example.test/api/3/action/package_list", response
-    )
-    assert status == "YELLOW"
-    assert "invalid JSON" in (note or "")
-
-
-def test_validate_ckan_action_response_non_ckan_url() -> None:
-    response = FakeResponse(status_code=200, content_type="text/html")
-    status, note = radar_check.validate_ckan_action_response(
-        "https://example.test/", response
-    )
-    # Non-CKAN URL should just be classified by status code
-    assert status == "GREEN"
-    assert note is None
-
-
-def test_is_sdmx_url() -> None:
-    assert radar_check._is_sdmx_url("https://example.test/rest/dataflow") is True
-    assert radar_check._is_sdmx_url("https://example.test/SDMXWS/data") is True
-    assert radar_check._is_sdmx_url("https://example.test/sdmx/v1/data") is True
-    assert radar_check._is_sdmx_url("https://example.test/api/3/action") is False
-    assert radar_check._is_sdmx_url("https://example.test/datasets") is False
-
-
-def test_probe_url_success(monkeypatch) -> None:
-    def fake_ssl_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
-        return SslFallbackResult(
-            response=FakeResponse(
-                status_code=200,
-                json_payload={"success": True, "result": []},
+class TestBuildReport:
+    def test_build_status_report_basic(self) -> None:
+        registry = {
+            "demo_ckan": {
+                "base_url": "https://demo.test/api/3/action/package_list",
+                "source_kind": "catalog",
+                "protocol": "ckan",
+                "observation_mode": "catalog-watch",
+            },
+            "istat_sdmx": {
+                "base_url": "https://sdmx.istat.it/rest/",
+                "source_kind": "catalog",
+                "protocol": "sdmx",
+                "observation_mode": "radar-only",
+            },
+        }
+        results = {
+            "demo_ckan": radar_check.ProbeResult(
+                status="GREEN", http_code="200", content_type="application/json"
             ),
-            err=None,
-            ssl_fallback_used=None,
-        )
+            "istat_sdmx": radar_check.ProbeResult(
+                status="YELLOW", http_code="503", note="SDMX retry esaurito"
+            ),
+        }
+        report = radar_check.build_status_report(registry, results, "2026-04-11")
+        assert "# Stato Radar" in report
+        assert "Ultimo run: 2026-04-11" in report
+        assert "Fonti controllate: 2" in report
+        assert "GREEN: 1" in report
+        assert "YELLOW: 1" in report
+        assert "RED: 0" in report
+        assert "| demo_ckan |" in report
+        assert "| istat_sdmx |" in report
+        assert "## Note" in report
+        assert "istat_sdmx" in report
 
-    monkeypatch.setattr(radar_check, "observatory_ssl_fallback_get", fake_ssl_get)
-    result = radar_check.probe_url("https://demo.test/api/3/action/package_list")
-    assert result.status == "GREEN"
-    assert result.http_code == "200"
-    assert result.ssl_fallback_used is False
-
-
-def test_probe_url_timeout(monkeypatch) -> None:
-    import requests as real_requests
-
-    def fake_ssl_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
-        return SslFallbackResult(
-            response=None,
-            err=real_requests.exceptions.Timeout("Connection timed out"),
-            ssl_fallback_used=False,
-        )
-
-    monkeypatch.setattr(radar_check, "observatory_ssl_fallback_get", fake_ssl_get)
-    result = radar_check.probe_url("https://slow.test/api/3/action")
-    assert result.status == "YELLOW"
-    assert "Timeout" in (result.note or "")
-
-
-def test_probe_url_connection_error(monkeypatch) -> None:
-    import requests as real_requests
-
-    def fake_ssl_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
-        return SslFallbackResult(
-            response=None,
-            err=real_requests.exceptions.ConnectionError("Connection refused"),
-            ssl_fallback_used=False,
-        )
-
-    monkeypatch.setattr(radar_check, "observatory_ssl_fallback_get", fake_ssl_get)
-    result = radar_check.probe_url("https://dead.test/api/3/action")
-    assert result.status == "RED"
-    assert "Connection error" in (result.note or "")
-
-
-def test_probe_url_ssl_fallback(monkeypatch) -> None:
-    """SSL error first, fallback succeeds — ssl_fallback_used=True.
-
-    observatory_ssl_fallback_get now returns SslFallbackResult with
-    ssl_fallback_used=True when primary SSL failed but fallback succeeded.
-    """
-    def fake_ssl_fallback_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
-        response = FakeResponse(status_code=200, json_payload={"success": True})
-        return SslFallbackResult(response=response, err=None, ssl_fallback_used=True)
-
-    monkeypatch.setattr(
-        radar_check, "observatory_ssl_fallback_get", fake_ssl_fallback_get
-    )
-    monkeypatch.setattr(
-        radar_check.requests.packages.urllib3,
-        "disable_warnings",
-        lambda *args, **kwargs: None,
-    )
-
-    result = radar_check._probe_once("https://ssl-broken.test/api/3/action")
-    assert result.ssl_fallback_used is True
-    assert result.status == "GREEN"
+    def test_build_radar_summary_schema(self) -> None:
+        registry = {
+            "demo_ckan": {
+                "base_url": "https://demo.test/api/3/action/package_list",
+                "source_kind": "catalog",
+                "protocol": "ckan",
+                "observation_mode": "catalog-watch",
+                "datasets_in_use": ["dataset1", "dataset2"],
+            },
+            "istat_sdmx": {
+                "base_url": "https://sdmx.istat.it/rest/",
+                "source_kind": "catalog",
+                "protocol": "sdmx",
+                "observation_mode": "radar-only",
+                "datasets_in_use": [],
+            },
+        }
+        results = {
+            "demo_ckan": radar_check.ProbeResult(
+                status="GREEN", http_code="200", content_type="application/json"
+            ),
+            "istat_sdmx": radar_check.ProbeResult(
+                status="YELLOW", http_code="-", note="Timeout"
+            ),
+        }
+        summary, sources_list = radar_check.build_radar_summary(registry, results, "2026-04-18")
+        assert "generated_at" in summary
+        assert "probe_date" in summary
+        assert "sources_total" in summary
+        assert "status_counts" in summary
+        assert "sources" in summary
+        assert summary["probe_date"] == "2026-04-18"
+        assert summary["sources_total"] == 2
+        assert summary["status_counts"]["GREEN"] == 1
+        assert summary["status_counts"]["YELLOW"] == 1
+        assert summary["status_counts"]["RED"] == 0
+        sources_by_id = {s["id"]: s for s in sources_list}
+        assert "demo_ckan" in sources_by_id
+        demo = sources_by_id["demo_ckan"]
+        assert demo["status"] == "GREEN"
+        assert demo["http_code"] == "200"
+        istat = sources_by_id["istat_sdmx"]
+        assert istat["status"] == "YELLOW"
+        assert istat["note"] == "Timeout"
+        json_str = json.dumps(summary)
+        reparsed = json.loads(json_str)
+        assert reparsed == summary
 
 
-def test_observatory_ssl_fallback_get_returns_true_on_fallback_success(monkeypatch) -> None:
-    """observatory_ssl_fallback_get returns (response, True) when fallback succeeds.
-
-    New contract: (response, True) = SSL fallback was used and succeeded.
-    (response, None) = primary request succeeded.
-    The key behavioral difference: callers that check 'if err' still work
-    (err is truthy), but now err=True means "fallback succeeded" not "error".
-    """
-    import requests
-
-    class FakeSuccessResponse:
-        status_code = 200
-        headers = {"content-type": "application/json"}
-        url = "https://ssl-broken.test/file.csv"
-        def __enter__(self): return self
-        def __exit__(self, *a): pass
-
-    class FakePrimarySession:
-        """Fake session for the primary (get_observatory_session) path."""
-        def __init__(self):
-            self.calls = []
-        def get(self, url, *, timeout=None, headers=None, verify=None, stream=None, **kwargs):
-            self.calls.append({"method": "get", "url": url, "verify": verify})
-            if len(self.calls) == 1:
-                raise requests.exceptions.SSLError("SSL cert verify failed")
-            return FakeSuccessResponse()
-        def __enter__(self): return self
-        def __exit__(self, *a): pass
-
-    class FakeFallbackSessionInstance:
-        """Fake session instance returned by requests.Session() in fallback path."""
-        def __init__(self):
-            self.headers = {}
-        def __enter__(self): return self
-        def __exit__(self, *a): pass
-        def get(self, url, *, timeout=None, headers=None, verify=None, stream=None, **kwargs):
-            return FakeSuccessResponse()
-
-    class FakeFallbackSessionClass:
-        """Fake requests.Session class for the fallback path."""
-        def __call__(self):
-            return FakeFallbackSessionInstance()
-        def __enter__(self): return FakeFallbackSessionInstance()
-        def __exit__(self, *a): pass
-
-    from collectors import base
-    orig_session = base.get_observatory_session
-    orig_requests_session = base.requests.Session
-    fake_primary_sessions = []
-
-    def make_fake_session(*a, **k):
-        fs = FakePrimarySession()
-        fake_primary_sessions.append(fs)
-        return fs
-
-    monkeypatch.setattr(base, "get_observatory_session", make_fake_session)
-    monkeypatch.setattr(base.requests, "Session", FakeFallbackSessionClass())
-    monkeypatch.setattr(base.urllib3, "disable_warnings", lambda *a, **k: None)
-
-    result = base.observatory_ssl_fallback_get("https://ssl-broken.test/file.csv", timeout=10)
-    assert result.response is not None
-    assert result.err is None
-    assert result.ssl_fallback_used is True  # fallback was used and succeeded
-    assert len(fake_primary_sessions) == 1  # Only primary was called (fallback uses requests.Session)
-
-    base.get_observatory_session = orig_session
-    base.requests.Session = orig_requests_session
+# ── helper ────────────────────────────────────────────────────────────────────────
 
 
-def test_observatory_head_retries_verify_false_on_ssl_error(monkeypatch) -> None:
-    """observatory_head retries with verify=False when SSLError is raised."""
-    import requests
+class _FakeClient:
+    """Fake HttpClient that returns a predetermined HttpResult for any get() call."""
 
-    class FakeSuccessResponse:
-        status_code = 200
-        headers = {"content-type": "text/html"}
-        url = "https://ssl-broken.test/"
-        def __enter__(self): return self
-        def __exit__(self, *a): pass
+    def __init__(self, result_fn):
+        self._result_fn = result_fn
 
-    class FakePrimarySession:
-        """Fake session for the primary (get_observatory_session) path."""
-        def __init__(self):
-            self.calls = []
-        def head(self, url, *, timeout=None, headers=None, verify=None, allow_redirects=None, **kwargs):
-            self.calls.append({"method": "head", "url": url, "verify": verify})
-            if len(self.calls) == 1:
-                raise requests.exceptions.SSLError("SSL cert verify failed")
-            return FakeSuccessResponse()
-        def __enter__(self): return self
-        def __exit__(self, *a): pass
+    def get(self, url, **kwargs):
+        return self._result_fn(url, **kwargs)
 
-    class FakeFallbackSessionInstance:
-        """Fake session instance returned by requests.Session() in fallback path."""
-        def __init__(self):
-            self.headers = {}
-        def __enter__(self): return self
-        def __exit__(self, *a): pass
-        def head(self, url, *, timeout=None, headers=None, verify=None, allow_redirects=None, **kwargs):
-            return FakeSuccessResponse()
-
-    class FakeFallbackSessionClass:
-        """Fake requests.Session class for the fallback path."""
-        def __call__(self):
-            return FakeFallbackSessionInstance()
-        def __enter__(self): return FakeFallbackSessionInstance()
-        def __exit__(self, *a): pass
-
-    from collectors import base
-    orig = base.get_observatory_session
-    orig_requests_session = base.requests.Session
-    fake_primary_sessions = []
-
-    def make_fake_session(*a, **k):
-        fs = FakePrimarySession()
-        fake_primary_sessions.append(fs)
-        return fs
-
-    monkeypatch.setattr(base, "get_observatory_session", make_fake_session)
-    monkeypatch.setattr(base.requests, "Session", FakeFallbackSessionClass())
-    monkeypatch.setattr(base.urllib3, "disable_warnings", lambda *a, **k: None)
-
-    resp = base.observatory_head("https://ssl-broken.test/", timeout=10)
-    assert resp.status_code == 200
-    assert len(fake_primary_sessions) == 1  # Only primary called
-
-    base.get_observatory_session = orig
-    base.requests.Session = orig_requests_session
-
-
-def test_probe_url_ssl_fallback_double_failure(monkeypatch) -> None:
-    """SSL error first, fallback also fails — ssl_fallback_used=True, both errors preserved.
-
-    Both primary SSL and fallback failed. result.ssl_fallback_used=False but
-    ssl_failure_err is set (from the primary SSLError), so ssl_fallback_used=True
-    in the ProbeResult (it correctly reflects that an SSL error occurred).
-    """
-    import requests as real_requests
-
-    def fake_ssl_fallback_get(url, *, timeout=None, allow_redirects=None, stream=None, **kwargs):
-        ssl_exc = real_requests.exceptions.SSLError("SSL cert verify failed")
-        fallback_exc = real_requests.exceptions.ConnectionError("Connection refused after fallback")
-        return SslFallbackResult(
-            response=None,
-            err=SslFallbackFailed(ssl_error=ssl_exc, fallback_error=fallback_exc),
-            ssl_fallback_used=False,
-        )
-
-    monkeypatch.setattr(
-        radar_check, "observatory_ssl_fallback_get", fake_ssl_fallback_get
-    )
-    monkeypatch.setattr(
-        radar_check.requests.packages.urllib3,
-        "disable_warnings",
-        lambda *args, **kwargs: None,
-    )
-
-    result = radar_check._probe_once("https://ssl-broken.test/api/3/action")
-    # ssl_failure_err is the primary SSLError → ssl_fallback_used=True in ProbeResult
-    assert result.ssl_fallback_used is True
-    assert "SSL verify failed" in (result.note or "")
-
-
-def test_build_status_report_basic() -> None:
-    registry = {
-        "demo_ckan": {
-            "base_url": "https://demo.test/api/3/action/package_list",
-            "source_kind": "catalog",
-            "protocol": "ckan",
-            "observation_mode": "catalog-watch",
-        },
-        "istat_sdmx": {
-            "base_url": "https://sdmx.istat.it/rest/",
-            "source_kind": "catalog",
-            "protocol": "sdmx",
-            "observation_mode": "radar-only",
-        },
-    }
-    results = {
-        "demo_ckan": radar_check.ProbeResult(
-            status="GREEN", http_code="200", content_type="application/json"
-        ),
-        "istat_sdmx": radar_check.ProbeResult(
-            status="YELLOW", http_code="503", note="SDMX retry esaurito"
-        ),
-    }
-
-    report = radar_check.build_status_report(registry, results, "2026-04-11")
-
-    assert "# Stato Radar" in report
-    assert "Ultimo run: 2026-04-11" in report
-    assert "Fonti controllate: 2" in report
-    assert "GREEN: 1" in report
-    assert "YELLOW: 1" in report
-    assert "RED: 0" in report
-    assert "| demo_ckan |" in report
-    assert "| istat_sdmx |" in report
-    assert "## Note" in report
-    assert "istat_sdmx" in report
-
-
-def test_build_radar_summary_schema() -> None:
-    """Test che build_radar_summary produce un JSON consumabile da ACB."""
-    registry = {
-        "demo_ckan": {
-            "base_url": "https://demo.test/api/3/action/package_list",
-            "source_kind": "catalog",
-            "protocol": "ckan",
-            "observation_mode": "catalog-watch",
-            "datasets_in_use": ["dataset1", "dataset2"],
-        },
-        "istat_sdmx": {
-            "base_url": "https://sdmx.istat.it/rest/",
-            "source_kind": "catalog",
-            "protocol": "sdmx",
-            "observation_mode": "radar-only",
-            "datasets_in_use": [],
-        },
-    }
-    results = {
-        "demo_ckan": radar_check.ProbeResult(
-            status="GREEN", http_code="200", content_type="application/json"
-        ),
-        "istat_sdmx": radar_check.ProbeResult(
-            status="YELLOW", http_code="-", note="Timeout"
-        ),
-    }
-
-    summary, sources_list = radar_check.build_radar_summary(registry, results, "2026-04-18")
-
-    # Verifica struttura top-level
-    assert "generated_at" in summary
-    assert "probe_date" in summary
-    assert "sources_total" in summary
-    assert "status_counts" in summary
-    assert "sources" in summary
-
-    # Verifica conteggi
-    assert summary["probe_date"] == "2026-04-18"
-    assert summary["sources_total"] == 2
-    assert summary["status_counts"]["GREEN"] == 1
-    assert summary["status_counts"]["YELLOW"] == 1
-    assert summary["status_counts"]["RED"] == 0
-
-    # Verifica entry fonte (new lean schema — history-oriented)
-    assert len(sources_list) == 2
-    sources_by_id = {s["id"]: s for s in sources_list}
-    assert "demo_ckan" in sources_by_id
-    assert "istat_sdmx" in sources_by_id
-
-    demo = sources_by_id["demo_ckan"]
-    assert demo["status"] == "GREEN"
-    assert demo["protocol"] == "ckan"
-    assert demo["http_code"] == "200"
-    assert "note" in demo or demo.get("note") is None
-
-    istat = sources_by_id["istat_sdmx"]
-    assert istat["status"] == "YELLOW"
-    assert istat["http_code"] == "-"
-    assert istat["note"] == "Timeout"
-
-    # Verifica JSON-serializable
-    json_str = json.dumps(summary)
-    assert isinstance(json_str, str)
-    reparsed = json.loads(json_str)
-    assert reparsed == summary
+    def head(self, url, **kwargs):
+        return self._result_fn(url, **kwargs)


### PR DESCRIPTION
## Summary
- Sostituisce la duplicazione SSL fallback in SO con `lab_connectors.http`
- Aggiunge dipendenza `lab-connectors@v0.1.0`

## Cosa cambia
- `requirements.txt`: +`lab-connectors@v0.1.0`
- `collectors/base.py`: rimossi `SslFallbackResult`, `SslFallbackFailed`, `observatory_ssl_fallback_get`
- `collectors/html.py`: 5 call site ora usano `HttpClient.get` direttamente
- `radar_check.py`: usa `HttpClient` + `HttpFallbackError`
- `mcp/so_server_core.py`: `_get_observatory_ssl_fallback_get()` ora è un adapter che usa `HttpClient`
- Test riscritti per mockare `HttpClient` invece delle vecchie funzioni

## Cosa è stato rimosso
- ~260 LOC di codice HTTP duplicato in SO

## Diagnostica preservata
- `ssl_fallback_used=True/False/None` — stessa semantica
- `ProbeResult.note` — stesso formato ("SSL verify failed...")

## Fuori scope per questa PR
- `test_so_mcp.py` MCP wrapper — lasciato com'è, i test passano già