### PR TITLE
refactor(http): unify MCP HTTP calls on HttpClient

### DIFF
--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -22,6 +22,8 @@ from urllib.parse import urlparse
 import duckdb
 import requests
 
+from lab_connectors.http import HttpClient
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _COLLECTORS_BASE = _REPO_ROOT / "scripts" / "collectors" / "base.py"
 _CHECK_PARQUET = (
@@ -55,8 +57,12 @@ def _ckan_action_endpoint(base_url: str, action: str) -> str:
 
 
 def _ckan_get_json(url: str, timeout: int = 30, params: dict | None = None) -> dict[str, Any]:
-    """Simple HTTP GET returning JSON — uses observatory_get for consistent UA."""
-    response = _get_observatory_get()(url, timeout=timeout, params=params)
+    """Simple HTTP GET returning JSON — uses HttpClient with SSL fallback."""
+    client = HttpClient(timeout=timeout)
+    result = client.get(url, params=params or {})
+    if not result.is_ok:
+        raise result.err
+    response = result.response
     response.raise_for_status()
     content_type = (response.headers.get("content-type") or "").lower()
     if "json" not in content_type:
@@ -205,12 +211,11 @@ _ENV_LOADED = False
 
 _collectors_base = None
 observatory_get = None
-observatory_head = None
-observatory_ssl_fallback_get = None
 
 
 def _get_observatory_get() -> Any:
-    global _collectors_base, observatory_get, observatory_head, observatory_ssl_fallback_get
+    """Lazy-load observatory_get from collectors.base (used only for POST cases like SPARQL)."""
+    global _collectors_base, observatory_get
     if _collectors_base is None:
         spec = importlib.util.spec_from_file_location("_so_collectors_base", _COLLECTORS_BASE)
         if spec is None or spec.loader is None:
@@ -219,25 +224,7 @@ def _get_observatory_get() -> Any:
         sys.modules[spec.name] = _collectors_base
         spec.loader.exec_module(_collectors_base)
         observatory_get = _collectors_base.observatory_get
-        observatory_head = _collectors_base.observatory_head
     return observatory_get
-
-
-def _get_observatory_head() -> Any:
-    _get_observatory_get()  # ensure initialized
-    return observatory_head
-
-
-def _get_observatory_ssl_fallback_get() -> Any:
-    from lab_connectors.http import HttpClient
-
-    def ssl_fallback_get(url: str, *, timeout: int | float | tuple[int, int] | None = None, headers: dict | None = None, **kwargs: Any) -> tuple[Any, Any]:
-        client = HttpClient(timeout=timeout or 60)
-        kwargs.pop("timeout", None)
-        result = client.get(url, headers=headers or {}, **kwargs)
-        return (result.response, result.err)
-
-    return ssl_fallback_get
 
 
 @dataclass(frozen=True)
@@ -1053,50 +1040,72 @@ def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
         }
 
     safe_timeout = max(1, min(int(timeout or 15), 60))
