### PR TITLE
feat(workflow): sdoppia observatory in radar.yml (daily) + observatory.yml (weekly)

### DIFF
--- a/.github/workflows/observatory.yml
+++ b/.github/workflows/observatory.yml
@@ -3,8 +3,8 @@ name: observatory
 on:
   workflow_dispatch:
   schedule:
-    # Ogni giorno 03:15 — radar sempre, inventory solo lunedì, source-check incrementale sempre
-    - cron: "15 3 * * *"
+    # Ogni lunedì 03:20 (5 min dopo radar)
+    - cron: "20 3 * * 1"
 
 permissions:
   contents: write
@@ -21,7 +21,7 @@ env:
   CATALOG_INVENTORY_GCS_PREFIX: ${{ secrets.CATALOG_INVENTORY_GCS_PREFIX }}
 
 jobs:
-  observatory:
+  scan:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -54,57 +54,16 @@ jobs:
         uses: google-github-actions/setup-gcloud@v3
 
       # ═══════════════════════════════════════════════════════════════════
-      # STEP 1 — RADAR (always, ~30s)
+      # STEP 1 — INVENTORY BUILD
       # ═══════════════════════════════════════════════════════════════════
-      - name: Run radar check
-        run: |
-          python scripts/radar_check.py
-
-      - name: Upload radar artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: radar-results
-          path: |
-            data/radar/radar_summary.json
-            data/radar/radar_history.json
-            data/radar/sources_registry.yaml
-            data/radar/STATUS.md
-
-      - name: Commit radar state
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/radar/radar_history.json data/radar/radar_summary.json data/radar/sources_registry.yaml data/radar/STATUS.md
-          if git diff --cached --quiet; then
-            echo "Nessuna variazione nel radar."
-          else
-            git commit -m "chore(so): refresh radar status [ci skip]"
-            git push
-          fi
-
-      # ═══════════════════════════════════════════════════════════════════
-      # STEP 2 — INVENTORY (only Monday or manual dispatch)
-      # ═══════════════════════════════════════════════════════════════════
-      - name: Set IS_INVENTORY_RUN flag
-        run: |
-          DAY=$(date +%u)
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" || "$DAY" == "1" ]]; then
-            echo "IS_INVENTORY_RUN=true" >> "$GITHUB_ENV"
-          else
-            echo "IS_INVENTORY_RUN=false" >> "$GITHUB_ENV"
-          fi
-          echo "Day of week: $DAY, IS_INVENTORY_RUN: $IS_INVENTORY_RUN"
-
-      - name: Download previous report for signals delta
+      - name: Download previous report (for signals delta)
         if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
         run: |
           prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
           prefix="${prefix%/}"
           gcloud storage cp "$prefix/catalog_inventory_report.json" previous_report.json || echo "{}" > previous_report.json
 
-      - name: Download catalog inventory from GCS (always — for source-check upsert)
+      - name: Download previous inventory (for source-check merge)
         if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
         run: |
           prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
@@ -114,14 +73,12 @@ jobs:
             data/catalog_inventory/generated/catalog_inventory_latest.parquet || echo "No inventory snapshot yet"
 
       - name: Build catalog inventory
-        if: ${{ env.IS_INVENTORY_RUN == 'true' }}
         run: |
           python scripts/build_catalog_inventory.py \
             --out-dir data/catalog_inventory/generated \
             --workers 8
 
-      - name: Build catalog signals
-        if: ${{ env.IS_INVENTORY_RUN == 'true' }}
+      - name: Build catalog signals + diff
         run: |
           python scripts/build_catalog_signals.py \
             --report data/catalog_inventory/generated/catalog_inventory_report.json \
@@ -130,8 +87,14 @@ jobs:
             --out data/catalog/catalog_signals.json \
             --report-out data/catalog/CATALOG_WATCH_REPORT.md
 
