### PR TITLE
feat(so): aggiungi AIFA al sources registry

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -368,10 +368,10 @@ opencivitas:
     value: 1084
     method: csv_magnet_area_pages_paginated
     reliability: medium
-    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback 
+    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback
       necessario per cert invalido.
   verdict: go
-  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL 
+  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL
     fallback attivo. ZIP con CSV/XLSX dentro.
   html_portal:
     topic_hint: trasparenza
@@ -380,4 +380,26 @@ opencivitas:
     page_max: 100
     page_stop_on_empty: true
     delay_seconds: 0.3
+  datasets_in_use: []
+aifa:
+  source_kind: catalog
+  protocol: html
+  observation_mode: catalog-watch
+  base_url: https://www.aifa.gov.it/dati-aifa
+  verdict: go
+  note: >
+    Portale Open Data AIFA — CSV scaricabili senza autenticazione.
+    Licenza CC-BY 4.0. Inventory via area_pages (sito principale ha
+    protezioni anti-bot). Dataset: liste farmaci, provvedimenti,
+    sperimentazioni cliniche, farmacovigilanza, incarichi, bandi.
+  html_portal:
+    topic_hint: sanita
+    area_pages:
+      - https://www.aifa.gov.it/web/guest/liste-dei-farmaci
+      - https://www.aifa.gov.it/web/guest/provvedimenti-aifa
+      - https://www.aifa.gov.it/web/guest/sperimentazioni-cliniche
+      - https://www.aifa.gov.it/web/guest/farmacovigilanza-open-data
+      - https://www.aifa.gov.it/web/guest/incarichi-e-consulenze
+      - https://www.aifa.gov.it/web/guest/bandi-di-gara-e-contratti-
+    delay_seconds: 0.5
   datasets_in_use: []


### PR DESCRIPTION
## Summary

- Aggiunta fonte **AIFA** (Agenzia Italiana del Farmaco) al `sources_registry.yaml`
- Protocollo `html` con 6 `area_pages` per inventory CSV magnet
- 42 item scoperti, 39 reachable (93%), 1 intake candidate (score 72)

## Dettagli

| Metrica | Valore |
|---|---|
| Area pages | 6 |
| Item totali | 42 |
| Reachable | 39/42 |
| Avg score | 33.3 |
| Max score | 72 (strutture_responsabili_farmacovigilanza) |
| Intake candidates | 1 |

## Area pages configurate

1. `liste-dei-farmaci` — 18 CSV (anagrafica farmaci, ATC, liste trasparenza, farmaci carenti, registri, orfani)
2. `provvedimenti-aifa` — 14 CSV (provvedimenti qualità 2016-2026, accordi PA-privati)
3. `sperimentazioni-cliniche` — 1 CSV + 3 ZIP
4. `farmacovigilanza-open-data` — 1 CSV
5. `incarichi-e-consulenze` — 3 CSV
6. `bandi-di-gara-e-contratti-` — 1 CSV + 1 XML

## Note

- Licenza CC-BY 4.0, nessun login richiesto
- Sito principale ha protezioni anti-bot → inventory via area_pages dirette
- I dataset farmaceutici più grandi (anagrafica 82MB, principi attivi 11MB) sono su `drive.aifa.gov.it` e vengono correttamente rilevati dalla pagina `liste-dei-farmaci`
- I dati OsMed (spesa farmaceutica regionale) sono nell'app interattiva, non in CSV scaricabili → non entrano nell'inventory automatico