### PR TITLE
fix(source-check): normalize preview fields before parquet write

### DIFF
--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -327,7 +327,7 @@ def _preview_meta_from_enrich(enrich: dict[str, Any]) -> dict[str, Any]:
     """Build preview_meta from enrich, ensuring col_types and columns are parquet-safe.
 
     Both col_types (dict) and columns (list) must be JSON-encoded as strings
-    before写入 DataFrame to avoid ArrowTypeError on to_parquet.
+    before writing the DataFrame to avoid ArrowTypeError on to_parquet.
     """
     import json as _json
 
@@ -345,6 +345,30 @@ def _preview_meta_from_enrich(enrich: dict[str, Any]) -> dict[str, Any]:
         "col_types": col_types_val,
         "columns": columns_val,
     }
+
+
+def _normalize_preview_columns_for_parquet(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize preview metadata columns before parquet writes.
+
+    Incremental runs concatenate new checks with previous parquet rows. Older
+    rows may still contain Arrow struct/list values loaded back as dict/list,
+    so normalize the final DataFrame, not only newly-built row payloads.
+    """
+    import json as _json
+
+    normalized = df.copy()
+    for column, nested_types in {
+        "col_types": (dict,),
+        "columns": (list,),
+    }.items():
+        if column not in normalized.columns:
+            continue
+        normalized[column] = normalized[column].map(
+            lambda value: _json.dumps(value)
+            if isinstance(value, nested_types)
+            else value
+        )
+    return normalized
 
 
 def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
@@ -712,6 +736,7 @@ def main() -> None:
             logger.info("Top candidates:\n%s", top.to_string(index=False))
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
+    results = _normalize_preview_columns_for_parquet(results)
     results.to_parquet(args.out, index=False)
     logger.info("Results: %s", args.out)
 

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -327,66 +327,33 @@ def test_fetch_data_preview_xls_fake_tsv_latin1(monkeypatch) -> None:
     assert result.get("preview_row_count") == 2
 
 
-# ── _preview_meta_from_enrich: dict/col_types → JSON string parquet-safe ──────
-
-
-def test_preview_meta_from_enrich_dict_col_types_to_json() -> None:
-    """_preview_meta_from_enrich must JSON-encode dict col_types to string."""
+def test_normalize_preview_columns_for_parquet_handles_existing_nested_rows(tmp_path: Path) -> None:
+    """Final parquet write must handle old incremental rows with dict/list cells."""
     import json
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
-    from bulk_source_check import _preview_meta_from_enrich
 
-    enrich_dict = {
-        "file_size": 1024,
-        "preview_row_count": 50,
-        "col_types": {"col1": "int64", "col2": "str"},
-        "columns": ["col1", "col2"],
-        "enrich_method": "csv_preview",
-    }
-    result = _preview_meta_from_enrich(enrich_dict)
+    import pandas as pd
 
-    # col_types must be a JSON string, not a dict
-    assert isinstance(result["col_types"], str), f"col_types should be string, got {type(result['col_types'])}"
-    assert json.loads(result["col_types"]) == {"col1": "int64", "col2": "str"}
+    from bulk_source_check import _normalize_preview_columns_for_parquet
 
+    df = pd.DataFrame(
+        [
+            {
+                "item_id": "new",
+                "col_types": json.dumps({"a": "int64"}),
+                "columns": json.dumps(["a"]),
+            },
+            {
+                "item_id": "old",
+                "col_types": {"b": "object"},
+                "columns": ["b"],
+            },
+        ]
+    )
 
-def test_preview_meta_from_enrich_list_columns_to_json() -> None:
-    """_preview_meta_from_enrich must JSON-encode list columns to string."""
-    import json
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
-    from bulk_source_check import _preview_meta_from_enrich
+    normalized = _normalize_preview_columns_for_parquet(df)
+    out = tmp_path / "source_check_results.parquet"
+    normalized.to_parquet(out, index=False)
 
-    enrich_dict = {
-        "file_size": 1024,
-        "preview_row_count": 50,
-        "col_types": {"col1": "int64"},
-        "columns": ["col1", "col2", "col3"],
-        "enrich_method": "csv_preview",
-    }
-    result = _preview_meta_from_enrich(enrich_dict)
-
-    # columns must be a JSON string, not a list
-    assert isinstance(result["columns"], str), f"columns should be string, got {type(result['columns'])}"
-    assert json.loads(result["columns"]) == ["col1", "col2", "col3"]
-
-
-def test_preview_meta_from_enrich_already_string_unchanged() -> None:
-    """_preview_meta_from_enrich must leave string col_types/columns as-is."""
-    import json
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
-    from bulk_source_check import _preview_meta_from_enrich
-
-    already_string = json.dumps({"col1": "int64"})
-    already_columns = json.dumps(["col1", "col2"])
-    enrich_dict = {
-        "file_size": 1024,
-        "preview_row_count": 50,
-        "col_types": already_string,
-        "columns": already_columns,
-        "enrich_method": "csv_preview",
-    }
-    result = _preview_meta_from_enrich(enrich_dict)
-
-    # Must be unchanged (string stays string)
-    assert result["col_types"] == already_string
-    assert result["columns"] == already_columns
+    reloaded = pd.read_parquet(out)
+    assert json.loads(reloaded.loc[reloaded["item_id"] == "old", "col_types"].iloc[0]) == {"b": "object"}
+    assert json.loads(reloaded.loc[reloaded["item_id"] == "old", "columns"].iloc[0]) == ["b"]


### PR DESCRIPTION
## Summary\n- normalize final source-check DataFrame preview fields before parquet writes\n- covers incremental upsert rows loaded from previous parquet that may contain dict/list cells\n- adds regression test with mixed new JSON-string rows and old nested rows\n\n## Test\n- python -m pytest tests/test_bulk_source_check.py -q\n- python -m pytest -q\n- python -m ruff check scripts/bulk_source_check.py tests/test_bulk_source_check.py