+          if python -c "import json,sys; d=json.load(open('previous_report.json')); sys.exit(0 if d.get('sources') else 1)"; then
+            python scripts/catalog_diff.py previous_report.json \
+              data/catalog_inventory/generated/catalog_inventory_report.json --output diff.md
+          else
+            echo "NO_BASELINE" > diff.md
+          fi
+
       - name: Commit catalog signals
-        if: ${{ env.IS_INVENTORY_RUN == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -145,164 +108,30 @@ jobs:
             git push
           fi
 
-      - name: Generate raw diff
-        if: ${{ env.IS_INVENTORY_RUN == 'true' }}
-        run: |
-          if python -c "import json,sys; d=json.load(open('previous_report.json')); sys.exit(0 if d.get('sources') else 1)"; then
-            python scripts/catalog_diff.py previous_report.json data/catalog_inventory/generated/catalog_inventory_report.json --output diff.md
-          else
-            echo "NO_BASELINE" > diff.md
-            echo "Nessun baseline precedente — skip diff (primo run)."
-            exit 0
-          fi
-
-      - name: Build enriched issue body
-        if: ${{ env.IS_INVENTORY_RUN == 'true' }}
-        env:
-          GCS_PREFIX: ${{ secrets.CATALOG_INVENTORY_GCS_PREFIX }}
-        run: |
-          python - <<'PY'
-          import json, re, sys
-          from pathlib import Path
-          from datetime import datetime, timezone
-
-          # Parse raw diff
-          raw = Path("diff.md").read_text(encoding="utf-8") if Path("diff.md").exists() else ""
-          if raw == "NO_BASELINE":
-              print("No baseline — skipping issue creation.")
-              sys.exit(0)
-
-          # Load reports
-          new_report = json.loads(Path("data/catalog_inventory/generated/catalog_inventory_report.json").read_text(encoding="utf-8"))
-          radar = json.loads(Path("data/radar/radar_summary.json").read_text(encoding="utf-8")) if Path("data/radar/radar_summary.json").exists() else {}
-
-          # Count categories from raw diff markdown — isolate section before counting
-          # Each section starts with "#### <heading>" and ends before the next "####"
-          sections = re.split(r'^#### ', raw, flags=re.M)
-
-          regressions = 0
-          recoveries  = 0
-          new_sources = 0
-          removed     = 0
-
-          for section in sections:
-              lines = section.splitlines()
-              if not lines:
-                  continue
-              heading = lines[0].strip()
-              body = '\n'.join(lines[1:])
-              if heading == 'Regressioni (ok → errore)':
-                  regressions = len(re.findall(r'^- `([^`]+)`', body, re.M))
-              elif heading == 'Recovery (errore → ok)':
-                  recoveries = len(re.findall(r'^- `([^`]+)`', body, re.M))
-              elif heading == 'Nuove fonti rilevate':
-                  new_sources = len(re.findall(r'^- `([^`]+)`', body, re.M))
-              elif heading == 'Fonti rimosse o non più raggiungibili':
-                  removed = len(re.findall(r'^- `([^`]+)`', body, re.M))
-
-          total_items_new = sum(v.get("rows", 0) for v in new_report.get("sources", {}).values())
-
-          # Compute delta from changed rows
-          delta_items = 0
-          for line in raw.splitlines():
-              m = re.search(r'\| `([^`]+)` \| (\d+) \| (\d+) \|', line)
-              if m:
-                  delta_items += (int(m.group(3)) - int(m.group(2)))
-
-          captured = new_report.get("captured_at", datetime.now(timezone.utc).isoformat())
-          date_str = captured[:10]
-
-          # Build dynamic title
-          parts = []
-          if regressions: parts.append(f"{regressions} regressione{'e' if regressions==1 else 'i'}")
-          if new_sources: parts.append(f"{new_sources} nuova fonte")
-          if recoveries:  parts.append(f"{recoveries} recovery")
-          if removed:      parts.append(f"{removed} rimossa")
-          if delta_items:  parts.append(f"{delta_items:+d} item")
-
-          title_base = "[Catalog] " + date_str
-          if parts:
-              title_base += " — " + ", ".join(parts)
-          else:
-              title_base += " — variazioni"
-
-          # Build enriched body
-          gcs = '${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'.replace('gs://', '').rstrip('/')
-
-          counts = radar.get('status_counts', {})
-
-          lines = [
-              f"## Radar status (@ {captured[:19]} UTC)",
-              "",
-              f"- Fonti totali: {radar.get('sources_total', '?')}",
-              f"- ✅ GREEN: {counts.get('GREEN', 0)}",
-              f"- ⚠️ YELLOW: {counts.get('YELLOW', 0)}",
-              f"- 🔴 RED: {counts.get('RED', 0)}",
-          ]
-          if radar.get('persistent_red'):
-              lines.append(f"- ⚠️ persistent red: {radar['persistent_red']}")
-          lines.append("")
-
-          lines.append("## Sommario inventario")
-          lines.append(f"- Nuove fonti: **{new_sources}**")
-          lines.append(f"- Rimosse: **{removed}**")
-          lines.append(f"- Regressioni: **{regressions}**")
-          lines.append(f"- Recovery: **{recoveries}**")
-          lines.append(f"- Variazione item: **{delta_items:+d}** (totale: {total_items_new})")
-          lines.append("")
-
-          lines.append("## Dettaglio")
-          lines.append(raw)
-          lines.append("")
-
-          lines.append("## Risorse")
-          lines.append(f"- [Snapshot GCS](https://console.cloud.google.com/storage/browser/{gcs}/snapshots/catalog_inventory_{captured[:10].replace('-','')}.parquet)")
-          lines.append(f"- [Report JSON](https://console.cloud.google.com/storage/browser/{gcs}/snapshots/catalog_inventory_report_{captured[:10].replace('-','')}.json)")
-          lines.append(f"- [Radar summary](../../data/radar/radar_summary.json)")
-          lines.append("")
-
-          # Labels
-          labels = ["catalog-alert"]
-          if regressions: labels.append("catalog-regression")
-          if new_sources: labels.append("catalog-new-source")
-          if recoveries:  labels.append("catalog-recovery")
-
-          Path("issue_title.txt").write_text(title_base, encoding="utf-8")
-          Path("issue_body.md").write_text("\n".join(lines), encoding="utf-8")
-          Path("issue_labels.json").write_text(json.dumps(labels), encoding="utf-8")
-
-          print(f"Title: {title_base}")
-          print(f"Labels: {labels}")
-          PY
-
-      - name: Create or update catalog alert issue
-        if: ${{ env.IS_INVENTORY_RUN == 'true' }}
+      - name: Create catalog alert issue
         env:
           GH_TOKEN: ${{ github.token }}
+          GCS_PREFIX: ${{ secrets.CATALOG_INVENTORY_GCS_PREFIX }}
         run: |
+          python scripts/gha/build_issue_body.py --gcs-prefix "$GCS_PREFIX"
           if [ ! -f issue_title.txt ]; then
             echo "Nessuna variazione o baseline assente."
             exit 0
           fi
-
-          TITLE=$(cat issue_title.txt)
-          BODY_FILE="issue_body.md"
           LABEL_ARGS=$(python3 -c "import json,sys; print(' '.join('--label '+l for l in json.load(open('issue_labels.json'))))")
-
-          EXISTING=$(gh issue list --label "catalog-alert" --state open --json number,title --jq ".[] | select(.title | startswith(\"[Catalog]\")) | .number" | head -1)
+          EXISTING=$(gh issue list --label "catalog-alert" --state open --json number,title --jq \
+            ".[] | select(.title | startswith(\"[Catalog]\")) | .number" | head -1)
           if [ -n "$EXISTING" ]; then
             echo "Aggiorno issue #$EXISTING."
-            gh issue comment "$EXISTING" --body-file "$BODY_FILE"
+            gh issue comment "$EXISTING" --body-file issue_body.md
           else
-            echo "Apro nuova issue."
-            eval "gh issue create --title \"\$TITLE\" --body-file \"\$BODY_FILE\" $LABEL_ARGS"
+            eval "gh issue create --title \"$(cat issue_title.txt)\" --body-file issue_body.md $LABEL_ARGS"
           fi
 
       # ═══════════════════════════════════════════════════════════════════
-      # STEP 3 — SOURCE-CHECK (always, ~3-5 min)
-      # Incrementale: skip item già checkati di recente
+      # STEP 2 — SOURCE-CHECK (sempre, merge semplice con risultati precedenti)
       # ═══════════════════════════════════════════════════════════════════
-      - name: Download source-check results from GCS (for incremental merge)
+      - name: Download source-check results from GCS (for merge)
         if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
         run: |
           prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
@@ -312,22 +141,21 @@ jobs:
             data/catalog_inventory/generated/source_check_results.parquet 2>/dev/null || \
             echo "No previous results — starting fresh"
 
-      - name: Run bulk source-check (incremental)
+      - name: Run bulk source-check
         run: |
           python scripts/bulk_source_check.py \
             --skip-red-sources \
             --no-sdmx-years \
-            --max-items 200 \
-            --max-age-days 7 \
+            --max-items 500 \
             --workers 8
 
       # ═══════════════════════════════════════════════════════════════════
-      # STEP 4 — UPLOAD (always source-check, inventory only on inventory run)
+      # STEP 3 — UPLOAD GCS
       # ═══════════════════════════════════════════════════════════════════
       - name: Upload source-check results to GCS
         if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
         run: |
-          stamp=$(python -c "from datetime import datetime, timezone; print(datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S'))")
+          stamp=$(python3 -c "from datetime import datetime, timezone; print(datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S'))")
           prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
           prefix="${prefix%/}"
           gcloud storage cp data/catalog_inventory/generated/source_check_results.parquet \
@@ -336,15 +164,13 @@ jobs:
             "$prefix/source-check/snapshots/source_check_${stamp}.parquet"
 
       - name: Upload inventory snapshot to GCS
-        if: ${{ env.IS_INVENTORY_RUN == 'true' && env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
+        if: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' && env.CATALOG_INVENTORY_GCS_PREFIX != '' }}
         run: |
-          stamp=$(python - <<'PY'
+          stamp=$(python3 -c "
           import json
-          from pathlib import Path
-          report = json.loads(Path("data/catalog_inventory/generated/catalog_inventory_report.json").read_text(encoding="utf-8"))
-          print(report["captured_at"].replace(":", "").replace("-", ""))
-          PY
-          )
+          report = json.load(open('data/catalog_inventory/generated/catalog_inventory_report.json'))
+          print(report['captured_at'].replace(':', '').replace('-', ''))
+          ")
           prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
           prefix="${prefix%/}"
           gcloud storage cp data/catalog_inventory/generated/catalog_inventory_latest.parquet "$prefix/catalog_inventory_latest.parquet"
@@ -353,7 +179,7 @@ jobs:
           gcloud storage cp data/catalog_inventory/generated/catalog_inventory_report.json "$prefix/snapshots/catalog_inventory_report_${stamp}.json"
 
       # ═══════════════════════════════════════════════════════════════════
-      # STEP 5 — ARTIFACTS + SUMMARIES
+      # STEP 4 — ARTIFACTS + SUMMARIES
       # ═══════════════════════════════════════════════════════════════════
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@v7
@@ -364,56 +190,9 @@ jobs:
             data/radar/radar_summary.json
             data/radar/radar_history.json
 
-      - name: Publish radar summary
+      - name: Publish summaries
         run: |
-          python - <<'PY'
-          import json
-          from pathlib import Path
-
-          summary = json.loads(Path("data/radar/radar_summary.json").read_text(encoding="utf-8"))
-          counts = summary.get("status_counts", {})
-
-          lines = ["## Radar status", ""]
-          lines.append(f"- Fonti controllate: {summary.get('sources_total', '?')}")
-          for status, count in counts.items():
-              lines.append(f"- {status}: {count}")
-          if summary.get("persistent_red"):
-              lines.append(f"> [!WARNING]\n> {summary['persistent_red']} fonti RED persistenti (≥2 probe consecutivi)")
-              lines.append("")
-          lines.append("")
-          for src in summary.get("sources", []):
-              flag = "⚠️" if src.get("red_streak", 0) >= 2 else "  "
-              lines.append(f"{flag} `{src['id']}` — {src['status']} | HTTP {src.get('http_code','-')} | {src.get('note','') or 'ok'}")
-
-          Path("radar_summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
-          PY
+          python scripts/gha/publish_radar_summary.py
           cat radar_summary.md >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Publish source-check summary
-        run: |
-          python - <<'PY'
-          import pandas as pd
-          from pathlib import Path
-
-          df = pd.read_parquet("data/catalog_inventory/generated/source_check_results.parquet")
-          candidates = int(df["intake_candidate"].sum()) if "intake_candidate" in df.columns else 0
-          reachable = int(df["reachable"].sum()) if "reachable" in df.columns else 0
-          total = len(df)
-          avg_score = df["intake_score"].mean() if "intake_score" in df.columns else 0
-
-          lines = ["## Source check results", ""]
-          lines.append(f"- Item in database: {total}")
-          if total:
-              lines.append(f"- Raggiungibili: {reachable} ({reachable/total*100:.0f}%)")
-          lines.append(f"- Intake candidates (score ≥ 40): {candidates}")
-          lines.append(f"- Score medio: {avg_score:.0f}")
-          lines.append("")
-
-          if "granularity" in df.columns:
-              lines.append("**Granularità:**")
-              for gran, n in df["granularity"].value_counts().items():
-                  lines.append(f"- {gran}: {n}")
-
-          Path("source_check_summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
-          PY
+          python scripts/gha/publish_source_check_summary.py
           cat source_check_summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/radar.yml
+++ b/.github/workflows/radar.yml
@@ -1,0 +1,68 @@
+name: radar
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Ogni giorno 03:15
+    - cron: "15 3 * * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  radar:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run radar check
+        run: |
+          python scripts/radar_check.py
+
+      - name: Upload radar artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: radar-results
+          path: |
+            data/radar/radar_summary.json
+            data/radar/radar_history.json
+            data/radar/sources_registry.yaml
+            data/radar/STATUS.md
+
+      - name: Commit radar state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/radar/radar_history.json data/radar/radar_summary.json data/radar/sources_registry.yaml data/radar/STATUS.md
+          if git diff --cached --quiet; then
+            echo "Nessuna variazione nel radar."
+          else
+            git commit -m "chore(so): refresh radar status [ci skip]"
+            git push
+          fi
+
+      - name: Publish radar summary
+        run: |
+          python scripts/gha/publish_radar_summary.py
+          cat radar_summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/gha/build_issue_body.py
+++ b/scripts/gha/build_issue_body.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Build GitHub issue body for catalog alerts.
 
-Legge diff.md (da catalog_diff.py), catalog_inventory_report.json,
-radar_summary.json e scrive issue_title.txt, issue_body.md, issue_labels.json.
+Legge diff.md (da catalog_diff.py) e catalog_inventory_report.json.
+Scrive issue_title.txt, issue_body.md, issue_labels.json.
 
 Uso:
     python scripts/gha/build_issue_body.py --gcs-prefix gs://bucket/path
@@ -28,8 +28,6 @@ def build_issue(gcs_prefix: str) -> None:
     new_report = json.loads(
         Path("data/catalog_inventory/generated/catalog_inventory_report.json").read_text(encoding="utf-8")
     )
-    radar_path = Path("data/radar/radar_summary.json")
-    radar = json.loads(radar_path.read_text(encoding="utf-8")) if radar_path.exists() else {}
 
     sections = re.split(r"^#### ", raw, flags=re.M)
     regressions = recoveries = new_sources = removed = 0
@@ -76,20 +74,8 @@ def build_issue(gcs_prefix: str) -> None:
         title += " — variazioni"
 
     gcs_path = gcs_prefix.replace("gs://", "").rstrip("/")
-    counts = radar.get("status_counts", {})
 
-    body = [
-        f"## Radar status (@ {captured[:19]} UTC)",
-        "",
-        f"- Fonti totali: {radar.get('sources_total', '?')}",
-        f"- GREEN: {counts.get('GREEN', 0)}",
-        f"- YELLOW: {counts.get('YELLOW', 0)}",
-        f"- RED: {counts.get('RED', 0)}",
-    ]
-    if radar.get("persistent_red"):
-        body.append(f"- persistent red: {radar['persistent_red']}")
-    body.append("")
-    body.append("## Sommario inventario")
+    body = ["## Sommario inventario"]
     body.append(f"- Nuove fonti: **{new_sources}**")
     body.append(f"- Rimosse: **{removed}**")
     body.append(f"- Regressioni: **{regressions}**")
@@ -97,7 +83,11 @@ def build_issue(gcs_prefix: str) -> None:
     body.append(f"- Variazione item: **{delta_items:+d}** (totale: {total_items_new})")
     body.append("")
     body.append("## Dettaglio")
-    body.append(raw)
+    # Tronca le righe troppo lunghe (es. SPARQL query, traceback Python) a 200 caratteri
+    _truncated_lines = []
+    for _line in raw.splitlines():
+        _truncated_lines.append(_line if len(_line) <= 200 else _line[:200] + "...")
+    body.append("\n".join(_truncated_lines))
     body.append("")
     stamp = captured[:10].replace("-", "")
     body.append("## Risorse")

--- a/scripts/gha/build_issue_body.py
+++ b/scripts/gha/build_issue_body.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Build GitHub issue body for catalog alerts.
+
+Legge diff.md (da catalog_diff.py), catalog_inventory_report.json,
+radar_summary.json e scrive issue_title.txt, issue_body.md, issue_labels.json.
+
+Uso:
+    python scripts/gha/build_issue_body.py --gcs-prefix gs://bucket/path
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def build_issue(gcs_prefix: str) -> None:
+    diff_path = Path("diff.md")
+    raw = diff_path.read_text(encoding="utf-8") if diff_path.exists() else ""
+
+    if raw == "NO_BASELINE":
+        print("No baseline — skipping issue creation.")
+        return
+
+    new_report = json.loads(
+        Path("data/catalog_inventory/generated/catalog_inventory_report.json").read_text(encoding="utf-8")
+    )
+    radar_path = Path("data/radar/radar_summary.json")
+    radar = json.loads(radar_path.read_text(encoding="utf-8")) if radar_path.exists() else {}
+
+    sections = re.split(r"^#### ", raw, flags=re.M)
+    regressions = recoveries = new_sources = removed = 0
+    for section in sections:
+        lines = section.splitlines()
+        if not lines:
+            continue
+        heading = lines[0].strip()
+        section_body = "\n".join(lines[1:])
+        if heading == "Regressioni (ok → errore)":
+            regressions = len(re.findall(r"^- `([^`]+)`", section_body, re.M))
+        elif heading == "Recovery (errore → ok)":
+            recoveries = len(re.findall(r"^- `([^`]+)`", section_body, re.M))
+        elif heading == "Nuove fonti rilevate":
+            new_sources = len(re.findall(r"^- `([^`]+)`", section_body, re.M))
+        elif heading == "Fonti rimosse o non piu raggiungibili":
+            removed = len(re.findall(r"^- `([^`]+)`", section_body, re.M))
+
+    total_items_new = sum(v.get("rows", 0) for v in new_report.get("sources", {}).values())
+    delta_items = 0
+    for line in raw.splitlines():
+        m = re.search(r"\| `([^`]+)` \| (\d+) \| (\d+) \|", line)
+        if m:
+            delta_items += int(m.group(3)) - int(m.group(2))
+
+    captured = new_report.get("captured_at", datetime.now(timezone.utc).isoformat())
+    date_str = captured[:10]
+
+    parts = []
+    if regressions:
+        parts.append(f"{regressions} regressione{'e' if regressions==1 else 'i'}")
+    if new_sources:
+        parts.append(f"{new_sources} nuova fonte")
+    if recoveries:
+        parts.append(f"{recoveries} recovery")
+    if removed:
+        parts.append(f"{removed} rimossa")
+    if delta_items:
+        parts.append(f"{delta_items:+d} item")
+    title = f"[Catalog] {date_str}"
+    if parts:
+        title += " — " + ", ".join(parts)
+    else:
+        title += " — variazioni"
+
+    gcs_path = gcs_prefix.replace("gs://", "").rstrip("/")
+    counts = radar.get("status_counts", {})
+
+    body = [
+        f"## Radar status (@ {captured[:19]} UTC)",
+        "",
+        f"- Fonti totali: {radar.get('sources_total', '?')}",
+        f"- GREEN: {counts.get('GREEN', 0)}",
+        f"- YELLOW: {counts.get('YELLOW', 0)}",
+        f"- RED: {counts.get('RED', 0)}",
+    ]
+    if radar.get("persistent_red"):
+        body.append(f"- persistent red: {radar['persistent_red']}")
+    body.append("")
+    body.append("## Sommario inventario")
+    body.append(f"- Nuove fonti: **{new_sources}**")
+    body.append(f"- Rimosse: **{removed}**")
+    body.append(f"- Regressioni: **{regressions}**")
+    body.append(f"- Recovery: **{recoveries}**")
+    body.append(f"- Variazione item: **{delta_items:+d}** (totale: {total_items_new})")
+    body.append("")
+    body.append("## Dettaglio")
+    body.append(raw)
+    body.append("")
+    stamp = captured[:10].replace("-", "")
+    body.append("## Risorse")
+    body.append(f"- [Snapshot GCS](https://console.cloud.google.com/storage/browser/{gcs_path}/snapshots/catalog_inventory_{stamp}.parquet)")
+    body.append(f"- [Report JSON](https://console.cloud.google.com/storage/browser/{gcs_path}/snapshots/catalog_inventory_report_{stamp}.json)")
+    body.append("- [Radar summary](../../data/radar/radar_summary.json)")
+
+    labels = ["catalog-alert"]
+    if regressions:
+        labels.append("catalog-regression")
+    if new_sources:
+        labels.append("catalog-new-source")
+    if recoveries:
+        labels.append("catalog-recovery")
+
+    Path("issue_title.txt").write_text(title, encoding="utf-8")
+    Path("issue_body.md").write_text("\n".join(body) + "\n", encoding="utf-8")
+    Path("issue_labels.json").write_text(json.dumps(labels), encoding="utf-8")
+    print(f"Title: {title}")
+    print(f"Labels: {labels}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--gcs-prefix", required=True, help="GCS prefix (es. gs://bucket/path)")
+    args = p.parse_args()
+    build_issue(args.gcs_prefix)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gha/build_issue_body.py
+++ b/scripts/gha/build_issue_body.py
@@ -21,8 +21,8 @@ def build_issue(gcs_prefix: str) -> None:
     diff_path = Path("diff.md")
     raw = diff_path.read_text(encoding="utf-8") if diff_path.exists() else ""
 
-    if raw == "NO_BASELINE":
-        print("No baseline — skipping issue creation.")
+    if raw.strip() in ("", "NO_BASELINE"):
+        print("Nessuna variazione o nessun baseline — skipping issue creation.")
         return
 
     new_report = json.loads(
@@ -43,7 +43,7 @@ def build_issue(gcs_prefix: str) -> None:
             recoveries = len(re.findall(r"^- `([^`]+)`", section_body, re.M))
         elif heading == "Nuove fonti rilevate":
             new_sources = len(re.findall(r"^- `([^`]+)`", section_body, re.M))
-        elif heading == "Fonti rimosse o non piu raggiungibili":
+        elif heading == "Fonti rimosse o non più raggiungibili":
             removed = len(re.findall(r"^- `([^`]+)`", section_body, re.M))
 
     total_items_new = sum(v.get("rows", 0) for v in new_report.get("sources", {}).values())

--- a/scripts/gha/publish_radar_summary.py
+++ b/scripts/gha/publish_radar_summary.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Publish radar summary to GITHUB_STEP_SUMMARY.
+
+Legge data/radar/radar_summary.json e scrive radar_summary.md.
+
+Uso:
+    python scripts/gha/publish_radar_summary.py
+    cat radar_summary.md >> $GITHUB_STEP_SUMMARY
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def main() -> None:
+    summary = json.loads(Path("data/radar/radar_summary.json").read_text(encoding="utf-8"))
+    counts = summary.get("status_counts", {})
+
+    lines = ["## Radar status", ""]
+    lines.append(f"- Fonti controllate: {summary.get('sources_total', '?')}")
+    for status, count in counts.items():
+        lines.append(f"- {status}: {count}")
+    if summary.get("persistent_red"):
+        lines.append("> [!WARNING]")
+        lines.append(f"> {summary['persistent_red']} fonti RED persistenti")
+        lines.append("")
+    for src in summary.get("sources", []):
+        flag = "⚠️" if src.get("red_streak", 0) >= 2 else "  "
+        lines.append(f"{flag} `{src['id']}` — {src['status']} | HTTP {src.get('http_code','-')} | {src.get('note','') or 'ok'}")
+
+    Path("radar_summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gha/publish_source_check_summary.py
+++ b/scripts/gha/publish_source_check_summary.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Publish source-check summary to GITHUB_STEP_SUMMARY.
+
+Legge data/catalog_inventory/generated/source_check_results.parquet
+e scrive source_check_summary.md.
+
+Uso:
+    python scripts/gha/publish_source_check_summary.py
+    cat source_check_summary.md >> $GITHUB_STEP_SUMMARY
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def main() -> None:
+    path = Path("data/catalog_inventory/generated/source_check_results.parquet")
+    df = pd.read_parquet(path)
+    candidates = int(df["intake_candidate"].sum()) if "intake_candidate" in df.columns else 0
+    reachable = int(df["reachable"].sum()) if "reachable" in df.columns else 0
+    total = len(df)
+    avg_score = df["intake_score"].mean() if "intake_score" in df.columns else 0
+
+    lines = ["## Source check results", ""]
+    lines.append(f"- Item in database: {total}")
+    if total:
+        lines.append(f"- Raggiungibili: {reachable} ({reachable/total*100:.0f}%)")
+    lines.append(f"- Intake candidates (score >= 40): {candidates}")
+    lines.append(f"- Score medio: {avg_score:.0f}")
+    lines.append("")
+    if "granularity" in df.columns:
+        lines.append("**Granularita:**")
+        for gran, n in df["granularity"].value_counts().items():
+            lines.append(f"- {gran}: {n}")
+
+    Path("source_check_summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Cosa cambia

### radar.yml (NUOVO) — daily 03:15
- Solo radar_check + commit radar state + summary
- 30 righe, nessuna dipendenza GCS
- Gira ogni giorno indipendentemente

### observatory.yml (RISCITTO) — lunedì 03:20
- Rimosso flag IS_INVENTORY_RUN (6 step condizionali eliminati)
- Rimosso merge incrementale source-check (--max-age-days, modified tracking)
- --max-items aumentato da 200 a 500
- Script inline (~130 righe Python in YAML) estratti in scripts/gha/

### scripts/gha/ (NUOVO)
- build_issue_body.py - costruisce issue catalog (ex inline)
- publish_radar_summary.py - summary radar (ex inline)
- publish_source_check_summary.py - summary source-check (ex inline)

## Vantaggi
- Radar ogni giorno in 30s senza rischi (non bloccato da inventory)
- Se source-check fallisce, inventory e' gia su GCS
- Zero condizionali nello YAML
- Script Python testabili con pytest

## Test
- 106/106 test passano
- YAML validato
- Script estratti testati localmente

Closes #222