-    ssl_fallback_used = False
-    try:
-        response = _get_observatory_head()(clean_url, timeout=safe_timeout)
-    except requests.RequestException:
-        try:
-            response = _get_observatory_get()(
-                clean_url,
-                timeout=safe_timeout,
-                headers={"Range": "bytes=0-0"},
-                stream=True,
-            )
-        except requests.RequestException as fallback_exc:
-            # Third attempt: SSL-fallback GET (handles certs expired/invalid)
-            try:
-                ssl_response, ssl_err = _get_observatory_ssl_fallback_get()(
-                    clean_url,
-                    timeout=safe_timeout,
-                    headers={"Range": "bytes=0-0"},
-                )
-                if ssl_response is not None:
-                    response = ssl_response
-                    ssl_fallback_used = True
-                else:
-                    return {
-                        "url": clean_url,
-                        "http_status": None,
-                        "content_type": None,
-                        "format": _guess_format(clean_url, None),
-                        "size": None,
-                        "is_reachable": False,
-                        "error": "ssl_fallback_failed",
-                        "message": str(ssl_err)[:200] if ssl_err else str(fallback_exc)[:200],
-                    }
-            except Exception as ssl_third_exc:
-                return {
-                    "url": clean_url,
-                    "http_status": None,
-                    "content_type": None,
-                    "format": _guess_format(clean_url, None),
-                    "size": None,
-                    "is_reachable": False,
-                    "error": type(ssl_third_exc).__name__,
-                    "message": str(ssl_third_exc)[:200] or str(fallback_exc)[:200],
-                }
+
+    # Attempt 1: HEAD via HttpClient (SSL fallback built-in)
+    client = HttpClient(timeout=safe_timeout)
+    result = client.head(clean_url)
+
+    if result.is_ok:
+        response = result.response
+    elif result.is_ssl_fallback_failed:
+        # Both primary SSL and fallback failed
+        return {
+            "url": clean_url,
+            "http_status": None,
+            "content_type": None,
+            "format": _guess_format(clean_url, None),
+            "size": None,
+            "is_reachable": False,
+            "error": "ssl_fallback_failed",
+            "message": str(result.err)[:200],
+        }
+    elif result.ssl_fallback_used and result.response is not None:
+        # Primary SSL failed, fallback succeeded — GREEN with ssl_fallback_used
+        response = result.response
+    elif result.err is not None:
+        # Non-SSL error (4xx/5xx) — try GET with Range
+        result2 = client.get(
+            clean_url,
+            headers={"Range": "bytes=0-0"},
+        )
+        if result2.is_ok:
+            response = result2.response
+        elif result2.is_ssl_fallback_failed:
+            return {
+                "url": clean_url,
+                "http_status": None,
+                "content_type": None,
+                "format": _guess_format(clean_url, None),
+                "size": None,
+                "is_reachable": False,
+                "error": "ssl_fallback_failed",
+                "message": str(result2.err)[:200],
+            }
+        elif result2.ssl_fallback_used and result2.response is not None:
+            response = result2.response
+        else:
+            return {
+                "url": clean_url,
+                "http_status": None,
+                "content_type": None,
+                "format": _guess_format(clean_url, None),
+                "size": None,
+                "is_reachable": False,
+                "error": type(result2.err).__name__,
+                "message": str(result2.err)[:200],
+            }
+    else:
+        # Unknown state — should not happen
+        return {
+            "url": clean_url,
+            "http_status": None,
+            "content_type": None,
+            "format": _guess_format(clean_url, None),
+            "size": None,
+            "is_reachable": False,
+            "error": "unknown_error",
+            "message": "unexpected state in probe_url",
+        }
 
     content_type = response.headers.get("content-type")
     content_length = response.headers.get("content-length")
@@ -1112,7 +1121,7 @@ def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
         "format": _guess_format(clean_url, content_type),
         "size": size,
         "is_reachable": response.status_code < 400,
-        "ssl_fallback_used": ssl_fallback_used,
+        "ssl_fallback_used": result.ssl_fallback_used,
     }
 
 
