### PR TITLE
fix(bulk_source_check): JSON-encode col_types quando è un dict

### DIFF
--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -371,10 +371,14 @@ def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
     # nel blocco sopra (perche' granularita' era gia' determinata),
     # propaga comunque i campi preview dall'enrich.
     if not preview_meta and enrich.get("enrich_method") == "csv_preview":
+        import json as _json
+        col_types_val = enrich.get("col_types")
+        if isinstance(col_types_val, dict):
+            col_types_val = _json.dumps(col_types_val)
         preview_meta = {
             "file_size": enrich.get("file_size"),
             "preview_row_count": enrich.get("preview_row_count"),
-            "col_types": enrich.get("col_types"),
+            "col_types": col_types_val,
             "columns": enrich.get("columns"),
         }
 

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -323,6 +323,30 @@ def _safe_str(v: Any) -> str | None:
     return str(v)
 
 
+def _preview_meta_from_enrich(enrich: dict[str, Any]) -> dict[str, Any]:
+    """Build preview_meta from enrich, ensuring col_types and columns are parquet-safe.
+
+    Both col_types (dict) and columns (list) must be JSON-encoded as strings
+    before写入 DataFrame to avoid ArrowTypeError on to_parquet.
+    """
+    import json as _json
+
+    col_types_val = enrich.get("col_types")
+    if isinstance(col_types_val, dict):
+        col_types_val = _json.dumps(col_types_val)
+
+    columns_val = enrich.get("columns")
+    if isinstance(columns_val, list):
+        columns_val = _json.dumps(columns_val)
+
+    return {
+        "file_size": enrich.get("file_size"),
+        "preview_row_count": enrich.get("preview_row_count"),
+        "col_types": col_types_val,
+        "columns": columns_val,
+    }
+
+
 def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
     enrich = _enrich_with_inventory(row, registry)
 
@@ -360,27 +384,13 @@ def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
                     year_min = preview["year_min"]
                 if pd.isna(year_max) and preview.get("year_max") is not None:
                     year_max = preview["year_max"]
-                preview_meta = {
-                    "file_size": preview.get("file_size"),
-                    "preview_row_count": preview.get("preview_row_count"),
-                    "col_types": preview.get("col_types"),
-                    "columns": preview.get("columns"),
-                }
+                preview_meta = _preview_meta_from_enrich(preview)
 
     # Se l'enrich ha gia' chiamato _fetch_data_preview ma non siamo rientrati
     # nel blocco sopra (perche' granularita' era gia' determinata),
     # propaga comunque i campi preview dall'enrich.
     if not preview_meta and enrich.get("enrich_method") == "csv_preview":
-        import json as _json
-        col_types_val = enrich.get("col_types")
-        if isinstance(col_types_val, dict):
-            col_types_val = _json.dumps(col_types_val)
-        preview_meta = {
-            "file_size": enrich.get("file_size"),
-            "preview_row_count": enrich.get("preview_row_count"),
-            "col_types": col_types_val,
-            "columns": enrich.get("columns"),
-        }
+        preview_meta = _preview_meta_from_enrich(enrich)
 
     # URL da controllare: enrichment resource > catalogo landing_page > distribution_url
     url_to_check = (

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -325,3 +325,68 @@ def test_fetch_data_preview_xls_fake_tsv_latin1(monkeypatch) -> None:
     assert len(cols) == 3
     assert cols == ["col1", "col2", "col3"]
     assert result.get("preview_row_count") == 2
+
+
+# ── _preview_meta_from_enrich: dict/col_types → JSON string parquet-safe ──────
+
+
+def test_preview_meta_from_enrich_dict_col_types_to_json() -> None:
+    """_preview_meta_from_enrich must JSON-encode dict col_types to string."""
+    import json
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    from bulk_source_check import _preview_meta_from_enrich
+
+    enrich_dict = {
+        "file_size": 1024,
+        "preview_row_count": 50,
+        "col_types": {"col1": "int64", "col2": "str"},
+        "columns": ["col1", "col2"],
+        "enrich_method": "csv_preview",
+    }
+    result = _preview_meta_from_enrich(enrich_dict)
+
+    # col_types must be a JSON string, not a dict
+    assert isinstance(result["col_types"], str), f"col_types should be string, got {type(result['col_types'])}"
+    assert json.loads(result["col_types"]) == {"col1": "int64", "col2": "str"}
+
+
+def test_preview_meta_from_enrich_list_columns_to_json() -> None:
+    """_preview_meta_from_enrich must JSON-encode list columns to string."""
+    import json
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    from bulk_source_check import _preview_meta_from_enrich
+
+    enrich_dict = {
+        "file_size": 1024,
+        "preview_row_count": 50,
+        "col_types": {"col1": "int64"},
+        "columns": ["col1", "col2", "col3"],
+        "enrich_method": "csv_preview",
+    }
+    result = _preview_meta_from_enrich(enrich_dict)
+
+    # columns must be a JSON string, not a list
+    assert isinstance(result["columns"], str), f"columns should be string, got {type(result['columns'])}"
+    assert json.loads(result["columns"]) == ["col1", "col2", "col3"]
+
+
+def test_preview_meta_from_enrich_already_string_unchanged() -> None:
+    """_preview_meta_from_enrich must leave string col_types/columns as-is."""
+    import json
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    from bulk_source_check import _preview_meta_from_enrich
+
+    already_string = json.dumps({"col1": "int64"})
+    already_columns = json.dumps(["col1", "col2"])
+    enrich_dict = {
+        "file_size": 1024,
+        "preview_row_count": 50,
+        "col_types": already_string,
+        "columns": already_columns,
+        "enrich_method": "csv_preview",
+    }
+    result = _preview_meta_from_enrich(enrich_dict)
+
+    # Must be unchanged (string stays string)
+    assert result["col_types"] == already_string
+    assert result["columns"] == already_columns


### PR DESCRIPTION
## Riassunto
- Fix ArrowTypeError quando scrive `col_types` su parquet: dict invece di bytes/string
- `enrich.get("col_types")` poteva restituire un dict Python da un path fallback in `_enrich_with_inventory` invece di una stringa JSON-encoded
- JSON-encode quando è dict, altrimenti passa il valore così com'è

## Root cause
Il blocco fallback (linee 373-379) propaga `col_types` dall'enrich dict a `preview_meta`. Quando enrich viene da un path che non JSON-encoda `col_types`, arriva come dict → pyarrow crasha su `to_parquet`.

## Testing
- Run locale: 5 item, parquet write OK, col_types dtype=str, 0 non-string
- Tutti i 34 test bulk_source_check passano