### PR TITLE
chore: centralizzato retry HTTP in HttpClient (SDMX + radar + dead code)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ ddgs>=9.14.2,<10.0
 mcp>=1.27.1
 fastmcp>=3.2.4
 lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.6.0
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@a06005c1424bd381a63070058cb4beae463035c8
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@47924e0207152a6357d134f5863ccd66d8102353

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pyarrow>=24.0.0,<25.0
 ddgs>=9.14.2,<10.0
 mcp>=1.27.1
 fastmcp>=3.2.4
-lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.4.0
+lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.6.0
 dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@a06005c1424bd381a63070058cb4beae463035c8

--- a/scripts/_constants.py
+++ b/scripts/_constants.py
@@ -4,9 +4,6 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
-SDMX_RETRYABLE_STATUS_CODES = {500, 502, 503, 504}
-SDMX_RETRY_DELAYS_SECONDS = (2, 5)
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REGISTRY_PATH = REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
 CATALOG_INVENTORY_REPORT_PATH = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_report.json"

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -5,6 +5,8 @@ from typing import Any
 from datetime import datetime, timezone
 from urllib.parse import urlsplit, urlunsplit
 
+import requests
+
 
 USER_AGENT = "DataCivicLab-SourceObservatory/1.0"
 DEFAULT_TIMEOUT_SECONDS = 60

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -5,9 +5,6 @@ from typing import Any
 from datetime import datetime, timezone
 from urllib.parse import urlsplit, urlunsplit
 
-import requests
-from requests.adapters import HTTPAdapter
-
 
 USER_AGENT = "DataCivicLab-SourceObservatory/1.0"
 DEFAULT_TIMEOUT_SECONDS = 60
@@ -25,16 +22,6 @@ class CollectorResult:
 
 def now_utc_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-
-
-def get_pooled_session(pool_connections: int = 16, pool_maxsize: int = 32) -> requests.Session:
-    """Session with HTTPAdapter connection pooling — reuse across calls."""
-    session = requests.Session()
-    session.headers["User-Agent"] = USER_AGENT
-    adapter = HTTPAdapter(pool_connections=pool_connections, pool_maxsize=pool_maxsize)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    return session
 
 
 def observatory_get(

--- a/scripts/collectors/sdmx.py
+++ b/scripts/collectors/sdmx.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import time
-import requests
 import xml.etree.ElementTree as ET
 from typing import Any
 
-from .base import CollectorResult, observatory_get
-from _constants import SDMX_RETRYABLE_STATUS_CODES, SDMX_RETRY_DELAYS_SECONDS
+from lab_connectors.http import HttpClient
+
+from .base import CollectorResult
 
 
 def parse_sdmx_name(name_elem: ET.Element | None) -> str | None:
@@ -26,39 +25,21 @@ def _sdmx_api_base(url: str) -> str | None:
 
 
 def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> CollectorResult:
-    attempts = len(SDMX_RETRY_DELAYS_SECONDS) + 1
     endpoint = source_cfg["base_url"]
-    response: requests.Response | None = None
-    last_error: Exception | None = None
-    retry_events: list[str] = []
+    client = HttpClient(timeout=120, max_retries=3, retry_backoff=2.0)
+    result = client.get(endpoint)
 
-    for attempt in range(1, attempts + 1):
-        try:
-            response = observatory_get(endpoint, timeout=120)
-            response.raise_for_status()
-            break
-        except (requests.Timeout, requests.ConnectionError) as exc:
-            last_error = exc
-            retry_events.append(
-                f"tentativo {attempt}: {type(exc).__name__} ({endpoint})"
-            )
-        except requests.HTTPError as exc:
-            status_code = exc.response.status_code if exc.response is not None else None
-            if status_code not in SDMX_RETRYABLE_STATUS_CODES:
-                raise
-            last_error = exc
-            retry_events.append(f"tentativo {attempt}: HTTP {status_code} ({endpoint})")
+    if result.is_error:
+        raise RuntimeError(
+            f"SDMX fetch failed for {source_id} on {endpoint}: {result.err}"
+        ) from result.err
 
-        if attempt < attempts:
-            time.sleep(SDMX_RETRY_DELAYS_SECONDS[attempt - 1])
-        else:
-            details = ", ".join(retry_events) if retry_events else str(last_error)
-            raise RuntimeError(
-                f"SDMX fetch failed after {attempts} attempts for {source_id} on {endpoint}: {details}"
-            ) from last_error
-
-    if response is None:
-        raise RuntimeError(f"SDMX fetch produced no response for {source_id}")
+    response = result.response
+    if response.status_code >= 400:
+        raise RuntimeError(
+            f"SDMX endpoint returned HTTP {response.status_code} for {source_id}"
+            f" ({source_id}): {response.text[:200]}"
+        )
 
     try:
         root = ET.fromstring(response.content)
@@ -100,11 +81,4 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
                 "ordinal": idx,
             }
         )
