### PR TITLE
feat(source-check): integra profiler toolkit in _fetch_data_preview

### DIFF
--- a/data/catalog/CATALOG_WATCH_REPORT.md
+++ b/data/catalog/CATALOG_WATCH_REPORT.md
@@ -1,6 +1,6 @@
 # Catalog Watch Report
 
-_Generato: 2026-05-10T20:27:58+00:00 — 13 fonti controllate_
+_Generato: 2026-05-10T22:24:44+00:00 — 13 fonti controllate_
 
 ## Segnali attivi
 

--- a/data/catalog/CATALOG_WATCH_REPORT.md
+++ b/data/catalog/CATALOG_WATCH_REPORT.md
@@ -1,6 +1,6 @@
 # Catalog Watch Report
 
-_Generato: 2026-05-10T19:49:03+00:00 — 13 fonti controllate_
+_Generato: 2026-05-10T20:27:58+00:00 — 13 fonti controllate_
 
 ## Segnali attivi
 

--- a/data/catalog/CATALOG_WATCH_REPORT.md
+++ b/data/catalog/CATALOG_WATCH_REPORT.md
@@ -1,6 +1,6 @@
 # Catalog Watch Report
 
-_Generato: 2026-05-09T13:03:54+00:00 — 13 fonti controllate_
+_Generato: 2026-05-10T19:49:03+00:00 — 13 fonti controllate_
 
 ## Segnali attivi
 

