### PR TITLE
fix(source-check): handle array-like preview fields before parquet write

### DIFF
--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -351,23 +351,33 @@ def _normalize_preview_columns_for_parquet(df: pd.DataFrame) -> pd.DataFrame:
     """Normalize preview metadata columns before parquet writes.
 
     Incremental runs concatenate new checks with previous parquet rows. Older
-    rows may still contain Arrow struct/list values loaded back as dict/list,
-    so normalize the final DataFrame, not only newly-built row payloads.
+    rows may still contain Arrow struct/list values loaded back as dict/list or
+    array-like values, so normalize the final DataFrame, not only newly-built
+    row payloads.
     """
     import json as _json
 
+    def _preview_cell_for_parquet(value: Any) -> Any:
+        if isinstance(value, str) or value is None:
+            return value
+        if isinstance(value, dict):
+            return _json.dumps(value, ensure_ascii=False)
+        if isinstance(value, (list, tuple, set)):
+            return _json.dumps(list(value), ensure_ascii=False)
+        tolist = getattr(value, "tolist", None)
+        if callable(tolist):
+            converted = tolist()
+            if isinstance(converted, dict):
+                return _json.dumps(converted, ensure_ascii=False)
+            if isinstance(converted, list):
+                return _json.dumps(converted, ensure_ascii=False)
+        return value
+
     normalized = df.copy()
-    for column, nested_types in {
-        "col_types": (dict,),
-        "columns": (list,),
-    }.items():
+    for column in ("col_types", "columns"):
         if column not in normalized.columns:
             continue
-        normalized[column] = normalized[column].map(
-            lambda value: _json.dumps(value)
-            if isinstance(value, nested_types)
-            else value
-        )
+        normalized[column] = normalized[column].map(_preview_cell_for_parquet)
     return normalized
 
 

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -328,9 +328,10 @@ def test_fetch_data_preview_xls_fake_tsv_latin1(monkeypatch) -> None:
 
 
 def test_normalize_preview_columns_for_parquet_handles_existing_nested_rows(tmp_path: Path) -> None:
-    """Final parquet write must handle old incremental rows with dict/list cells."""
+    """Final parquet write must handle old incremental rows with nested cells."""
     import json
 
+    import numpy as np
     import pandas as pd
 
     from bulk_source_check import _normalize_preview_columns_for_parquet
@@ -345,7 +346,7 @@ def test_normalize_preview_columns_for_parquet_handles_existing_nested_rows(tmp_
             {
                 "item_id": "old",
                 "col_types": {"b": "object"},
-                "columns": ["b"],
+                "columns": np.array(["b"]),
             },
         ]
     )


### PR DESCRIPTION
## Summary\n- extend final preview-field normalization before source-check parquet writes\n- handles array-like cells such as numpy.ndarray in columns, not only dict/list\n- updates the regression test to reproduce the latest workflow failure: mixed JSON string + dict + ndarray cells, then real to_parquet\n\n## Failure replay\n- Failing step: observatory / Run bulk source-check (incremental)\n- Sink: results.to_parquet(args.out, index=False)\n- Latest traceback: ArrowTypeError on column columns with numpy.ndarray object\n- Test reaches same sink with to_parquet on a mixed DataFrame\n\n## Test\n- python -m pytest tests/test_bulk_source_check.py -q\n- python -m pytest -q\n- python -m ruff check scripts/bulk_source_check.py tests/test_bulk_source_check.py