-    warning = None
-    if retry_events:
-        warning = {
-            "type": "retry_backoff",
-            "message": "Recupero SDMX riuscito dopo retry con backoff.",
-            "events": retry_events,
-        }
-    return CollectorResult(rows=rows, warning=warning)
+    return CollectorResult(rows=rows)

--- a/scripts/collectors/sdmx.py
+++ b/scripts/collectors/sdmx.py
@@ -37,8 +37,8 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
     response = result.response
     if response.status_code >= 400:
         raise RuntimeError(
-            f"SDMX endpoint returned HTTP {response.status_code} for {source_id}"
-            f" ({source_id}): {response.text[:200]}"
+            f"SDMX endpoint returned HTTP {response.status_code} for {source_id}: "
+            f"{response.text[:200]}"
         )
 
     try:

--- a/scripts/collectors/sdmx.py
+++ b/scripts/collectors/sdmx.py
@@ -26,7 +26,7 @@ def _sdmx_api_base(url: str) -> str | None:
 
 def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> CollectorResult:
     endpoint = source_cfg["base_url"]
-    client = HttpClient(timeout=120, max_retries=3, retry_backoff=2.0)
+    client = HttpClient(timeout=120, max_retries=3)
     result = client.get(endpoint)
 
     if result.is_error:

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -6,15 +6,12 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 import json
-import time
 from pathlib import Path
 from typing import Any, Literal
 
 import requests
 
 from _constants import (
-    SDMX_RETRYABLE_STATUS_CODES,
-    SDMX_RETRY_DELAYS_SECONDS,
     REGISTRY_PATH,
     RADAR_SUMMARY_PATH,
     RADAR_HISTORY_PATH,
@@ -215,46 +212,8 @@ def probe_url(base_url: str) -> ProbeResult:
             )
         return result
 
-    # SDMX: retry on known intermittent status codes
-    last_result = None
-    for attempt, delay in enumerate([0, *SDMX_RETRY_DELAYS_SECONDS], start=1):
-        if delay > 0:
-            time.sleep(delay)
-        result = _probe_once(base_url)
-        last_result = result
-
-        # Success or non-retryable error: stop
-        if result.status == "GREEN":
-            return result
-        http_code = int(result.http_code) if result.http_code != "-" else 0
-        if http_code not in SDMX_RETRYABLE_STATUS_CODES:
-            if attempt > 1:
-                note = f"Retry dopo {attempt - 1} tentativi: {result.note or 'nessun dettaglio'}"
-                return ProbeResult(
-                    status=result.status,
-                    http_code=result.http_code,
-                    note=note,
-                    final_url=result.final_url,
-                    content_type=result.content_type,
-                )
-            return result
-
-    # All retries exhausted
-    if last_result:
-        note = (
-            f"SDMX retry esaurito ({len(SDMX_RETRY_DELAYS_SECONDS) + 1} tentativi): "
-            f"{last_result.note or 'nessun dettaglio'}"
-        )
-        return ProbeResult(
-            status=last_result.status,
-            http_code=last_result.http_code,
-            note=note,
-            final_url=last_result.final_url,
-            content_type=last_result.content_type,
-        )
-    return last_result or ProbeResult(
-        status="RED", http_code="-", note="SDMX probe fallito"
-    )
+    # SDMX: HttpClient handles retry with backoff internally
+    return _probe_once(base_url)
 
 
 def build_status_report(


### PR DESCRIPTION
## Cosa

Tre migrazioni di retry custom verso HttpClient:

1. **`collectors/sdmx.py`**: rimosso retry custom (3 tentativi con delay [2s, 5s], retry solo su {500,502,503,504}). Sostituito con `HttpClient(max_retries=3, retry_backoff=2.0)` che dà backoff 2s/4s su tutti i 5xx.

2. **`radar_check.py`**: rimosso SDMX retry loop con `SDMX_RETRY_DELAYS_SECONDS`. `_probe_once()` già usa `HttpClient.get()` con retry built-in — l'outer loop era ridondante.

3. **`_constants.py`**: rimosse `SDMX_RETRYABLE_STATUS_CODES` e `SDMX_RETRY_DELAYS_SECONDS` (non più usate).

4. **`base.py`**: rimosso `get_pooled_session()` — dead code, mai chiamato da nessun collector.

### Dimensione

- 4 file toccati, +20/-101 righe (netto -81)

## Issue collegate

Parte di dataciviclab/lab-connectors#10