--- a/data/catalog/catalog_signals.json
+++ b/data/catalog/catalog_signals.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-05-09T13:03:54+00:00",
+  "captured_at": "2026-05-10T19:49:03+00:00",
   "sources_checked": 13,
   "signals": [
     {
@@ -643,18 +643,16 @@
       "source": "dati_camera",
       "protocol": "sparql",
       "signal_type": "no signal",
-      "result": "stabile",
-      "metric_value": 104,
-      "detail": "104 item (sparql_query), in linea con la baseline.",
+      "result": "skipped",
+      "detail": "Connessione/endpoint coperti da radar_summary; nessun segnale inventariale affidabile in questo run.",
       "suggested_action": "nessuna"
     },
     {
       "source": "dati_cultura",
       "protocol": "sparql",
       "signal_type": "no signal",
-      "result": "stabile",
-      "metric_value": 213,
-      "detail": "213 item (sparql_query), in linea con la baseline.",
+      "result": "skipped",
+      "detail": "Connessione/endpoint coperti da radar_summary; nessun segnale inventariale affidabile in questo run.",
       "suggested_action": "nessuna"
     },
     {

--- a/data/catalog/catalog_signals.json
+++ b/data/catalog/catalog_signals.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-05-10T20:27:58+00:00",
+  "captured_at": "2026-05-10T22:24:44+00:00",
   "sources_checked": 13,
   "signals": [
     {
@@ -643,8 +643,9 @@
       "source": "dati_camera",
       "protocol": "sparql",
       "signal_type": "no signal",
-      "result": "skipped",
-      "detail": "Connessione/endpoint coperti da radar_summary; nessun segnale inventariale affidabile in questo run.",
+      "result": "stabile",
+      "metric_value": 104,
+      "detail": "104 item (sparql_query), in linea con la baseline.",
       "suggested_action": "nessuna"
     },
     {

--- a/data/catalog/catalog_signals.json
+++ b/data/catalog/catalog_signals.json
@@ -1,5 +1,5 @@
 {
-  "captured_at": "2026-05-10T19:49:03+00:00",
+  "captured_at": "2026-05-10T20:27:58+00:00",
   "sources_checked": 13,
   "signals": [
     {

--- a/data/radar/STATUS.md
+++ b/data/radar/STATUS.md
@@ -5,8 +5,8 @@ Ultimo run: 2026-05-10
 ## Sommario
 
 - Fonti controllate: 16
-- GREEN: 10
-- YELLOW: 4
+- GREEN: 8
+- YELLOW: 6
 - RED: 2
 
 ## Tipi sorgente
@@ -31,7 +31,7 @@ Nota: lo stato radar descrive la salute della fonte, non il valore o l'aggiornam
 
 | Fonte | Tipo | Protocollo | Modalita' | Stato | HTTP code | Datasets collegati |
 | --- | --- | --- | --- | --- | --- | --- |
-| istat_sdmx | catalog | sdmx | catalog-watch | GREEN | 200 | istat-gini-regionale, istat-housing-crowding, istat-ipab-aree |
+| istat_sdmx | catalog | sdmx | catalog-watch | YELLOW | - | istat-gini-regionale, istat-housing-crowding, istat-ipab-aree |
 | anac | catalog | ckan | radar-only | YELLOW | 403 | - |
 | inps | catalog | ckan | catalog-watch | GREEN | 200 | inps-pensioni |
 | openbdap | catalog | ckan | catalog-watch | GREEN | 200 | dipendenti-pubblici, bdap-lea |
@@ -39,7 +39,7 @@ Nota: lo stato radar descrive la salute della fonte, non il valore o l'aggiornam
 | inail_opendata | portal | aem | radar-only | GREEN | 200 | - |
 | mim_opendata | catalog | html | catalog-watch | GREEN | 200 | mim-alunni-corso-eta |
 | dati_camera | catalog | sparql | catalog-watch | RED | 503 | - |
-| dati_cultura | catalog | sparql | catalog-watch | GREEN | 200 | - |
+| dati_cultura | catalog | sparql | catalog-watch | YELLOW | - | - |
 | ispra_linked_data | catalog | sparql | catalog-watch | GREEN | 200 | - |
 | consip_open_data | catalog | ckan | catalog-watch | GREEN | 200 | - |
 | lavoro_opendata | catalog | ckan | catalog-watch | YELLOW | 200 | - |
@@ -50,9 +50,11 @@ Nota: lo stato radar descrive la salute della fonte, non il valore o l'aggiornam
 
 ## Note
 
+- `istat_sdmx`: Timeout (ReadTimeout)
 - `anac`: HTTP 403 | content-type: text/html; charset=UTF-8 | url finale: https://dati.anticorruzione.it/opendata/api/3/action/package_list?limit=1 | WAF blocca endpoint CKAN. Declassato a radar-only finche' non disponibile endpoint alternativo o accesso istituzionale.
 - `dati_salute`: SSL verify failed; fallback connection error (SSLError)
 - `dati_camera`: HTTP 503 | content-type: text/html; charset=UTF-8 | url finale: https://dati.camera.it/sparql | Catalogo linked-data Camera inventariabile via query SPARQL custom. Il template DCAT generico non valorizza titolo e descrizione perché l'endpoint usa dc:title e dc:description.
+- `dati_cultura`: Retry timeout/connection: Timeout (ConnectTimeout)
 - `lavoro_opendata`: HTTP 200 | content-type: text/html | url finale: https://dati.lavoro.gov.it/SpodCkanApi/api/3/action/package_list?limit=1 | CKAN API returned non-JSON content
 - `mur_ustat`: Retry timeout/connection: Timeout (ConnectTimeout)
 - `opencoesione`: HTTP 403 | content-type: text/html; charset=utf-8 | url finale: https://opencoesione.gov.it/it/api/ | Portale disabilitato/ritirato. CKAN API non piu' raggiungibile (redirect a /it/ con 404 "Pagina non trovata"). Mantenuto in radar-only per eventuale monitoraggio futuro.

--- a/data/radar/STATUS.md
+++ b/data/radar/STATUS.md
@@ -5,9 +5,9 @@ Ultimo run: 2026-05-10
 ## Sommario
 
 - Fonti controllate: 16
-- GREEN: 8
-- YELLOW: 6
-- RED: 2
+- GREEN: 10
+- YELLOW: 5
+- RED: 1
 
 ## Tipi sorgente
 
@@ -31,14 +31,14 @@ Nota: lo stato radar descrive la salute della fonte, non il valore o l'aggiornam
 
 | Fonte | Tipo | Protocollo | Modalita' | Stato | HTTP code | Datasets collegati |
 | --- | --- | --- | --- | --- | --- | --- |
-| istat_sdmx | catalog | sdmx | catalog-watch | YELLOW | - | istat-gini-regionale, istat-housing-crowding, istat-ipab-aree |
+| istat_sdmx | catalog | sdmx | catalog-watch | GREEN | 200 | istat-gini-regionale, istat-housing-crowding, istat-ipab-aree |
 | anac | catalog | ckan | radar-only | YELLOW | 403 | - |
 | inps | catalog | ckan | catalog-watch | GREEN | 200 | inps-pensioni |
 | openbdap | catalog | ckan | catalog-watch | GREEN | 200 | dipendenti-pubblici, bdap-lea |
 | dati_salute | catalog | html | catalog-watch | RED | - | - |
 | inail_opendata | portal | aem | radar-only | GREEN | 200 | - |
 | mim_opendata | catalog | html | catalog-watch | GREEN | 200 | mim-alunni-corso-eta |
-| dati_camera | catalog | sparql | catalog-watch | RED | 503 | - |
+| dati_camera | catalog | sparql | catalog-watch | GREEN | 200 | - |
 | dati_cultura | catalog | sparql | catalog-watch | YELLOW | - | - |
 | ispra_linked_data | catalog | sparql | catalog-watch | GREEN | 200 | - |
 | consip_open_data | catalog | ckan | catalog-watch | GREEN | 200 | - |
@@ -50,10 +50,8 @@ Nota: lo stato radar descrive la salute della fonte, non il valore o l'aggiornam
 
 ## Note
 
-- `istat_sdmx`: Timeout (ReadTimeout)
 - `anac`: HTTP 403 | content-type: text/html; charset=UTF-8 | url finale: https://dati.anticorruzione.it/opendata/api/3/action/package_list?limit=1 | WAF blocca endpoint CKAN. Declassato a radar-only finche' non disponibile endpoint alternativo o accesso istituzionale.
 - `dati_salute`: SSL verify failed; fallback connection error (SSLError)
-- `dati_camera`: HTTP 503 | content-type: text/html; charset=UTF-8 | url finale: https://dati.camera.it/sparql | Catalogo linked-data Camera inventariabile via query SPARQL custom. Il template DCAT generico non valorizza titolo e descrizione perché l'endpoint usa dc:title e dc:description.
 - `dati_cultura`: Retry timeout/connection: Timeout (ConnectTimeout)
 - `lavoro_opendata`: HTTP 200 | content-type: text/html | url finale: https://dati.lavoro.gov.it/SpodCkanApi/api/3/action/package_list?limit=1 | CKAN API returned non-JSON content
 - `mur_ustat`: Retry timeout/connection: Timeout (ConnectTimeout)

--- a/data/radar/radar_history.json
+++ b/data/radar/radar_history.json
@@ -2,119 +2,6 @@
   "probes": [
     {
       "probe_date": "2026-05-04",
-      "captured_at": "2026-05-04T06:21:30.947809+00:00",
-      "sources": [
-        {
-          "id": "istat_sdmx",
-          "status": "RED",
-          "protocol": "sdmx",
-          "http_code": "-",
-          "note": "Probe exception non gestita: ReadTimeout: HTTPSConnectionPool(host='esploradati.istat.it', port=443): Read timed out. (read timeout=10)"
-        },
-        {
-          "id": "anac",
-          "status": "YELLOW",
-          "protocol": "ckan",
-          "http_code": "403",
-          "note": null
-        },
-        {
-          "id": "inps",
-          "status": "GREEN",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "openbdap",
-          "status": "GREEN",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "dati_salute",
-          "status": "RED",
-          "protocol": "html",
-          "http_code": "-",
-          "note": "SSL verify failed; fallback connection error (SSLError)",
-          "red_streak": 2
-        },
-        {
-          "id": "inail_opendata",
-          "status": "GREEN",
-          "protocol": "aem",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "mim_opendata",
-          "status": "GREEN",
-          "protocol": "html",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "dati_camera",
-          "status": "GREEN",
-          "protocol": "sparql",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "dati_cultura",
-          "status": "GREEN",
-          "protocol": "sparql",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "ispra_linked_data",
-          "status": "GREEN",
-          "protocol": "sparql",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "consip_open_data",
-          "status": "GREEN",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "lavoro_opendata",
-          "status": "YELLOW",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": "CKAN API returned non-JSON content"
-        },
-        {
-          "id": "mur_ustat",
-          "status": "RED",
-          "protocol": "ckan",
-          "http_code": "-",
-          "note": "Probe exception non gestita: ConnectTimeout: HTTPSConnectionPool(host='dati-ustat.mur.gov.it', port=443): Max retries exceeded with url: /api/3/action/package_list?limit=1 (Caused by ConnectTimeoutError(<HTTPSConnection(host='dati-ustat.mur.gov.it', port=443) at 0x7f5351f45d90>, 'Connection to dati-ustat.mur.gov.it timed out. (connect timeout=10)'))",
-          "red_streak": 2
-        },
-        {
-          "id": "opencoesione",
-          "status": "YELLOW",
-          "protocol": "rest",
-          "http_code": "403",
-          "note": null
-        },
-        {
-          "id": "mef_irpef",
-          "status": "GREEN",
-          "protocol": "html",
-          "http_code": "200",
-          "note": null
-        }
-      ]
-    },
-    {
-      "probe_date": "2026-05-04",
       "captured_at": "2026-05-04T07:59:40.787149+00:00",
       "sources": [
         {
@@ -1581,6 +1468,126 @@
           "protocol": "sparql",
           "http_code": "503",
           "note": null
+        },
+        {
+          "id": "dati_cultura",
+          "status": "YELLOW",
+          "protocol": "sparql",
+          "http_code": "-",
+          "note": "Retry timeout/connection: Timeout (ConnectTimeout)"
+        },
+        {
+          "id": "ispra_linked_data",
+          "status": "GREEN",
+          "protocol": "sparql",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "consip_open_data",
+          "status": "GREEN",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "lavoro_opendata",
+          "status": "YELLOW",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": "CKAN API returned non-JSON content"
+        },
+        {
+          "id": "mur_ustat",
+          "status": "YELLOW",
+          "protocol": "ckan",
+          "http_code": "-",
+          "note": "Retry timeout/connection: Timeout (ConnectTimeout)"
+        },
+        {
+          "id": "opencoesione",
+          "status": "YELLOW",
+          "protocol": "rest",
+          "http_code": "403",
+          "note": null
+        },
+        {
+          "id": "mef_irpef",
+          "status": "GREEN",
+          "protocol": "html",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "opencivitas",
+          "status": "GREEN",
+          "protocol": "html",
+          "http_code": "200",
+          "note": "SSL verify failed; fallback verify=False used (SSLError)"
+        }
+      ]
+    },
+    {
+      "probe_date": "2026-05-10",
+      "captured_at": "2026-05-10T20:27:49.918826+00:00",
+      "sources": [
+        {
+          "id": "istat_sdmx",
+          "status": "YELLOW",
+          "protocol": "sdmx",
+          "http_code": "-",
+          "note": "Timeout (ReadTimeout)"
+        },
+        {
+          "id": "anac",
+          "status": "YELLOW",
+          "protocol": "ckan",
+          "http_code": "403",
+          "note": null
+        },
+        {
+          "id": "inps",
+          "status": "GREEN",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "openbdap",
+          "status": "GREEN",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "dati_salute",
+          "status": "RED",
+          "protocol": "html",
+          "http_code": "-",
+          "note": "SSL verify failed; fallback connection error (SSLError)",
+          "red_streak": 14
+        },
+        {
+          "id": "inail_opendata",
+          "status": "GREEN",
+          "protocol": "aem",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "mim_opendata",
+          "status": "GREEN",
+          "protocol": "html",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "dati_camera",
+          "status": "RED",
+          "protocol": "sparql",
+          "http_code": "503",
+          "note": null,
+          "red_streak": 2
         },
         {
           "id": "dati_cultura",

--- a/data/radar/radar_history.json
+++ b/data/radar/radar_history.json
@@ -1,110 +1,6 @@
 {
   "probes": [
     {
-      "probe_date": "2026-05-03",
-      "captured_at": "2026-05-03T07:46:56.009110+00:00",
-      "sources": [
-        {
-          "id": "istat_sdmx",
-          "status": "GREEN",
-          "protocol": "sdmx",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "anac",
-          "status": "YELLOW",
-          "protocol": "ckan",
-          "http_code": "403",
-          "note": null
-        },
-        {
-          "id": "inps",
-          "status": "GREEN",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "openbdap",
-          "status": "GREEN",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "dati_salute",
-          "status": "RED",
-          "protocol": "html",
-          "http_code": "-",
-          "note": "SSL verify failed; fallback connection error (SSLError)"
-        },
-        {
-          "id": "inail_opendata",
-          "status": "GREEN",
-          "protocol": "aem",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "mim_opendata",
-          "status": "GREEN",
-          "protocol": "html",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "dati_camera",
-          "status": "GREEN",
-          "protocol": "sparql",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "dati_cultura",
-          "status": "GREEN",
-          "protocol": "sparql",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "ispra_linked_data",
-          "status": "GREEN",
-          "protocol": "sparql",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "consip_open_data",
-          "status": "GREEN",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "lavoro_opendata",
-          "status": "YELLOW",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": "CKAN API returned non-JSON content"
-        },
-        {
-          "id": "mur_ustat",
-          "status": "RED",
-          "protocol": "ckan",
-          "http_code": "-",
-          "note": "Probe exception non gestita: ConnectTimeout: HTTPSConnectionPool(host='dati-ustat.mur.gov.it', port=443): Max retries exceeded with url: /api/3/action/package_list?limit=1 (Caused by ConnectTimeoutError(<HTTPSConnection(host='dati-ustat.mur.gov.it', port=443) at 0x7f66b6271070>, 'Connection to dati-ustat.mur.gov.it timed out. (connect timeout=10)'))"
-        },
-        {
-          "id": "opencoesione",
-          "status": "YELLOW",
-          "protocol": "rest",
-          "http_code": "403",
-          "note": null
-        }
-      ]
-    },
-    {
       "probe_date": "2026-05-04",
       "captured_at": "2026-05-04T06:21:30.947809+00:00",
       "sources": [
@@ -1573,6 +1469,125 @@
           "protocol": "sparql",
           "http_code": "200",
           "note": null
+        },
+        {
+          "id": "ispra_linked_data",
+          "status": "GREEN",
+          "protocol": "sparql",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "consip_open_data",
+          "status": "GREEN",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "lavoro_opendata",
+          "status": "YELLOW",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": "CKAN API returned non-JSON content"
+        },
+        {
+          "id": "mur_ustat",
+          "status": "YELLOW",
+          "protocol": "ckan",
+          "http_code": "-",
+          "note": "Retry timeout/connection: Timeout (ConnectTimeout)"
+        },
+        {
+          "id": "opencoesione",
+          "status": "YELLOW",
+          "protocol": "rest",
+          "http_code": "403",
+          "note": null
+        },
+        {
+          "id": "mef_irpef",
+          "status": "GREEN",
+          "protocol": "html",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "opencivitas",
+          "status": "GREEN",
+          "protocol": "html",
+          "http_code": "200",
+          "note": "SSL verify failed; fallback verify=False used (SSLError)"
+        }
+      ]
+    },
+    {
+      "probe_date": "2026-05-10",
+      "captured_at": "2026-05-10T19:48:54.617745+00:00",
+      "sources": [
+        {
+          "id": "istat_sdmx",
+          "status": "YELLOW",
+          "protocol": "sdmx",
+          "http_code": "-",
+          "note": "Timeout (ReadTimeout)"
+        },
+        {
+          "id": "anac",
+          "status": "YELLOW",
+          "protocol": "ckan",
+          "http_code": "403",
+          "note": null
+        },
+        {
+          "id": "inps",
+          "status": "GREEN",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "openbdap",
+          "status": "GREEN",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "dati_salute",
+          "status": "RED",
+          "protocol": "html",
+          "http_code": "-",
+          "note": "SSL verify failed; fallback connection error (SSLError)",
+          "red_streak": 14
+        },
+        {
+          "id": "inail_opendata",
+          "status": "GREEN",
+          "protocol": "aem",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "mim_opendata",
+          "status": "GREEN",
+          "protocol": "html",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "dati_camera",
+          "status": "RED",
+          "protocol": "sparql",
+          "http_code": "503",
+          "note": null
+        },
+        {
+          "id": "dati_cultura",
+          "status": "YELLOW",
+          "protocol": "sparql",
+          "http_code": "-",
+          "note": "Retry timeout/connection: Timeout (ConnectTimeout)"
         },
         {
           "id": "ispra_linked_data",

--- a/data/radar/radar_history.json
+++ b/data/radar/radar_history.json
@@ -1,120 +1,6 @@
 {
   "probes": [
     {
-      "probe_date": "2026-05-05",
-      "captured_at": "2026-05-05T05:50:17.591584+00:00",
-      "sources": [
-        {
-          "id": "istat_sdmx",
-          "status": "RED",
-          "protocol": "sdmx",
-          "http_code": "-",
-          "note": "Probe exception non gestita: ReadTimeout: HTTPSConnectionPool(host='esploradati.istat.it', port=443): Read timed out. (read timeout=10)",
-          "red_streak": 2
-        },
-        {
-          "id": "anac",
-          "status": "YELLOW",
-          "protocol": "ckan",
-          "http_code": "403",
-          "note": null
-        },
-        {
-          "id": "inps",
-          "status": "GREEN",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "openbdap",
-          "status": "RED",
-          "protocol": "ckan",
-          "http_code": "-",
-          "note": "Probe exception non gestita: ReadTimeout: HTTPSConnectionPool(host='bdap-opendata.rgs.mef.gov.it', port=443): Read timed out. (read timeout=10)"
-        },
-        {
-          "id": "dati_salute",
-          "status": "RED",
-          "protocol": "html",
-          "http_code": "-",
-          "note": "SSL verify failed; fallback connection error (SSLError)",
-          "red_streak": 4
-        },
-        {
-          "id": "inail_opendata",
-          "status": "GREEN",
-          "protocol": "aem",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "mim_opendata",
-          "status": "GREEN",
-          "protocol": "html",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "dati_camera",
-          "status": "GREEN",
-          "protocol": "sparql",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "dati_cultura",
-          "status": "GREEN",
-          "protocol": "sparql",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "ispra_linked_data",
-          "status": "GREEN",
-          "protocol": "sparql",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "consip_open_data",
-          "status": "GREEN",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "lavoro_opendata",
-          "status": "YELLOW",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": "CKAN API returned non-JSON content"
-        },
-        {
-          "id": "mur_ustat",
-          "status": "RED",
-          "protocol": "ckan",
-          "http_code": "-",
-          "note": "Probe exception non gestita: ConnectTimeout: HTTPSConnectionPool(host='dati-ustat.mur.gov.it', port=443): Max retries exceeded with url: /api/3/action/package_list?limit=1 (Caused by ConnectTimeoutError(<HTTPSConnection(host='dati-ustat.mur.gov.it', port=443) at 0x7f4d88636c90>, 'Connection to dati-ustat.mur.gov.it timed out. (connect timeout=10)'))",
-          "red_streak": 4
-        },
-        {
-          "id": "opencoesione",
-          "status": "YELLOW",
-          "protocol": "rest",
-          "http_code": "403",
-          "note": null
-        },
-        {
-          "id": "mef_irpef",
-          "status": "GREEN",
-          "protocol": "html",
-          "http_code": "200",
-          "note": null
-        }
-      ]
-    },
-    {
       "probe_date": "2026-05-06",
       "captured_at": "2026-05-06T06:12:30.982126+00:00",
       "sources": [
@@ -1595,6 +1481,126 @@
           "http_code": "503",
           "note": null,
           "red_streak": 3
+        },
+        {
+          "id": "dati_cultura",
+          "status": "YELLOW",
+          "protocol": "sparql",
+          "http_code": "-",
+          "note": "Retry timeout/connection: Timeout (ConnectTimeout)"
+        },
+        {
+          "id": "ispra_linked_data",
+          "status": "GREEN",
+          "protocol": "sparql",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "consip_open_data",
+          "status": "GREEN",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "lavoro_opendata",
+          "status": "YELLOW",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": "CKAN API returned non-JSON content"
+        },
+        {
+          "id": "mur_ustat",
+          "status": "YELLOW",
+          "protocol": "ckan",
+          "http_code": "-",
+          "note": "Retry timeout/connection: Timeout (ConnectTimeout)"
+        },
+        {
+          "id": "opencoesione",
+          "status": "YELLOW",
+          "protocol": "rest",
+          "http_code": "403",
+          "note": null
+        },
+        {
+          "id": "mef_irpef",
+          "status": "GREEN",
+          "protocol": "html",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "opencivitas",
+          "status": "GREEN",
+          "protocol": "html",
+          "http_code": "200",
+          "note": "SSL verify failed; fallback verify=False used (SSLError)"
+        }
+      ]
+    },
+    {
+      "probe_date": "2026-05-10",
+      "captured_at": "2026-05-10T22:24:37.426384+00:00",
+      "sources": [
+        {
+          "id": "istat_sdmx",
+          "status": "GREEN",
+          "protocol": "sdmx",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "anac",
+          "status": "YELLOW",
+          "protocol": "ckan",
+          "http_code": "403",
+          "note": null
+        },
+        {
+          "id": "inps",
+          "status": "GREEN",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "openbdap",
+          "status": "GREEN",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "dati_salute",
+          "status": "RED",
+          "protocol": "html",
+          "http_code": "-",
+          "note": "SSL verify failed; fallback connection error (SSLError)",
+          "red_streak": 14
+        },
+        {
+          "id": "inail_opendata",
+          "status": "GREEN",
+          "protocol": "aem",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "mim_opendata",
+          "status": "GREEN",
+          "protocol": "html",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "dati_camera",
+          "status": "GREEN",
+          "protocol": "sparql",
+          "http_code": "200",
+          "note": null,
+          "red_streak": 4
         },
         {
           "id": "dati_cultura",

--- a/data/radar/radar_history.json
+++ b/data/radar/radar_history.json
@@ -1,119 +1,6 @@
 {
   "probes": [
     {
-      "probe_date": "2026-05-04",
-      "captured_at": "2026-05-04T07:59:40.787149+00:00",
-      "sources": [
-        {
-          "id": "istat_sdmx",
-          "status": "RED",
-          "protocol": "sdmx",
-          "http_code": "-",
-          "note": "Probe exception non gestita: ReadTimeout: HTTPSConnectionPool(host='esploradati.istat.it', port=443): Read timed out. (read timeout=10)"
-        },
-        {
-          "id": "anac",
-          "status": "YELLOW",
-          "protocol": "ckan",
-          "http_code": "403",
-          "note": null
-        },
-        {
-          "id": "inps",
-          "status": "GREEN",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "openbdap",
-          "status": "GREEN",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "dati_salute",
-          "status": "RED",
-          "protocol": "html",
-          "http_code": "-",
-          "note": "SSL verify failed; fallback connection error (SSLError)",
-          "red_streak": 3
-        },
-        {
-          "id": "inail_opendata",
-          "status": "GREEN",
-          "protocol": "aem",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "mim_opendata",
-          "status": "GREEN",
-          "protocol": "html",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "dati_camera",
-          "status": "GREEN",
-          "protocol": "sparql",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "dati_cultura",
-          "status": "GREEN",
-          "protocol": "sparql",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "ispra_linked_data",
-          "status": "GREEN",
-          "protocol": "sparql",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "consip_open_data",
-          "status": "GREEN",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": null
-        },
-        {
-          "id": "lavoro_opendata",
-          "status": "YELLOW",
-          "protocol": "ckan",
-          "http_code": "200",
-          "note": "CKAN API returned non-JSON content"
-        },
-        {
-          "id": "mur_ustat",
-          "status": "RED",
-          "protocol": "ckan",
-          "http_code": "-",
-          "note": "Probe exception non gestita: ConnectTimeout: HTTPSConnectionPool(host='dati-ustat.mur.gov.it', port=443): Max retries exceeded with url: /api/3/action/package_list?limit=1 (Caused by ConnectTimeoutError(<HTTPSConnection(host='dati-ustat.mur.gov.it', port=443) at 0x7f258eefef90>, 'Connection to dati-ustat.mur.gov.it timed out. (connect timeout=10)'))",
-          "red_streak": 3
-        },
-        {
-          "id": "opencoesione",
-          "status": "YELLOW",
-          "protocol": "rest",
-          "http_code": "403",
-          "note": null
-        },
-        {
-          "id": "mef_irpef",
-          "status": "GREEN",
-          "protocol": "html",
-          "http_code": "200",
-          "note": null
-        }
-      ]
-    },
-    {
       "probe_date": "2026-05-05",
       "captured_at": "2026-05-05T05:50:17.591584+00:00",
       "sources": [
@@ -1588,6 +1475,126 @@
           "http_code": "503",
           "note": null,
           "red_streak": 2
+        },
+        {
+          "id": "dati_cultura",
+          "status": "YELLOW",
+          "protocol": "sparql",
+          "http_code": "-",
+          "note": "Retry timeout/connection: Timeout (ConnectTimeout)"
+        },
+        {
+          "id": "ispra_linked_data",
+          "status": "GREEN",
+          "protocol": "sparql",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "consip_open_data",
+          "status": "GREEN",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "lavoro_opendata",
+          "status": "YELLOW",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": "CKAN API returned non-JSON content"
+        },
+        {
+          "id": "mur_ustat",
+          "status": "YELLOW",
+          "protocol": "ckan",
+          "http_code": "-",
+          "note": "Retry timeout/connection: Timeout (ConnectTimeout)"
+        },
+        {
+          "id": "opencoesione",
+          "status": "YELLOW",
+          "protocol": "rest",
+          "http_code": "403",
+          "note": null
+        },
+        {
+          "id": "mef_irpef",
+          "status": "GREEN",
+          "protocol": "html",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "opencivitas",
+          "status": "GREEN",
+          "protocol": "html",
+          "http_code": "200",
+          "note": "SSL verify failed; fallback verify=False used (SSLError)"
+        }
+      ]
+    },
+    {
+      "probe_date": "2026-05-10",
+      "captured_at": "2026-05-10T21:41:15.974694+00:00",
+      "sources": [
+        {
+          "id": "istat_sdmx",
+          "status": "YELLOW",
+          "protocol": "sdmx",
+          "http_code": "-",
+          "note": "Timeout (ReadTimeout)"
+        },
+        {
+          "id": "anac",
+          "status": "YELLOW",
+          "protocol": "ckan",
+          "http_code": "403",
+          "note": null
+        },
+        {
+          "id": "inps",
+          "status": "GREEN",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "openbdap",
+          "status": "GREEN",
+          "protocol": "ckan",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "dati_salute",
+          "status": "RED",
+          "protocol": "html",
+          "http_code": "-",
+          "note": "SSL verify failed; fallback connection error (SSLError)",
+          "red_streak": 14
+        },
+        {
+          "id": "inail_opendata",
+          "status": "GREEN",
+          "protocol": "aem",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "mim_opendata",
+          "status": "GREEN",
+          "protocol": "html",
+          "http_code": "200",
+          "note": null
+        },
+        {
+          "id": "dati_camera",
+          "status": "RED",
+          "protocol": "sparql",
+          "http_code": "503",
+          "note": null,
+          "red_streak": 3
         },
         {
           "id": "dati_cultura",

--- a/data/radar/radar_summary.json
+++ b/data/radar/radar_summary.json
@@ -1,20 +1,20 @@
 {
-  "generated_at": "2026-05-10T21:41:15.974702+00:00",
+  "generated_at": "2026-05-10T22:24:37.426392+00:00",
   "probe_date": "2026-05-10",
   "sources_total": 16,
   "status_counts": {
-    "GREEN": 8,
-    "YELLOW": 6,
-    "RED": 2
+    "GREEN": 10,
+    "YELLOW": 5,
+    "RED": 1
   },
-  "persistent_red": 2,
+  "persistent_red": 1,
   "sources": [
     {
       "id": "istat_sdmx",
-      "status": "YELLOW",
+      "status": "GREEN",
       "protocol": "sdmx",
-      "http_code": "-",
-      "note": "Timeout (ReadTimeout)"
+      "http_code": "200",
+      "note": null
     },
     {
       "id": "anac",
@@ -61,11 +61,10 @@
     },
     {
       "id": "dati_camera",
-      "status": "RED",
+      "status": "GREEN",
       "protocol": "sparql",
-      "http_code": "503",
-      "note": null,
-      "red_streak": 4
+      "http_code": "200",
+      "note": null
     },
     {
       "id": "dati_cultura",

--- a/data/radar/radar_summary.json
+++ b/data/radar/radar_summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T20:27:49.918835+00:00",
+  "generated_at": "2026-05-10T21:41:15.974702+00:00",
   "probe_date": "2026-05-10",
   "sources_total": 16,
   "status_counts": {
@@ -65,7 +65,7 @@
       "protocol": "sparql",
       "http_code": "503",
       "note": null,
-      "red_streak": 3
+      "red_streak": 4
     },
     {
       "id": "dati_cultura",

--- a/data/radar/radar_summary.json
+++ b/data/radar/radar_summary.json
@@ -1,20 +1,20 @@
 {
-  "generated_at": "2026-05-10T06:19:14.169557+00:00",
+  "generated_at": "2026-05-10T19:48:54.617753+00:00",
   "probe_date": "2026-05-10",
   "sources_total": 16,
   "status_counts": {
-    "GREEN": 10,
-    "YELLOW": 4,
+    "GREEN": 8,
+    "YELLOW": 6,
     "RED": 2
   },
-  "persistent_red": 1,
+  "persistent_red": 2,
   "sources": [
     {
       "id": "istat_sdmx",
-      "status": "GREEN",
+      "status": "YELLOW",
       "protocol": "sdmx",
-      "http_code": "200",
-      "note": null
+      "http_code": "-",
+      "note": "Timeout (ReadTimeout)"
     },
     {
       "id": "anac",
@@ -64,14 +64,15 @@
       "status": "RED",
       "protocol": "sparql",
       "http_code": "503",
-      "note": null
+      "note": null,
+      "red_streak": 2
     },
     {
       "id": "dati_cultura",
-      "status": "GREEN",
+      "status": "YELLOW",
       "protocol": "sparql",
-      "http_code": "200",
-      "note": null
+      "http_code": "-",
+      "note": "Retry timeout/connection: Timeout (ConnectTimeout)"
     },
     {
       "id": "ispra_linked_data",

--- a/data/radar/radar_summary.json
+++ b/data/radar/radar_summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T19:48:54.617753+00:00",
+  "generated_at": "2026-05-10T20:27:49.918835+00:00",
   "probe_date": "2026-05-10",
   "sources_total": 16,
   "status_counts": {
@@ -65,7 +65,7 @@
       "protocol": "sparql",
       "http_code": "503",
       "note": null,
-      "red_streak": 2
+      "red_streak": 3
     },
     {
       "id": "dati_cultura",

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -14,11 +14,11 @@ Config canonica workspace:
 {
   "mcpServers": {
     "source-observatory": {
-      "command": "/home/gabry/dev/dataciviclab-workspace/source-observatory/.venv/bin/python",
+      "command": "python",
       "args": [
-        "/home/gabry/dev/dataciviclab-workspace/source-observatory/mcp/so_server.py"
+        "mcp/so_server.py"
       ],
-      "cwd": "/tmp"
+      "cwd": "/path/to/source-observatory"
     }
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ ddgs>=9.14.2,<10.0
 mcp>=1.27.0
 fastmcp>=3.2.4
 lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.2.0
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@main

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -110,15 +110,19 @@ def _sniff_csv_rows(rows: list[dict[str, Any]], logger: logging.Logger) -> None:
     if not targets:
         return
 
+    # Limita sniff a 100 item per fonte per evitare rallentamenti eccessivi
+    # su fonti con migliaia di CSV. 100 item × ~1s = ~100s con 8 workers ≈ 12s.
+    targets = targets[:100]
+
     logger.info("  sniff CSV: %d items", len(targets))
     sniffed = 0
 
     def _sniff_one(dist_url: str) -> dict[str, Any]:
-        client = HttpClient(timeout=(3, 10))
-        fetch = client.get(dist_url, headers={"Range": "bytes=0-15359"})
+        client = HttpClient(timeout=(3, 5))
+        fetch = client.get(dist_url, headers={"Range": "bytes=0-10239"})
         if not fetch.is_ok or fetch.response is None or fetch.response.status_code >= 400:
             return {}
-        content = fetch.response.content[:15 * 1024]  # 15KB max
+        content = fetch.response.content[:10 * 1024]  # 10KB max
         with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
             tmp.write(content)
             tmp_path = Path(tmp.name)

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -72,6 +72,82 @@ def _collect_source(
         return source_id, [], None, None, exc
 
 
+# Formati per cui vale la pena fare sniff leggero del file dati
+_SNIFFABLE_FORMATS = {"csv", "xlsx", "xls", "tsv"}
+
+
+def _is_sniffable(format_str: Any) -> bool:
+    """True se format contiene uno dei formati sniffabili (es. 'csv', 'csv,xml')."""
+    if not isinstance(format_str, str):
+        return False
+    return any(f in format_str.lower() for f in _SNIFFABLE_FORMATS)
+
+
+def _sniff_csv_rows(rows: list[dict[str, Any]], logger: logging.Logger) -> None:
+    """Lightweight CSV sniff per item con URL diretto a file dati.
+
+    Scarica primi ~10KB, sniffa encoding/delim/decimal/skip con
+    ``toolkit.profile.raw.sniff_source_file`` (puro Python, nessun DuckDB).
+    I risultati aggiornano direttamente le righe (encoding_suggested, ecc.).
+
+    Costo: ~0.5s per download + ~0.02s per sniff. Skip per formati non sniffabili
+    o URL non HTTP.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from pathlib import Path
+    import tempfile
+
+    from lab_connectors.http import HttpClient
+    from toolkit.profile.raw import sniff_source_file
+
+    # Filtra righe con formato sniffabile e URL diretto
+    targets = [
+        (i, row) for i, row in enumerate(rows)
+        if _is_sniffable(row.get("format"))
+        and isinstance(row.get("distribution_url"), str)
+        and row["distribution_url"].startswith("http")
+    ]
+    if not targets:
+        return
+
+    logger.info("  sniff CSV: %d items", len(targets))
+    sniffed = 0
+
+    def _sniff_one(dist_url: str) -> dict[str, Any]:
+        client = HttpClient(timeout=(3, 10))
+        fetch = client.get(dist_url, headers={"Range": "bytes=0-15359"})
+        if not fetch.is_ok or fetch.response is None or fetch.response.status_code >= 400:
+            return {}
+        content = fetch.response.content[:15 * 1024]  # 15KB max
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+            tmp.write(content)
+            tmp_path = Path(tmp.name)
+        try:
+            sniff = sniff_source_file(tmp_path)
+            return {
+                "encoding_suggested": sniff.get("encoding_suggested"),
+                "delim_suggested": sniff.get("delim_suggested"),
+                "decimal_suggested": sniff.get("decimal_suggested"),
+                "skip_suggested": sniff.get("skip_suggested", 0),
+            }
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        fut_to_idx = {pool.submit(_sniff_one, row["distribution_url"]): idx for idx, row in targets}
+        for fut in as_completed(fut_to_idx):
+            idx = fut_to_idx[fut]
+            try:
+                result = fut.result()
+                if result and result.get("encoding_suggested"):
+                    rows[idx].update(result)
+                    sniffed += 1
+            except Exception:
+                pass
+
+    logger.info("  sniff CSV OK: %d/%d", sniffed, len(targets))
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Costruisce il catalog inventory derivato dal registry di source-observatory."
@@ -201,6 +277,15 @@ def main() -> None:
             row["source_status"] = "active"
             row["stale_reason"] = None
             row["last_successful_fetch"] = captured_at
+
+        # Lightweight CSV sniff: per ogni item con URL diretto a file dati,
+        # scarica ~10KB e sniffa encoding/delim/decimal/skip.
+        # Non usa DuckDB — solo puro Python, ~0.02s per sniff + ~0.5s per download.
+        # I risultati (encoding_suggested, delim_suggested, ...) vengono scritti
+        # direttamente nel catalog inventory, pronti per source-check e scoring.
+        if rows:
+            _sniff_csv_rows(rows, logger)
+
         all_rows.extend(rows)
 
         source_report: dict[str, Any] = {

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -235,8 +235,15 @@ def main() -> None:
             executor.submit(_collect_source, source_id, source_cfg, captured_at): source_id
             for source_id, source_cfg in inventoriable
         }
+        _SOURCE_TIMEOUT = 300  # 5 minuti per fonte — evita che fonti lente/bloccate tengano il workflow in stallo
         for future in as_completed(future_to_id):
-            sid, rows, warning, summary, exc = future.result()
+            try:
+                sid, rows, warning, summary, exc = future.result(timeout=_SOURCE_TIMEOUT)
+            except TimeoutError:
+                sid = future_to_id[future]
+                logger.warning("Source %s timed out after %ds, treating as failed", sid, _SOURCE_TIMEOUT)
+                exc = TimeoutError(f"Source timed out after {_SOURCE_TIMEOUT}s")
+                rows, warning, summary = [], None, None
             collected[sid] = (rows, warning, summary, exc)
 
     # Load existing inventory for merge (always, not just with --source-ids filter)

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -415,27 +415,40 @@ def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
         if pd.isna(year_max):
             year_max = fb_ymax
 
-    # Preview dati reali: se granularità ancora non determinata e abbiamo URL diretto
-    # a un file CSV/XLSX/XLS, scarica le prime righe per estrarre colonne reali.
-    # Questo funziona per qualsiasi protocollo (CKAN, SDMX, html) purché l'URL
-    # sia un file dati diretto, non una landing page.
+    # Preview dati reali: per ogni item con URL a file CSV/XLSX/XLS, scarica
+    # un sample e profila con toolkit (encoding, delim, colonne, mapping).
+    # Anni/granularità vengono aggiornati solo se i metadati non li hanno
+    # già determinati — ma i campi di profiling (encoding_suggested, ecc.)
+    # vengono SEMPRE popolati.
     preview_meta: dict[str, Any] = {}
-    if granularity in (None, "non_determinato") or pd.isna(year_min):
-        preview_url: Any = (
+    # Per inventory_only e content_type_landing, enrich["resource_url"] è
+    # una landing page, non un file dati. In quei casi, distribution_url
+    # dal catalogo è più probabile sia un URL diretto a file CSV/XLSX.
+    # Per CKAN/SDMX/HTML, resource_url è già il file dati corretto.
+    if enrich["enrich_method"] in ("inventory_only", "content_type_landing"):
+        preview_url = (
+            _safe_str(row.get("distribution_url"))
+            or enrich.get("resource_url")
+            or _safe_str(row.get("url"))
+        )
+    else:
+        preview_url = (
             enrich.get("resource_url")
             or _safe_str(row.get("distribution_url"))
             or _safe_str(row.get("url"))
         )
-        if isinstance(preview_url, str) and preview_url.startswith("http"):
-            preview = _fetch_data_preview(preview_url)
-            if preview.get("enrich_method") == "csv_preview":
-                if granularity in (None, "non_determinato") and preview.get("granularity"):
-                    granularity = preview["granularity"]
-                if pd.isna(year_min) and preview.get("year_min") is not None:
-                    year_min = preview["year_min"]
-                if pd.isna(year_max) and preview.get("year_max") is not None:
-                    year_max = preview["year_max"]
-                preview_meta = _preview_meta_from_enrich(preview)
+    if isinstance(preview_url, str) and preview_url.startswith("http"):
+        preview = _fetch_data_preview(preview_url)
+        if preview.get("enrich_method") == "csv_preview":
+            # Anni/granularità: solo se metadati non bastano
+            if granularity in (None, "non_determinato") and preview.get("granularity"):
+                granularity = preview["granularity"]
+            if pd.isna(year_min) and preview.get("year_min") is not None:
+                year_min = preview["year_min"]
+            if pd.isna(year_max) and preview.get("year_max") is not None:
+                year_max = preview["year_max"]
+            # Campi profiling: SEMPRE popolati (encoding, delim, mapping, ecc.)
+            preview_meta = _preview_meta_from_enrich(preview)
 
     # Se l'enrich ha gia' chiamato _fetch_data_preview ma non siamo rientrati
     # nel blocco sopra (perche' granularita' era gia' determinata),

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -344,6 +344,10 @@ def _preview_meta_from_enrich(enrich: dict[str, Any]) -> dict[str, Any]:
     mapping_val = enrich.get("mapping_suggestions")
     if isinstance(mapping_val, dict):
         mapping_val = _json.dumps(mapping_val)
+    elif not isinstance(mapping_val, str):
+        # Forza "{}" invece di None per evitare che DuckDB inferisca
+        # DOUBLE per la colonna (quando tutti i valori sono None).
+        mapping_val = "{}"
 
     return {
         "file_size": enrich.get("file_size"),

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -505,19 +505,25 @@ def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame
     results = []
 
     with ThreadPoolExecutor(max_workers=workers) as pool:
-        future_to_idx = {pool.submit(_check_row, row, check_ts, registry): i for i, row in df.iterrows()}
+        # Usa enumerate per avere un indice posizionale garantito come int.
+        # df.iterrows() restituisce un indice generico (Hashable) che mypy
+        # non accetta per df.loc/df.iloc — con enumerate pos abbiamo int certo.
+        future_to_idx = {
+            pool.submit(_check_row, row, check_ts, registry): pos
+            for pos, (_idx, row) in enumerate(df.iterrows())
+        }
         done = 0
         total = len(future_to_idx)
         for future in as_completed(future_to_idx):
-            i = future_to_idx[future]
+            pos = future_to_idx[future]
             try:
                 results.append(_finalize_scores(future.result()))
             except Exception as exc:
-                logger.warning("Row check failed for index %d: %s", i, exc)
+                logger.warning("Row check failed for index %d: %s", pos, exc)
                 # Mantieni item_id e source_id anche in caso di fallimento,
                 # altrimenti il merge upsert (riga 743) crasha su results["item_id"]
                 # quando TUTTI i check falliscono (es. fonte temporaneamente down).
-                fallback_row = df.loc[i] if i in df.index else {}
+                fallback_row = df.iloc[pos] if pos < len(df) else {}
                 results.append({
                     "item_id": str(fallback_row.get("item_id", "")),
                     "source_id": str(fallback_row.get("source_id", "")),

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -517,7 +517,7 @@ def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame
                 # Mantieni item_id e source_id anche in caso di fallimento,
                 # altrimenti il merge upsert (riga 743) crasha su results["item_id"]
                 # quando TUTTI i check falliscono (es. fonte temporaneamente down).
-                fallback_row = df.iloc[i] if i < len(df) else {}
+                fallback_row = df.loc[i] if i in df.index else {}
                 results.append({
                     "item_id": str(fallback_row.get("item_id", "")),
                     "source_id": str(fallback_row.get("source_id", "")),

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -328,6 +328,8 @@ def _preview_meta_from_enrich(enrich: dict[str, Any]) -> dict[str, Any]:
 
     Both col_types (dict) and columns (list) must be JSON-encoded as strings
     before writing the DataFrame to avoid ArrowTypeError on to_parquet.
+    Nuovi campi toolkit (encoding_suggested, delim_suggested, ecc.) vengono
+    propagati direttamente — sono già tipi semplici (str, int, bool, None).
     """
     import json as _json
 
@@ -339,11 +341,22 @@ def _preview_meta_from_enrich(enrich: dict[str, Any]) -> dict[str, Any]:
     if isinstance(columns_val, list):
         columns_val = _json.dumps(columns_val)
 
+    mapping_val = enrich.get("mapping_suggestions")
+    if isinstance(mapping_val, dict):
+        mapping_val = _json.dumps(mapping_val)
+
     return {
         "file_size": enrich.get("file_size"),
         "preview_row_count": enrich.get("preview_row_count"),
         "col_types": col_types_val,
         "columns": columns_val,
+        # Nuovi campi dal toolkit profiler
+        "encoding_suggested": enrich.get("encoding_suggested"),
+        "delim_suggested": enrich.get("delim_suggested"),
+        "decimal_suggested": enrich.get("decimal_suggested"),
+        "skip_suggested": enrich.get("skip_suggested"),
+        "robust_read_suggested": enrich.get("robust_read_suggested"),
+        "mapping_suggestions": mapping_val,
     }
 
 
@@ -374,7 +387,7 @@ def _normalize_preview_columns_for_parquet(df: pd.DataFrame) -> pd.DataFrame:
         return value
 
     normalized = df.copy()
-    for column in ("col_types", "columns"):
+    for column in ("col_types", "columns", "mapping_suggestions"):
         if column not in normalized.columns:
             continue
         normalized[column] = normalized[column].map(_preview_cell_for_parquet)
@@ -472,6 +485,13 @@ def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
         "preview_row_count": preview_meta.get("preview_row_count"),
         "col_types": preview_meta.get("col_types"),
         "columns": preview_meta.get("columns"),
+        # Nuovi campi dal toolkit profiler (solo csv_preview)
+        "encoding_suggested": preview_meta.get("encoding_suggested"),
+        "delim_suggested": preview_meta.get("delim_suggested"),
+        "decimal_suggested": preview_meta.get("decimal_suggested"),
+        "skip_suggested": preview_meta.get("skip_suggested"),
+        "robust_read_suggested": preview_meta.get("robust_read_suggested"),
+        "mapping_suggestions": preview_meta.get("mapping_suggestions"),
         "source_status": row.get("source_status", "unknown"),
         "needs_review": (granularity == "non_determinato") or pd.isna(year_min),
         "intake_score": None,  # placeholder, calcolato sotto

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -523,7 +523,7 @@ def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame
                 # Mantieni item_id e source_id anche in caso di fallimento,
                 # altrimenti il merge upsert (riga 743) crasha su results["item_id"]
                 # quando TUTTI i check falliscono (es. fonte temporaneamente down).
-                fallback_row = df.iloc[pos] if pos < len(df) else {}
+                fallback_row = dict(df.iloc[pos]) if pos < len(df) else {}
                 results.append({
                     "item_id": str(fallback_row.get("item_id", "")),
                     "source_id": str(fallback_row.get("source_id", "")),

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -514,7 +514,16 @@ def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame
                 results.append(_finalize_scores(future.result()))
             except Exception as exc:
                 logger.warning("Row check failed for index %d: %s", i, exc)
-                results.append({"check_notes": f"check failed: {exc}", "enrich_method": "error"})
+                # Mantieni item_id e source_id anche in caso di fallimento,
+                # altrimenti il merge upsert (riga 743) crasha su results["item_id"]
+                # quando TUTTI i check falliscono (es. fonte temporaneamente down).
+                fallback_row = df.iloc[i] if i < len(df) else {}
+                results.append({
+                    "item_id": str(fallback_row.get("item_id", "")),
+                    "source_id": str(fallback_row.get("source_id", "")),
+                    "check_notes": f"check failed: {exc}",
+                    "enrich_method": "error",
+                })
             done += 1
             if done % 50 == 0 or done == total:
                 logger.info("  %d/%d completed", done, total)

--- a/scripts/source_check_analyze.py
+++ b/scripts/source_check_analyze.py
@@ -186,6 +186,10 @@ def _intake_score(
     enrich_method: str,
     needs_review: bool,
     source_status: Optional[str] = None,
+    encoding_suggested: Optional[str] = None,
+    mapping_suggestions: Optional[str] = None,
+    robust_read_suggested: Optional[bool] = None,
+    delim_suggested: Optional[str] = None,
 ) -> tuple[int, bool]:
     score = 0
     score += _GRAN_SCORE.get(granularity or "non_determinato", 0)
@@ -224,6 +228,27 @@ def _intake_score(
         score -= 10
         needs_review = True
 
+    # Segnali di qualita' reali dal toolkit profiler
+    if encoding_suggested:
+        score += 5  # file esiste, encoding rilevato == leggibile e parsabile
+    if delim_suggested:
+        score += 2  # delimitatore rilevato (formato strutturato)
+    if robust_read_suggested:
+        score -= 10  # CSV sporco (righe irregolari, padding necessario)
+        needs_review = True
+
+    # mapping_suggestions: JSON con colonne → dati ben strutturati
+    if mapping_suggestions:
+        import json as _json
+        try:
+            ms = _json.loads(mapping_suggestions) if isinstance(mapping_suggestions, str) else mapping_suggestions
+            if isinstance(ms, dict) and len(ms) >= 2:
+                score += 5  # almeno 2 colonne con tipo inferito
+            if isinstance(ms, dict) and len(ms) >= 1:
+                score += 3  # almeno 1 colonna
+        except Exception:
+            pass
+
     score = max(0, min(100, score))
     candidate = score >= 40 and not needs_review
     return score, candidate
@@ -239,6 +264,10 @@ def _finalize_scores(result: dict) -> dict:
         enrich_method=result.get("enrich_method", "none"),
         needs_review=result.get("needs_review", True),
         source_status=result.get("source_status"),
+        encoding_suggested=result.get("encoding_suggested"),
+        mapping_suggestions=result.get("mapping_suggestions"),
+        robust_read_suggested=result.get("robust_read_suggested"),
+        delim_suggested=result.get("delim_suggested"),
     )
     result["intake_score"] = score
     result["intake_candidate"] = candidate

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -530,7 +530,7 @@ def _fetch_data_preview(url: str) -> dict:
             "decimal_suggested": decimal_suggested,
             "skip_suggested": skip_suggested,
             "robust_read_suggested": robust_read_suggested,
-            "mapping_suggestions": _json.dumps(mapping_suggestions) if mapping_suggestions else None,
+            "mapping_suggestions": _json.dumps(mapping_suggestions) if isinstance(mapping_suggestions, dict) else "{}",
         })
         return result
 

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -449,6 +449,40 @@ def _fetch_data_preview(url: str) -> dict:
                                 year_values = y_vals
                                 break
 
+            elif fmt in ("xlsx", "xls") and not is_binary:
+                # XLS/XLSX falso: magic bytes non corrispondono a Excel.
+                # Prova a trattarlo come CSV con sniff (es. file TSV mascherato
+                # da estensione .xls con encoding Latin-1).
+                effective_read_cfg = {
+                    "encoding": encoding_suggested,
+                    "delim": delim_suggested,
+                    "decimal": decimal_suggested,
+                    "skip": skip_suggested,
+                    "header": True,
+                }
+                try:
+                    profile = profile_with_read_cfg(tmp_path, sniff, effective_read_cfg)
+                    columns = profile.get("columns_raw", [])
+                    types_map = profile.get("duckdb_types", [])
+                    if columns and types_map and len(columns) == len(types_map):
+                        col_types = dict(zip(columns, types_map))
+                    else:
+                        col_types = {}
+                    sample = profile.get("sample_rows", [])
+                    preview_row_count = len(sample) if sample else None
+                    robust_read_suggested = profile.get("robust_read_suggested", False)
+                    # Year detection (same as CSV branch)
+                    if sample:
+                        for col in columns:
+                            vals = [r.get(col) for r in sample if isinstance(r.get(col), (int, float))]
+                            if vals:
+                                y_vals = [int(v) for v in vals if v and 1900 <= int(v) <= 2100]
+                                if len(y_vals) >= 2:
+                                    year_values = y_vals
+                                    break
+                except Exception:
+                    pass
+
             elif fmt == "json":
                 # JSON: keep existing logic (toolkit doesn't profile JSON)
                 text = content.decode("utf-8", errors="replace")

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -272,24 +272,34 @@ def _fetch_html_metadata(url: str) -> dict:
         return result
 
 
-# ── Data preview ───────────────────────────────────────────────────────────
+# ── Data preview (toolkit profiler) ────────────────────────────────────────
 
 
-YEAR_COLUMNS = ["anno", "year", "data", "date", "periodo", "period", "mese", "month"]
 REGION_COLUMNS = ["regione", "region", "provincia", "province", "area", "territorio"]
 COMUNE_COLUMNS = ["comune", "municip", "localita", "citta", "city"]
 
+# Colonne il cui nome suggerisce valori anno — fallback se la detection
+# automatica da dati numerici non trova nulla
+_YEAR_COLUMN_HINTS = ["anno", "year", "data", "date", "periodo", "period", "mese", "month"]
+
 
 def _fetch_data_preview(url: str) -> dict:
-    """Fetch e parse content preview da un URL CSV/JSON/XLS.
+    """Fetch e parse content preview usando il profiler del toolkit.
+
+    Usa sniff_source_file + profile_with_read_cfg (DuckDB) invece di pandas
+    diretto. Gestisce encoding, delimitatore, decimale e skip in modo robusto,
+    anche per CSV italiani (latin-1, ; come delim, , come decimale).
 
     Returns dict in formato _EMPTY_ENRICH con campi aggiuntivi:
-    - columns: list[str]
-    - col_types: dict[str, str] (nomi colonna → tipo pandas)
+    - columns: list[str] (JSON-encoded)
+    - col_types: dict[str, str] (JSON-encoded)
     - year_min, year_max
     - granularity
     - file_size: int (bytes)
-    - preview_row_count: int | None (righe parse, campione limitato a 1000)
+    - preview_row_count: int | None
+    - encoding_suggested, delim_suggested, decimal_suggested, skip_suggested
+    - mapping_suggestions: dict (JSON-encoded, pronto per intake)
+    - robust_read_suggested: bool
     - enrich_method: "csv_preview"
     """
     if not isinstance(url, str) or not url.startswith("http"):
@@ -319,8 +329,7 @@ def _fetch_data_preview(url: str) -> dict:
             result["enrich_method"] = "csv_preview_http_error"
             return result
 
-        # Usa solo primi ~100KB per preview (limitato).
-        # file_size da Content-Length se disponibile, altrimenti dal download effettivo
+        # Usa solo primi ~100KB per preview.
         content = resp.content[:100 * 1024]
         try:
             file_size = int(resp.headers.get("Content-Length", "0"))
@@ -328,7 +337,11 @@ def _fetch_data_preview(url: str) -> dict:
             file_size = 0
         if file_size <= 0:
             file_size = len(resp.content)
-        text = content.decode("utf-8", errors="replace")
+
+        import json as _json
+        import tempfile
+        from pathlib import Path
+        from toolkit.profile.raw import sniff_source_file, profile_with_read_cfg
 
         columns: list[str] = []
         col_types: dict[str, str] = {}
@@ -337,108 +350,136 @@ def _fetch_data_preview(url: str) -> dict:
         year_max: Optional[int] = None
         granularity = "non_determinato"
         year_values: list[int] = []
+        encoding_suggested: str | None = None
+        delim_suggested: str | None = None
+        decimal_suggested: str | None = None
+        skip_suggested: int = 0
+        mapping_suggestions: dict | None = None
+        robust_read_suggested: bool = False
 
-        if fmt == "csv":
-            import pandas as pd
-            import io
+        # Salva il contenuto in un file temporaneo per usare il profiler toolkit
+        ext = f".{fmt}"
+        with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
+            tmp.write(content)
+            tmp_path = Path(tmp.name)
 
-            df = None
-            for sep in [None, ",", ";", "\t", "|"]:
-                try:
-                    kwargs: dict[str, Any] = {"nrows": 1000}
-                    if isinstance(sep, str):
-                        kwargs["sep"] = sep
-                    df = pd.read_csv(io.StringIO(text), **kwargs)
-                    if len(df.columns) > 1:
-                        break
-                except Exception:
-                    continue
-            if df is not None:
-                columns = [str(c) for c in df.columns]
-                col_types = {str(c): str(dtype) for c, dtype in df.dtypes.items()}
-                preview_row_count = len(df)
-                for c in columns:
-                    if c.lower() in YEAR_COLUMNS:
-                        try:
-                            vals = pd.to_numeric(df[c], errors="coerce").dropna()
-                            if not vals.empty:
-                                year_values = [int(v) for v in vals]
-                        except Exception:
-                            pass
+        try:
+            # Phase 1: sniff — encoding, delim, decimal, skip, binary detection
+            sniff = sniff_source_file(tmp_path)
+            encoding_suggested = sniff.get("encoding_suggested")
+            delim_suggested = sniff.get("delim_suggested")
+            decimal_suggested = sniff.get("decimal_suggested")
+            skip_suggested = sniff.get("skip_suggested", 0)
 
-        elif fmt in ("xlsx", "xls"):
-            import pandas as pd
-            import io
-            try:
-                excel = pd.ExcelFile(io.BytesIO(content))
-                if excel.sheet_names:
-                    df = pd.read_excel(excel, sheet_name=excel.sheet_names[0], nrows=1000)
-                    columns = [str(c) for c in df.columns]
-                    col_types = {str(c): str(dtype) for c, dtype in df.dtypes.items()}
-                    preview_row_count = len(df)
-                    for c in columns:
-                        if c.lower() in YEAR_COLUMNS:
-                            try:
-                                vals = pd.to_numeric(df[c], errors="coerce").dropna()
-                                if not vals.empty:
-                                    year_values = [int(v) for v in vals]
-                            except Exception:
-                                pass
-            except ImportError:
-                pass
-            except Exception:
-                # XLS falso (es. file TSV mascherato da .xls con encoding Latin-1)
-                # Prova come CSV con encoding + separatori fallback
-                try:
-                    csv_df = None
-                    for enc in ["latin-1", "windows-1252", "iso-8859-1"]:
-                        text_latin = content.decode(enc, errors="replace")
-                        for sep in [None, ",", ";", "\t", "|"]:
-                            try:
-                                csv_kwargs: dict[str, Any] = {"nrows": 1000}
-                                if isinstance(sep, str):
-                                    csv_kwargs["sep"] = sep
-                                csv_df = pd.read_csv(io.StringIO(text_latin), **csv_kwargs)
-                                if csv_df is not None and len(csv_df.columns) > 1:
+            is_binary = sniff.get("is_binary_file")
+
+            if fmt == "csv" and not is_binary:
+                # CSV: profiling DuckDB con sniff
+                effective_read_cfg: dict[str, Any] = {
+                    "encoding": encoding_suggested,
+                    "delim": delim_suggested,
+                    "decimal": decimal_suggested,
+                    "skip": skip_suggested,
+                    "header": True,
+                }
+
+                profile = profile_with_read_cfg(tmp_path, sniff, effective_read_cfg)
+                columns = profile.get("columns_raw", [])
+                types_map = profile.get("duckdb_types", [])
+                if columns and types_map and len(columns) == len(types_map):
+                    col_types = dict(zip(columns, types_map))
+                else:
+                    col_types = {}
+
+                sample = profile.get("sample_rows", [])
+                preview_row_count = len(sample) if sample else None
+                mapping_suggestions = profile.get("mapping_suggestions")
+                robust_read_suggested = profile.get("robust_read_suggested", False)
+
+                # Year detection: scorri TUTTE le colonne numeriche dai sample rows
+                # (non solo quelle con nome in YEAR_COLUMNS)
+                if sample:
+                    for col in columns:
+                        vals = []
+                        for row in sample:
+                            v = row.get(col)
+                            if isinstance(v, (int, float)):
+                                vals.append(v)
+                        if vals:
+                            # Filtra valori che sembrano anni (1900-2100)
+                            y_vals = [int(v) for v in vals if v and 1900 <= int(v) <= 2100]
+                            if len(y_vals) >= 2:
+                                year_values = y_vals
+                                break
+
+                    # Fallback: se nessuna colonna numerica ha valori anno,
+                    # prova colonne con nome in YEAR_COLUMN_HINTS
+                    if not year_values:
+                        for col in columns:
+                            if col.lower() in _YEAR_COLUMN_HINTS:
+                                vals = [r.get(col) for r in sample]
+                                numeric_vals = [int(v) for v in vals if isinstance(v, (int, float))]
+                                if numeric_vals:
+                                    year_values = numeric_vals
                                     break
-                            except Exception:
-                                continue
-                        if csv_df is not None and len(csv_df.columns) > 1:
-                            break
-                    if csv_df is not None and len(csv_df.columns) > 1:
-                        columns = [str(c) for c in csv_df.columns]
-                        col_types = {str(c): str(dtype) for c, dtype in csv_df.dtypes.items()}
-                        preview_row_count = len(csv_df)
+
+            elif fmt in ("xlsx", "xls") and is_binary in ("xlsx", "xls"):
+                # Excel: usa _profile_excel dal toolkit (stesso reader del runtime clean)
+                from toolkit.profile.raw import _profile_excel
+
+                read_cfg_excel = {"header": True, "skip": skip_suggested}
+                excel_result = _profile_excel(tmp_path, read_cfg_excel)
+                columns = excel_result.get("columns_raw", [])
+                preview_row_count = len(excel_result.get("sample_rows", []))
+                col_types = {}
+                robust_read_suggested = excel_result.get("robust_read_suggested", False)
+
+                # Year detection su Excel: stessi criteri del CSV
+                sample = excel_result.get("sample_rows", [])
+                if sample:
+                    for col in columns:
+                        vals = []
+                        for row in sample:
+                            v = row.get(col)
+                            if isinstance(v, (int, float)):
+                                vals.append(v)
+                        if vals:
+                            y_vals = [int(v) for v in vals if v and 1900 <= int(v) <= 2100]
+                            if len(y_vals) >= 2:
+                                year_values = y_vals
+                                break
+
+            elif fmt == "json":
+                # JSON: keep existing logic (toolkit doesn't profile JSON)
+                text = content.decode("utf-8", errors="replace")
+                try:
+                    data = _json.loads(text)
+                    if isinstance(data, list) and data and isinstance(data[0], dict):
+                        columns = list(data[0].keys())
+                        col_types = {str(k): type(v).__name__ for k, v in data[0].items()}
+                        preview_row_count = len(data)
+                    elif isinstance(data, dict):
+                        columns = list(data.keys())
                 except Exception:
                     pass
 
-        elif fmt == "json":
-            import json as _json
-            try:
-                data = _json.loads(text)
-                if isinstance(data, list) and data and isinstance(data[0], dict):
-                    columns = list(data[0].keys())
-                    col_types = {str(k): type(v).__name__ for k, v in data[0].items()}
-                    preview_row_count = len(data)
-                elif isinstance(data, dict):
-                    columns = list(data.keys())
-            except Exception:
-                pass
+            # Granularità da nomi colonna
+            if columns:
+                cols_lower = [c.lower() for c in columns]
+                if any(c in " ".join(cols_lower) for c in COMUNE_COLUMNS):
+                    granularity = "comune"
+                elif any(c in " ".join(cols_lower) for c in REGION_COLUMNS):
+                    granularity = "regione"
 
-        # Granularità da nomi colonna
-        if columns:
-            cols_lower = [c.lower() for c in columns]
-            if any(c in " ".join(cols_lower) for c in COMUNE_COLUMNS):
-                granularity = "comune"
-            elif any(c in " ".join(cols_lower) for c in REGION_COLUMNS):
-                granularity = "regione"
+            if year_values:
+                year_min = min(year_values)
+                year_max = max(year_values)
 
-        if year_values:
-            year_min = min(year_values)
-            year_max = max(year_values)
+        finally:
+            # Pulisce il file temporaneo
+            tmp_path.unlink(missing_ok=True)
 
         result = _EMPTY_ENRICH.copy()
-        import json as _json
         result.update({
             "columns": _json.dumps(columns) if columns else None,
             "col_types": _json.dumps(col_types) if col_types else None,
@@ -449,6 +490,13 @@ def _fetch_data_preview(url: str) -> dict:
             "granularity": granularity,
             "resource_format": fmt.upper(),
             "enrich_method": "csv_preview",
+            # Nuovi campi dal toolkit
+            "encoding_suggested": encoding_suggested,
+            "delim_suggested": delim_suggested,
+            "decimal_suggested": decimal_suggested,
+            "skip_suggested": skip_suggested,
+            "robust_read_suggested": robust_read_suggested,
+            "mapping_suggestions": _json.dumps(mapping_suggestions) if mapping_suggestions else None,
         })
         return result
 

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -257,7 +257,10 @@ def test_fetch_data_preview_returns_new_fields(monkeypatch) -> None:
     assert result.get("file_size") == len(b"col1,col2,col3\n1,2,3\n4,5,6")
     assert result.get("preview_row_count") == 2
     import json
-    assert json.loads(result.get("col_types") or "{}") == {"col1": "int64", "col2": "int64", "col3": "int64"}
+    # DuckDB restituisce BIGINT per interi (non int64 come pandas)
+    ct = json.loads(result.get("col_types") or "{}")
+    assert all(v.upper() in ("BIGINT", "INTEGER", "INT64") for v in ct.values()), f"Unexpected types: {ct}"
+    assert list(ct.keys()) == ["col1", "col2", "col3"]
     assert json.loads(result.get("columns") or "[]") == ["col1", "col2", "col3"]
 
 


### PR DESCRIPTION
Sostituisce il profiling pandas diretto in `_fetch_data_preview` con il profiler del toolkit DuckDB (`sniff_source_file` + `profile_with_read_cfg`). I nuovi campi (encoding, delim, mapping suggestions) sono propagati fino a `source_check_results.parquet`.

### Miglioramenti
- Encoding/delimitatore/decimale sniffati automaticamente
- Skip righe preambolo rilevato
- DuckDB parse correttamente numeri italiani (28.500,50 → 28500.5)
- Year detection da TUTTE le colonne numeriche (non solo nome colonna)
- Fallback per file .xls falso (trattato come CSV con sniff)
- 6 nuovi campi nel parquet: encoding_suggested, delim_suggested, decimal_suggested, skip_suggested, robust_read_suggested, mapping_suggestions

### Test: 133 passano, 0 falliti