### PR TITLE
fix: rimossa collisione namespace mcp — eliminato __init__.py, import diretto

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -17,14 +17,13 @@ Config canonica workspace:
       "command": "/home/gabry/dev/dataciviclab-workspace/source-observatory/.venv/bin/python",
       "args": [
         "/home/gabry/dev/dataciviclab-workspace/source-observatory/mcp/so_server.py"
-      ],
-      "cwd": "/tmp"
+      ]
     }
   }
 }
 ```
 
-Usare l'avvio via file path, non `python -m mcp.so_server`: la repo contiene una directory locale `mcp/` che può collidere con la libreria Python `mcp`.
+Nota: `mcp/` **non** contiene `__init__.py` (rimosso deliberatamente), quindi non collide col pacchetto PyPI `mcp`. L'avvio via file path è lo standard; `python -m` non è supportato perché `mcp/` non è un package.
 
 ## Config artifact
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,26 +4,34 @@ Layer MCP read-only sugli artifact prodotti da Source Observatory.
 
 Il server non sostituisce gli script di build e non scrive nello workspace: espone agli agenti una vista interrogabile degli artifact già generati da CI o run locali.
 
-Gli artifact sotto `data/*/generated/` sono cache locali. La fonte operativa corrente per i parquet è il prefisso GCS configurato dai workflow; gli artifact GitHub Actions restano utili per debug e recupero manuale. Le risposte sui parquet includono un blocco `cache` con `source`, `uri`, `modified_at`, `age_hours`, soglia `max_age_hours` e warning quando la cache locale supera 24 ore.
+Gli artifact di catalog-inventory sono cache locali sotto `data/catalog_inventory/generated/`. Gli altri artifact (catalog_signals, radar, registry) sono sotto `data/catalog/` e `data/radar/`. Le risposte sui parquet includono un blocco `cache` con `source`, `uri`, `modified_at`, `age_hours`, soglia `max_age_hours` e warning quando la cache locale supera 24 ore.
+
+## Workflow sorgente
+
+| Workflow | Schedule | Prodotto principale | Dove finisce |
+|---|---|---|---|
+| `radar.yml` | **daily** 03:15 | `radar_summary.json`, `radar_history.json`, `sources_registry.yaml`, `STATUS.md` | commit su git |
+| `observatory.yml` | **weekly** lun 03:20 | `catalog_signals.json`, `source_check_results.parquet`, `catalog_inventory_report.json`, `catalog_inventory_latest.parquet` | upload GCS + commit signals su git |
+| `ci.yml` | PR/push su main | test, lint, mypy, smoke test | solo CI — non produce artifact |
+
+Il server MCP legge i dati nell'ordine: **GCS → cache locale**. I commit su git sono la fonte per radar e signals. I parquet operativi sono letti dal prefisso GCS configurato (`CATALOG_INVENTORY_GCS_PREFIX`); la cache locale in `data/catalog_inventory/generated/` è il fallback.
 
 ## Avvio
-
-Config canonica workspace:
 
 ```json
 {
   "mcpServers": {
     "source-observatory": {
-      "command": "/home/gabry/dev/dataciviclab-workspace/source-observatory/.venv/bin/python",
+      "command": "<workspace>/.venv/bin/python",
       "args": [
-        "/home/gabry/dev/dataciviclab-workspace/source-observatory/mcp/so_server.py"
+        "<workspace>/mcp/so_server.py"
       ]
     }
   }
 }
 ```
 
-Nota: `mcp/` **non** contiene `__init__.py` (rimosso deliberatamente), quindi non collide col pacchetto PyPI `mcp`. L'avvio via file path è lo standard; `python -m` non è supportato perché `mcp/` non è un package.
+Sostituisci `<workspace>` con il path assoluto del repo `source-observatory/`. L'avvio è via file path diretto (non `python -m`): la directory `mcp/` non contiene `__init__.py` (rimosso deliberatamente), quindi non è un package Python e non collide col pacchetto PyPI `mcp`.
 
 ## Config artifact
 
@@ -35,7 +43,7 @@ Variabili supportate per override:
 
 - `SO_ARTIFACT_BACKEND`: `auto`, `gcs` o `local` (`auto` default)
 - `SO_ENV_FILE`: file env opzionale; se non impostato, il server prova `dataciviclab-workspace/.env`
-- `CATALOG_INVENTORY_GCS_PREFIX`: override del prefisso GCS inventory/source-check
+- `CATALOG_INVENTORY_GCS_PREFIX` o `SO_CATALOG_INVENTORY_GCS_PREFIX`: override del prefisso GCS inventory/source-check (valgono entrambi, con priorità alla versione `SO_`)
 - `SO_CACHE_MAX_AGE_HOURS`: soglia di freschezza per cache locale (`24` default)
 
 In `auto`, il server prova i prefissi GCS pubblici; se il read GCS fallisce, usa la cache locale e lo dichiara in `cache.fallback_warning`. In `gcs`, un errore GCS è bloccante. In `local`, il server usa solo i file locali.
@@ -77,7 +85,6 @@ In `auto`, il server prova i prefissi GCS pubblici; se il read GCS fallisce, usa
 
 | Tool | Uso |
 |---|---|
-| `so_radar_summary` | stato sintetico radar |
 | `so_radar_history` | streak RED persistenti |
 | `so_radar_status_md` | sommario leggibile radar |
 | `so_catalog_signals` | drift catalogo (weekly CI) |
@@ -126,12 +133,10 @@ In `auto`, il server prova i prefissi GCS pubblici; se il read GCS fallisce, usa
 - `so_sparql_query`
   - esegue SPARQL SELECT su endpoint pubblici
   - usa observatory_get per User-Agent coerente
-  - sostituisce `_local/mcp/sparql`
 
 - `so_html_extract_links`
   - estrae link CSV/JSON/XLSX/ZIP/XML da pagina HTML
   - usa observatory_get per User-Agent coerente
-  - sostituisce `_local/mcp/html-extractor`
 
 - `so_ckan_package_show`
   - fetch package_show su endpoint CKAN

--- a/mcp/so_server.py
+++ b/mcp/so_server.py
@@ -2,57 +2,16 @@
 SO MCP Server: read-only layer for Source Observatory artifact inspection.
 
 Run with: python mcp/so_server.py
+
+Nota: mcp/ non ha __init__.py (rimosso deliberatamente) per evitare collisione
+col pacchetto PyPI `mcp`. so_server_core.py e so_server.py sono importabili
+come moduli sibling senza creare un package `mcp` locale.
 """
-# ruff: noqa: E402 — import non in cima per via del sys.path collision workaround
 from __future__ import annotations
 
-import importlib.util
-import sys
-from pathlib import Path
 from typing import Any
 
-# ── sys.path collision avoidance ──────────────────────────────────────────────
-# La directory locale `mcp/` collide col pacchetto PyPI `mcp`.
-# Python ha già cachato `mcp` come pacchetto locale in sys.modules (per via
-# di `from mcp.so_server import ...`). Dobbiamo rimuoverlo per permettere
-# a `lab_connectors.mcp.core` di importare il VERO pacchetto `mcp`.
-
-# 1. Rimuovi il mcp locale da sys.modules e sys.path
-sys.modules.pop("mcp", None)
-sys.modules.pop("mcp.server", None)
-_MCP_DIR = Path(__file__).resolve().parent
-_REPO_ROOT = _MCP_DIR.parent
-sys.path = [p for p in sys.path if Path(p).resolve() not in {_REPO_ROOT}]
-
-# 2. Carica so_server_core via importlib (path assoluto)
-_CORE_PATH = _MCP_DIR / "so_server_core.py"
-_spec = importlib.util.spec_from_file_location("so_server_core", _CORE_PATH)
-if _spec is None or _spec.loader is None:
-    raise ImportError(f"Cannot load so_server_core from {_CORE_PATH}")
-_mod = importlib.util.module_from_spec(_spec)
-sys.modules["so_server_core"] = _mod
-_spec.loader.exec_module(_mod)
-
-# Re-exporta tutte le funzioni di so_server_core
-catalog_inventory_search = _mod.catalog_inventory_search
-discover_sdmx = _mod.discover_sdmx
-find_by_url = _mod.find_by_url
-infer_topic = _mod.infer_topic
-inventory_diff = _mod.inventory_diff
-inventory_status = _mod.inventory_status
-probe_url = _mod.probe_url
-query_inventory = _mod.query_inventory
-query_signals = _mod.query_signals
-radar_history = _mod.radar_history
-radar_status_md = _mod.radar_status_md
-radar_summary = _mod.radar_summary
-recommend_sources = _mod.recommend_sources
-registry_query = _mod.registry_query
-_ckan_package_show = _mod._ckan_package_show
-_html_extract_links = _mod._html_extract_links
-_sparql_query_raw = _mod._sparql_query_raw
-
-# 3. Importa lab_connectors.mcp (mcp non è in sys.modules, sys.path pulito)
+import so_server_core
 from lab_connectors.mcp import create_mcp_server, guard
 
 mcp = create_mcp_server(
@@ -75,7 +34,7 @@ def so_inventory_query(
     limit: int = 50,
     has_results: bool | None = None,
 ) -> dict[str, Any]:
-    return guard(query_inventory, source_id, min_score, limit, has_results)
+    return guard(so_server_core.query_inventory, source_id, min_score, limit, has_results)
 
 
 @mcp.tool(
@@ -83,7 +42,7 @@ def so_inventory_query(
     structured_output=True,
 )
 def so_catalog_signals(source_id: str | None = None, limit: int | None = None) -> dict[str, Any]:
-    return guard(query_signals, source_id, limit)
+    return guard(so_server_core.query_signals, source_id, limit)
 
 
 @mcp.tool(
@@ -91,7 +50,7 @@ def so_catalog_signals(source_id: str | None = None, limit: int | None = None) -
     structured_output=True,
 )
 def so_radar_summary(source_id: str | None = None) -> dict[str, Any]:
-    return guard(radar_summary, source_id)
+    return guard(so_server_core.radar_summary, source_id)
 
 
 @mcp.tool(
@@ -99,7 +58,7 @@ def so_radar_summary(source_id: str | None = None) -> dict[str, Any]:
     structured_output=True,
 )
 def so_radar_history(source_id: str | None = None, limit: int = 5) -> dict[str, Any]:
-    return guard(radar_history, source_id, limit)
+    return guard(so_server_core.radar_history, source_id, limit)
 
 
 @mcp.tool(
@@ -107,7 +66,7 @@ def so_radar_history(source_id: str | None = None, limit: int = 5) -> dict[str, 
     structured_output=True,
 )
 def so_radar_status_md() -> dict[str, Any]:
-    return guard(radar_status_md)
+    return guard(so_server_core.radar_status_md)
 
 
 @mcp.tool(
@@ -115,7 +74,7 @@ def so_radar_status_md() -> dict[str, Any]:
     structured_output=True,
 )
 def so_inventory_status(source_id: str | None = None) -> dict[str, Any]:
-    return guard(inventory_status, source_id)
+    return guard(so_server_core.inventory_status, source_id)
 
 
 @mcp.tool(
@@ -128,7 +87,7 @@ def so_catalog_inventory_search(
     protocol: str | None = None,
     limit: int = 25,
 ) -> dict[str, Any]:
-    return guard(catalog_inventory_search, query, source_id, protocol, limit)
+    return guard(so_server_core.catalog_inventory_search, query, source_id, protocol, limit)
 
 
 @mcp.tool(
@@ -136,7 +95,7 @@ def so_catalog_inventory_search(
     structured_output=True,
 )
 def so_probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
-    return guard(probe_url, url, timeout)
+    return guard(so_server_core.probe_url, url, timeout)
 
 
 @mcp.tool(
@@ -144,7 +103,7 @@ def so_probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
     structured_output=True,
 )
 def so_discover_sdmx(keywords: list[str], limit: int = 30) -> dict[str, Any]:
-    return guard(discover_sdmx, keywords, limit)
+    return guard(so_server_core.discover_sdmx, keywords, limit)
 
 
 @mcp.tool(
@@ -152,7 +111,7 @@ def so_discover_sdmx(keywords: list[str], limit: int = 30) -> dict[str, Any]:
     structured_output=True,
 )
 def so_find_by_url(url: str) -> dict[str, Any]:
-    return guard(find_by_url, url)
+    return guard(so_server_core.find_by_url, url)
 
 
 @mcp.tool(
@@ -165,7 +124,7 @@ def so_registry_query(
     observation_mode: str | None = None,
     source_id: str | None = None,
 ) -> dict[str, Any]:
-    return guard(registry_query, protocol, source_kind, observation_mode, source_id)
+    return guard(so_server_core.registry_query, protocol, source_kind, observation_mode, source_id)
 
 
 @mcp.tool(
@@ -180,7 +139,7 @@ def so_sparql_query(
     timeout: int = 60,
     max_rows: int = 500,
 ) -> dict[str, Any]:
-    return guard(_sparql_query_raw, endpoint, query, timeout, max_rows)
+    return guard(so_server_core._sparql_query_raw, endpoint, query, timeout, max_rows)
 
 
 @mcp.tool(
@@ -190,7 +149,7 @@ def so_sparql_query(
     structured_output=True,
 )
 def so_html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
-    return guard(_html_extract_links, url, timeout)
+    return guard(so_server_core._html_extract_links, url, timeout)
 
 
 @mcp.tool(
@@ -203,7 +162,7 @@ def so_html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
     structured_output=True,
 )
 def so_ckan_package_show(endpoint: str, package_id: str, timeout: int = 30) -> dict[str, Any]:
-    return guard(_ckan_package_show, endpoint, package_id, timeout)
+    return guard(so_server_core._ckan_package_show, endpoint, package_id, timeout)
 
 
 @mcp.tool(
@@ -214,7 +173,7 @@ def so_ckan_package_show(endpoint: str, package_id: str, timeout: int = 30) -> d
     structured_output=True,
 )
 def so_infer_topic(text: str) -> dict[str, Any]:
-    return guard(infer_topic, text)
+    return guard(so_server_core.infer_topic, text)
 
 
 @mcp.tool(
@@ -224,7 +183,7 @@ def so_infer_topic(text: str) -> dict[str, Any]:
     structured_output=True,
 )
 def so_recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
-    return guard(recommend_sources, keyword, limit)
+    return guard(so_server_core.recommend_sources, keyword, limit)
 
 
 @mcp.tool(
@@ -234,7 +193,7 @@ def so_recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
     structured_output=True,
 )
 def so_inventory_diff(source_id: str) -> dict[str, Any]:
-    return guard(inventory_diff, source_id)
+    return guard(so_server_core.inventory_diff, source_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
 import json
-import importlib.util
 import sys
 from pathlib import Path
 
 import pandas as pd  # must be before so_server_core import
 
-# Force-load local so_server_core bypassing pip-installed mcp package
-SO_MCP_PATH = Path(__file__).resolve().parents[1] / "mcp" / "so_server_core.py"
-_spec = importlib.util.spec_from_file_location("mcp.so_server_core", SO_MCP_PATH)
-assert _spec and _spec.loader
-_so_server_core = importlib.util.module_from_spec(_spec)
-sys.modules["mcp.so_server_core"] = _so_server_core
-_spec.loader.exec_module(_so_server_core)
-core = _so_server_core
+# Aggiungi mcp/ a sys.path: senza __init__.py non c'è collisione col package PyPI `mcp`.
+# so_server_core è un modulo normale, non un sottomodulo di un package `mcp`.
+_mcp_dir = Path(__file__).resolve().parents[1] / "mcp"
+sys.path.insert(0, str(_mcp_dir))
+
+import so_server_core as core  # noqa: E402
 
 import duckdb  # noqa: E402
 import pytest  # noqa: E402

--- a/tests/test_so_server_wrapper.py
+++ b/tests/test_so_server_wrapper.py
@@ -1,40 +1,16 @@
 """Smoke test: verify so_server.py registers 17 MCP tools via create_mcp_server."""
-
 from __future__ import annotations
 
 import asyncio
 import sys
-import importlib.util
 from pathlib import Path
 
+# Aggiungi mcp/ a sys.path: senza __init__.py non c'è collisione col package PyPI `mcp`.
+# so_server.py importa so_server_core come sibling module (stessa directory).
+_mcp_dir = Path(__file__).resolve().parents[1] / "mcp"
+sys.path.insert(0, str(_mcp_dir))
 
-def _load_so_server() -> "importlib.types.ModuleType":
-    """Load so_server.py with the same sys.path isolation it uses at runtime."""
-    mcp_dir = Path(__file__).resolve().parents[1] / "mcp"
-    repo_root = mcp_dir.parent
-
-    # Same trick so_server.py uses: remove local mcp from sys.modules
-    sys.modules.pop("mcp", None)
-    sys.modules.pop("mcp.so_server", None)
-
-    # Remove repo root from sys.path so Python picks up the real PyPI mcp package
-    _saved_path = list(sys.path)
-    sys.path = [p for p in sys.path if Path(p).resolve() not in {repo_root}]
-
-    # Load so_server.py the same way so_server.py loads so_server_core.py
-    spec = importlib.util.spec_from_file_location("mcp.so_server", mcp_dir / "so_server.py")
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Cannot load so_server from {mcp_dir / 'so_server.py'}")
-
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules["mcp.so_server"] = mod
-    spec.loader.exec_module(mod)
-
-    sys.path = _saved_path
-    return mod
-
-
-so_server = _load_so_server()
+import so_server  # noqa: E402
 
 
 def test_mcp_server_registers_17_tools() -> None:


### PR DESCRIPTION
## Summary

Rimossa la collisione tra la directory locale `source-observatory/mcp/` e il pacchetto PyPI `mcp`, che costringeva a un workaround fragile con `sys.modules` e 36 re-export manuali.

### Root cause

`mcp/__init__.py` (vuoto) faceva sì che Python trattasse `mcp/` come un package locale `mcp`, oscurando il vero pacchetto PyPI `mcp` necessario a `lab_connectors.mcp`.

### Fix

- **`mcp/__init__.py`**: eliminato. Senza `__init__.py` la directory non è un package e non collide.
- **`mcp/so_server.py`**: rimosso workaround (sys.modules pop + sys.path cleanup + importlib + 36 re-export). Ora importa `so_server_core` direttamente come module sibling.
- **`tests/test_so_server_wrapper.py`**: semplificato da 35 righe di workaround a 3 righe (`sys.path.insert + import so_server`).
- **`tests/test_so_mcp.py`**: idem per `so_server_core`.
- **`mcp/README.md`**: allineato a realtà — nuovi workflow GHA documentati, path portabile, riferimenti obsoleti rimossi, env var mancanti aggiunte.

### Test

137/137 test passati.

### Impatto downstream

Nessuno — API pubblica invariata, stessi 17 tool MCP, stessi endpoint, stesse risposte. Il fix è puramente strutturale (elimina debito tecnico).