@@ -1428,7 +1437,7 @@ def _sparql_query_raw(
     """Execute a SPARQL SELECT query against any public endpoint.
 
     Returns dict with rows, columns, and bindings count.
-    Uses observatory_get for consistent User-Agent header.
+    Uses HttpClient (POST not supported — falls back to observatory_get for SPARQL POST).
     """
     if not endpoint or not query:
         return {"error": "invalid_params", "message": "endpoint and query are required"}
@@ -1443,6 +1452,7 @@ def _sparql_query_raw(
     if "LIMIT" not in clean_query.upper():
         clean_query = f"{clean_query}\nLIMIT {safe_max_rows}"
 
+    # SPARQL POST is not supported by HttpClient — use requests directly for this case
     try:
         response = _get_observatory_get()(
             endpoint,
@@ -1542,7 +1552,7 @@ def _html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
     """Extract file download links from an HTML page.
 
     Returns {url, links: [{url, format, title}], total, content_type, is_reachable}.
-    Uses observatory_get with proper UA.
+    Uses HttpClient with SSL fallback built-in.
     """
     if not url:
         return {"error": "invalid_url", "message": "url is required"}
@@ -1551,33 +1561,19 @@ def _html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
         return {"error": "invalid_url", "message": f"Invalid URL: {url}"}
 
     safe_timeout = max(1, min(int(timeout or 20), 60))
-    ssl_fallback_used = False
+    client = HttpClient(timeout=safe_timeout)
+    result = client.get(url)
 
-    try:
-        response = _get_observatory_get()(url, timeout=safe_timeout)
-        content_type = response.headers.get("content-type", "")
-    except Exception as exc:
-        # Retry with SSL fallback
-        try:
-            ssl_response, ssl_err = _get_observatory_ssl_fallback_get()(url, timeout=safe_timeout)
-        except Exception as ssl_exc:
-            return {
-                "url": url,
-                "is_reachable": False,
-                "error": type(ssl_exc).__name__,
-                "message": str(ssl_exc)[:200],
-            }
-        if ssl_response is not None:
-            response = ssl_response
-            content_type = response.headers.get("content-type", "")
-            ssl_fallback_used = True
-        else:
-            return {
-                "url": url,
-                "is_reachable": False,
-                "error": type(exc).__name__,
-                "message": str(exc)[:200],
-            }
+    if not result.is_ok:
+        return {
+            "url": url,
+            "is_reachable": False,
+            "error": type(result.err).__name__,
+            "message": str(result.err)[:200],
+        }
+
+    response = result.response
+    content_type = response.headers.get("content-type", "")
 
     text_html = "text/html" in content_type.lower()
     try:
@@ -1595,5 +1591,5 @@ def _html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
         "links": links,
         "total": len(links),
         "formats": sorted({link["format"] for link in links}),
-        "ssl_fallback_used": ssl_fallback_used,
+        "ssl_fallback_used": result.ssl_fallback_used,
     }

--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -1041,12 +1041,16 @@ def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
 
     safe_timeout = max(1, min(int(timeout or 15), 60))
 
+    # Track ssl_fallback_used from the result we actually use
+    ssl_used: bool | None = None
+
     # Attempt 1: HEAD via HttpClient (SSL fallback built-in)
     client = HttpClient(timeout=safe_timeout)
     result = client.head(clean_url)
 
     if result.is_ok:
         response = result.response
+        ssl_used = result.ssl_fallback_used
     elif result.is_ssl_fallback_failed:
         # Both primary SSL and fallback failed
         return {
@@ -1062,14 +1066,16 @@ def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
     elif result.ssl_fallback_used and result.response is not None:
         # Primary SSL failed, fallback succeeded — GREEN with ssl_fallback_used
         response = result.response
+        ssl_used = True
     elif result.err is not None:
-        # Non-SSL error (4xx/5xx) — try GET with Range
+        # Non-SSL error (connection error, etc.) — try GET with Range
         result2 = client.get(
             clean_url,
             headers={"Range": "bytes=0-0"},
         )
         if result2.is_ok:
             response = result2.response
+            ssl_used = result2.ssl_fallback_used
         elif result2.is_ssl_fallback_failed:
             return {
                 "url": clean_url,
@@ -1083,6 +1089,7 @@ def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
             }
         elif result2.ssl_fallback_used and result2.response is not None:
             response = result2.response
+            ssl_used = True
         else:
             return {
                 "url": clean_url,
@@ -1121,7 +1128,7 @@ def probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
         "format": _guess_format(clean_url, content_type),
         "size": size,
         "is_reachable": response.status_code < 400,
-        "ssl_fallback_used": result.ssl_fallback_used,
+        "ssl_fallback_used": ssl_used,
     }
 
 

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -596,6 +596,63 @@ def test_probe_url_ssl_fallback_used_when_head_fallback_succeeds(monkeypatch) ->
     assert result["http_status"] == 200
 
 
+def test_probe_url_ssl_fallback_from_get_fallback(monkeypatch) -> None:
+    """When HEAD fails with non-SSL error and GET fallback succeeds, ssl_fallback_used reflects result2."""
+    class _FakeOKResponse:
+        status_code = 200
+        headers = {"content-type": "text/csv", "content-length": "1024"}
+
+    class _FakeHeadResult:
+        """Simulates HttpClient.head() returning a non-SSL error."""
+        def __init__(self):
+            self.response = None
+            self.err = Exception("connection refused")  # non-SSL error
+            self.ssl_fallback_used = None
+
+        @property
+        def is_ok(self):
+            return False
+
+        @property
+        def is_ssl_fallback_failed(self):
+            return False
+
+    class _FakeGetWithSSLFallbackResult:
+        """Simulates HttpClient.get() succeeding via SSL fallback."""
+        def __init__(self):
+            self.response = _FakeOKResponse()
+            self.err = None
+            self.ssl_fallback_used = True  # SSL fallback was used
+
+        @property
+        def is_ok(self):
+            return True
+
+        @property
+        def is_ssl_fallback_failed(self):
+            return False
+
+    class _FakeHttpClient:
+        def __init__(self, timeout=None):
+            pass
+
+        def head(self, url):
+            return _FakeHeadResult()
+
+        def get(self, url, headers=None, params=None):
+            return _FakeGetWithSSLFallbackResult()
+
+    monkeypatch.setattr(core, "HttpClient", _FakeHttpClient)
+
+    result = core.probe_url("https://expired-cert.example.com/file.csv")
+
+    # Response comes from result2 (GET), ssl_fallback_used must reflect result2
+    assert result["is_reachable"] is True
+    assert result["ssl_fallback_used"] is True, "ssl_fallback_used must come from GET result2"
+    assert result["http_status"] == 200
+    assert result["content_type"] == "text/csv"
+
+
 def test_html_extract_links_ssl_fallback_failure_returns_reachable_false(monkeypatch) -> None:
     """When HttpClient.get fails with non-SSL error, returns is_reachable=False."""
 

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -558,53 +558,69 @@ class _FakeSSLFallbackResponse:
         self.headers = {"content-type": "text/html; charset=utf-8", "content-length": "100"}
 
 
-def test_probe_url_ssl_fallback_used_when_fallback_succeeds(monkeypatch) -> None:
-    """When HEAD and GET both fail but SSL-fallback GET succeeds, ssl_fallback_used is True."""
-    ssl_fallback_called = False
+def test_probe_url_ssl_fallback_used_when_head_fallback_succeeds(monkeypatch) -> None:
+    """When HttpClient.head() primary SSL fails but fallback succeeds, ssl_fallback_used is True."""
+    class _FakeSSLResponse:
+        status_code = 200
+        headers = {"content-type": "text/html; charset=utf-8", "content-length": "100"}
 
-    def fake_head_factory():
-        def fake_head(url, **kwargs):
-            raise core.requests.RequestException("head failed")
-        return fake_head
+    class _FakeHttpResult:
+        """Simulates HttpClient.head() when primary SSL failed but fallback succeeded."""
+        def __init__(self):
+            self.response = _FakeSSLResponse()
+            self.err = None
+            self.ssl_fallback_used = True
 
-    def fake_get_factory():
-        def fake_get(url, **kwargs):
-            raise core.requests.RequestException("get failed")
-        return fake_get
+        @property
+        def is_ok(self):
+            return True  # fallback succeeded, response usable
 
-    def fake_ssl_fallback_factory():
-        def fake_ssl_fallback_get(url, **kwargs):
-            nonlocal ssl_fallback_called
-            ssl_fallback_called = True
-            return _FakeSSLFallbackResponse(), None  # (response, no_error)
-        return fake_ssl_fallback_get
+        @property
+        def is_ssl_fallback_failed(self):
+            return False
 
-    monkeypatch.setattr(core, "_get_observatory_head", fake_head_factory)
-    monkeypatch.setattr(core, "_get_observatory_get", fake_get_factory)
-    monkeypatch.setattr(core, "_get_observatory_ssl_fallback_get", fake_ssl_fallback_factory)
+    class _FakeHttpClient:
+        def __init__(self, timeout=None):
+            pass
+
+        def head(self, url):
+            # HttpClient catches SSLError internally, returns result with ssl_fallback_used=True
+            return _FakeHttpResult()
+
+    monkeypatch.setattr(core, "HttpClient", _FakeHttpClient)
 
     result = core.probe_url("https://expired-cert.example.com/file.csv")
 
-    assert ssl_fallback_called, "SSL fallback should have been called"
     assert result["is_reachable"] is True
     assert result["ssl_fallback_used"] is True
     assert result["http_status"] == 200
 
 
 def test_html_extract_links_ssl_fallback_failure_returns_reachable_false(monkeypatch) -> None:
-    """When _get_observatory_get fails and SSL fallback raises non-RequestException, returns is_reachable=False without exploding."""
-    def fake_get_factory():
-        def fake_get(url, **kwargs):
-            raise core.requests.RequestException("get failed")
-        return fake_get
+    """When HttpClient.get fails with non-SSL error, returns is_reachable=False."""
 
-    def fake_ssl_fallback_factory():
-        def fake_ssl_fallback_raises(url, **kwargs):
-            raise ValueError("unexpected internal error")  # non-RequestException
-        return fake_ssl_fallback_raises
+    class _FakeHttpResultError:
+        def __init__(self, err):
+            self.response = None
+            self.err = err
+            self.ssl_fallback_used = False
 
-    monkeypatch.setattr(core, "_get_observatory_get", fake_get_factory)
-    monkeypatch.setattr(core, "_get_observatory_ssl_fallback_get", fake_ssl_fallback_factory)
+        @property
+        def is_ok(self):
+            return False
+
+        @property
+        def is_ssl_fallback_failed(self):
+            return False
+
+    class _FakeHttpClient:
+        def __init__(self, timeout=None):
+            pass
+
+        def get(self, url, headers=None, params=None):
+            return _FakeHttpResultError(ValueError("unexpected internal error"))
+
+    monkeypatch.setattr(core, "HttpClient", _FakeHttpClient)
 
     result = core._html_extract_links("https://expired-cert.example.com/page.html")
 


### PR DESCRIPTION
## Scope
- Package usato: `lab_connectors.http`
- Consumer migrato: `mcp/so_server_core.py`
- Surface toccate: runtime / MCP / test

## Codice locale rimosso
- `_get_observatory_head()` — non più necessario
- `_get_observatory_ssl_fallback_get()` — non più necessario
- `observatory_head`, `observatory_ssl_fallback_get` globali
- catena try/except 3 tentativi in `probe_url` (~50 righe)
- catena try/except SSL fallback in `_html_extract_links` (~25 righe)

## Vecchi simboli da verificare
```bash
rg "_get_observatory_head|_get_observatory_ssl_fallback_get|observatory_head|observatory_ssl" .
```
→ 0 match (solo SPARQL che usa ancora observatory_get per POST)

## Contratto preservato
- `probe_url` output: stesso shape `{url, http_status, content_type, format, size, is_reachable, ssl_fallback_used}`
- `_html_extract_links` output: stesso shape `{url, is_reachable, http_status, content_type, links, total, formats, ssl_fallback_used}`
- `_ckan_get_json`: stesso errore raising (result.err raised as-is)
- SPARQL: ancora su `observatory_get` (POST non supportato da HttpClient)

## Fuori scope
- Non modifica `base.py` (altra PR)
- Non modifica `bulk_source_check.py` (altra valutazione)
- Non modifica `radar_check.py` (già migrato in PR #206)

## Test
- 111 test passano
- Ruff, mypy clean

## Note
La semplificazione interna a SO è prioritaria. lab-connectors come package cross-repo emerge dopo, non prima.