### PR TITLE
fix: MCP audit gaps (6/8) + guard→guard_timed migration

### DIFF
--- a/mcp/so_server.py
+++ b/mcp/so_server.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any
 
 import so_server_core
-from lab_connectors.mcp import create_mcp_server, guard
+from lab_connectors.mcp import create_mcp_server, guard_timed
 
 mcp = create_mcp_server(
     name="source-observatory",
@@ -34,7 +34,7 @@ def so_inventory_query(
     limit: int = 50,
     has_results: bool | None = None,
 ) -> dict[str, Any]:
-    return guard(so_server_core.query_inventory, source_id, min_score, limit, has_results)
+    return guard_timed(so_server_core.query_inventory, "so_inventory_query", source_id, min_score, limit, has_results, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -42,7 +42,7 @@ def so_inventory_query(
     structured_output=True,
 )
 def so_catalog_signals(source_id: str | None = None, limit: int | None = None) -> dict[str, Any]:
-    return guard(so_server_core.query_signals, source_id, limit)
+    return guard_timed(so_server_core.query_signals, "so_catalog_signals", source_id, limit, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -50,7 +50,7 @@ def so_catalog_signals(source_id: str | None = None, limit: int | None = None) -
     structured_output=True,
 )
 def so_radar_summary(source_id: str | None = None) -> dict[str, Any]:
-    return guard(so_server_core.radar_summary, source_id)
+    return guard_timed(so_server_core.radar_summary, "so_radar_summary", source_id, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -58,7 +58,7 @@ def so_radar_summary(source_id: str | None = None) -> dict[str, Any]:
     structured_output=True,
 )
 def so_radar_history(source_id: str | None = None, limit: int = 5) -> dict[str, Any]:
-    return guard(so_server_core.radar_history, source_id, limit)
+    return guard_timed(so_server_core.radar_history, "so_radar_history", source_id, limit, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -66,7 +66,7 @@ def so_radar_history(source_id: str | None = None, limit: int = 5) -> dict[str, 
     structured_output=True,
 )
 def so_radar_status_md() -> dict[str, Any]:
-    return guard(so_server_core.radar_status_md)
+    return guard_timed(so_server_core.radar_status_md, "so_radar_status_md", logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -74,7 +74,7 @@ def so_radar_status_md() -> dict[str, Any]:
     structured_output=True,
 )
 def so_inventory_status(source_id: str | None = None) -> dict[str, Any]:
-    return guard(so_server_core.inventory_status, source_id)
+    return guard_timed(so_server_core.inventory_status, "so_inventory_status", source_id, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -87,7 +87,7 @@ def so_catalog_inventory_search(
     protocol: str | None = None,
     limit: int = 25,
 ) -> dict[str, Any]:
-    return guard(so_server_core.catalog_inventory_search, query, source_id, protocol, limit)
+    return guard_timed(so_server_core.catalog_inventory_search, "so_catalog_inventory_search", query, source_id, protocol, limit, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -95,7 +95,7 @@ def so_catalog_inventory_search(
     structured_output=True,
 )
 def so_probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
-    return guard(so_server_core.probe_url, url, timeout)
+    return guard_timed(so_server_core.probe_url, "so_probe_url", url, timeout, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -103,15 +103,16 @@ def so_probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
     structured_output=True,
 )
 def so_discover_sdmx(keywords: list[str], limit: int = 30) -> dict[str, Any]:
-    return guard(so_server_core.discover_sdmx, keywords, limit)
+    return guard_timed(so_server_core.discover_sdmx, "so_discover_sdmx", keywords, limit, logger_name="source-observatory")
 
 
 @mcp.tool(
-    description="Cerca un URL in source_check_results.parquet e catalog_inventory_latest.parquet per vedere se e' gia' catalogato.",
+    description="Cerca un URL o testo in source_check_results (colonne URL) e catalog_inventory_latest (URL + item_name, item_id, title, notes_excerpt). "
+    "Usa LIKE %query% — utile per trovare item per URL, filename, ID o nome.",
     structured_output=True,
 )
 def so_find_by_url(url: str) -> dict[str, Any]:
-    return guard(so_server_core.find_by_url, url)
+    return guard_timed(so_server_core.find_by_url, "so_find_by_url", url, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -124,7 +125,7 @@ def so_registry_query(
     observation_mode: str | None = None,
     source_id: str | None = None,
 ) -> dict[str, Any]:
-    return guard(so_server_core.registry_query, protocol, source_kind, observation_mode, source_id)
+    return guard_timed(so_server_core.registry_query, "so_registry_query", protocol, source_kind, observation_mode, source_id, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -139,7 +140,7 @@ def so_sparql_query(
     timeout: int = 60,
     max_rows: int = 500,
 ) -> dict[str, Any]:
-    return guard(so_server_core._sparql_query_raw, endpoint, query, timeout, max_rows)
+    return guard_timed(so_server_core._sparql_query_raw, "so_sparql_query", endpoint, query, timeout, max_rows, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -149,7 +150,7 @@ def so_sparql_query(
     structured_output=True,
 )
 def so_html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
-    return guard(so_server_core._html_extract_links, url, timeout)
+    return guard_timed(so_server_core._html_extract_links, "so_html_extract_links", url, timeout, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -162,18 +163,19 @@ def so_html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
     structured_output=True,
 )
 def so_ckan_package_show(endpoint: str, package_id: str, timeout: int = 30) -> dict[str, Any]:
-    return guard(so_server_core._ckan_package_show, endpoint, package_id, timeout)
+    return guard_timed(so_server_core._ckan_package_show, "so_ckan_package_show", endpoint, package_id, timeout, logger_name="source-observatory")
 
 
 @mcp.tool(
     description="Infer thematic topics from any text string (item_name, title, tags, notes, etc.). "
-    "Uses a fixed taxonomy of 13 topics: lavoro, economia, sanita, istruzione, trasporti, "
-    "ambiente, agricoltura, turismo, giustizia, demografia, energia, commercio. "
+    "Uses a fixed taxonomy of 20 topics: lavoro, economia, sanita, istruzione, trasporti, "
+    "ambiente, agricoltura, turismo, giustizia, demografia, energia, commercio, "
+    "welfare, previdenza, casa, cultura, bilancio, innovazione, sicurezza. "
     "Returns topics sorted by relevance score (desc), with top_match if dominant (score>=3).",
     structured_output=True,
 )
 def so_infer_topic(text: str) -> dict[str, Any]:
-    return guard(so_server_core.infer_topic, text)
+    return guard_timed(so_server_core.infer_topic, "so_infer_topic", text, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -183,7 +185,7 @@ def so_infer_topic(text: str) -> dict[str, Any]:
     structured_output=True,
 )
 def so_recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
-    return guard(so_server_core.recommend_sources, keyword, limit)
+    return guard_timed(so_server_core.recommend_sources, "so_recommend_sources", keyword, limit, logger_name="source-observatory")
 
 
 @mcp.tool(
@@ -193,7 +195,7 @@ def so_recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
     structured_output=True,
 )
 def so_inventory_diff(source_id: str) -> dict[str, Any]:
-    return guard(so_server_core.inventory_diff, source_id)
+    return guard_timed(so_server_core.inventory_diff, "so_inventory_diff", source_id, logger_name="source-observatory")
 
 
 if __name__ == "__main__":

--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -108,14 +108,30 @@ def _ckan_package_show(endpoint: str, package_id: str, timeout: int = 30) -> dic
     try:
         payload = _ckan_get_json(api_url, params=params, timeout=timeout)
     except Exception as exc:
-        return {"error": type(exc).__name__, "message": str(exc)[:200]}
+        return {
+            "error": type(exc).__name__,
+            "message": str(exc)[:200],
+            "tried_url": api_url,
+            "package_id": package_id,
+        }
 
     if not payload.get("success"):
-        return {"error": "ckan_error", "message": f"success=false for {package_id}"}
+        return {
+            "error": "ckan_error",
+            "message": f"success=false for {package_id}",
+            "tried_url": api_url,
+            "package_id": package_id,
+            "ckan_response": payload.get("error") or payload,
+        }
 
     item = payload.get("result")
     if not isinstance(item, dict):
-        return {"error": "ckan_error", "message": f"result non-dict for {package_id}"}
+        return {
+            "error": "ckan_error",
+            "message": f"result non-dict for {package_id}",
+            "tried_url": api_url,
+            "package_id": package_id,
+        }
 
     # Organization
     organization = (item.get("organization") or {}).get("title") or (
@@ -194,6 +210,14 @@ _FORMAT_BY_CONTENT_TYPE = {
     "text/xml": "XML",
     "application/pdf": "PDF",
     "application/parquet": "PARQUET",
+    "text/html": "HTML",
+    "text/plain": "TXT",
+    "application/octet-stream": "BIN",
+    "text/tab-separated-values": "TSV",
+    "application/gzip": "GZ",
+    "application/zip": "ZIP",
+    "application/x-tar": "TAR",
+    "application/vnd.oasis.opendocument.spreadsheet": "ODS",
 }
 _FORMAT_BY_SUFFIX = {
     ".csv": "CSV",
@@ -712,7 +736,7 @@ def find_by_url(url: str) -> dict[str, Any]:
                         f"lower(coalesce(cast({c} as varchar), '')) LIKE ?"
                         for c in url_cols
                     )
-                    like = f"%{clean_url}%"
+                    like = f"%{clean_url.lower()}%"
                     sql = f'SELECT * FROM "{parquet_path}" WHERE {where} LIMIT 10'
                     rows = con.execute(sql, [like] * len(url_cols)).fetchall()
                     results["source_check_results"] = [dict(zip(cols, row)) for row in rows]
@@ -726,17 +750,22 @@ def find_by_url(url: str) -> dict[str, Any]:
             parquet_path = str(resolved_path)
             with safe_connect() as con:
                 cols = _table_columns(con, parquet_path)
-                url_cols = [c for c in cols if c in ("url", "url_checked", "distribution_url", "landing_page", "source_url")]
-                if not url_cols:
-                    results["catalog_inventory_error"] = "No URL columns found in parquet"
+                # Search URL columns + descriptive columns for better match coverage
+                search_cols = [
+                    c for c in cols
+                    if c in ("url", "url_checked", "distribution_url", "landing_page",
+                             "source_url", "item_name", "item_id", "title", "notes_excerpt")
+                ]
+                if not search_cols:
+                    results["catalog_inventory_error"] = "No searchable columns found in parquet"
                 else:
                     where = " OR ".join(
                         f"lower(coalesce(cast({c} as varchar), '')) LIKE ?"
-                        for c in url_cols
+                        for c in search_cols
                     )
-                    like = f"%{clean_url}%"
+                    like = f"%{clean_url.lower()}%"
                     sql = f'SELECT * FROM "{parquet_path}" WHERE {where} LIMIT 10'
-                    rows = con.execute(sql, [like] * len(url_cols)).fetchall()
+                    rows = con.execute(sql, [like] * len(search_cols)).fetchall()
                     results["catalog_inventory"] = [dict(zip(cols, row)) for row in rows]
                     results["catalog_inventory_cache"] = cache
     except FileNotFoundError:
@@ -1243,6 +1272,13 @@ _TOPIC_KEYWORDS = {
     "demografia": ["demografia", "popolazione", "natalita", "mortalita", "migrazioni", "invecchiamento", "indice_vecchiaia"],
     "energia": ["energia", "elettricita", "gas", "petrolio", "rinnovabili", "consumi_energetici"],
     "commercio": ["commercio", "export", "import", "interscambio", "merci", " esport", "import"],
+    "welfare": ["assistenza", "sussidi", "poverta", "esclusione", "inclusione", "bonus", "assegno", "sostegno", "nucleo_familiare", "ISEE", "handicap", "invalidita", "non_autosufficienza"],
+    "previdenza": ["pensione", "pensioni", "previdenza", "contributi", "pensionistico", "anzianita", "vecchiaia", "reversibilita", "quota"],
+    "casa": ["casa", "edilizia", "alloggi", "residenziale", "affitto", "proprieta", "catasto", "immobiliare", "mutuo", "sfratti"],
+    "cultura": ["cultura", "musei", "biblioteche", "patrimonio", "artistico", "archeologico", "monumenti", "spettacolo", "mostre"],
+    "bilancio": ["bilancio", "fiscalita", "tasse", "imposte", "tributi", "gettito", "spesa_pubblica", "debito", "entrate", "erariale", "IRPEF", "IVA", "IRES"],
+    "innovazione": ["innovazione", "digitale", "digitalizzaz", "tecnologia", "ICT", "banda_larga", "PA_digitale", "startup", "ricerca_sviluppo", "smart_city", "open_data", "interoperabilita"],
+    "sicurezza": ["sicurezza", "protezione_civile", "emergenza", "rischio", "prevenzione", "ordine_pubblico", "forze_ordine", "polizia", "vigili_fuoco", "protezione", "soccorso"],
 }
 
 
@@ -1270,9 +1306,10 @@ def _score_text_by_topics(text: str) -> dict[str, int]:
 def infer_topic(text: str) -> dict[str, Any]:
     """Infer thematic topics from any text string.
 
-    Matches against a fixed taxonomy of 13 topics (lavoro, economia, sanita,
+    Matches against a fixed taxonomy of 20 topics: lavoro, economia, sanita,
     istruzione, trasporti, ambiente, agricoltura, turismo, giustizia,
-    demografia, energia, commercio).
+    demografia, energia, commercio, welfare, previdenza, casa, cultura,
+    bilancio, innovazione, sicurezza.
     Returns topics sorted by relevance score (desc), with scores.
     Also returns top_match if a dominant topic exists (score >= 3).
     """
@@ -1318,6 +1355,11 @@ def recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
         artifact = _catalog_inventory_parquet()
         with _resolved_parquet(artifact) as (resolved_path, cache):
             with safe_connect() as con:
+                total_row = con.execute(
+                    f'SELECT COUNT(*) FROM "{resolved_path}"'
+                ).fetchone()
+                total_items = total_row[0] if total_row else 0
+
                 rows = con.execute(
                     f'''
                     SELECT source_id, source_kind, protocol,
@@ -1348,8 +1390,31 @@ def recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
         "filters": {"limit": safe_limit},
         "sources": sources,
         "returned": len(sources),
+        "total_items_in_inventory": total_items,
         "cache": cache,
     }
+
+
+def _source_radar_context(source_id: str) -> str | None:
+    """Check radar_summary.json for source context (health, days_red)."""
+    if not _RADAR_JSON.exists():
+        return None
+    try:
+        with _RADAR_JSON.open(encoding="utf-8") as fh:
+            radar = json.load(fh)
+        sources = radar.get("sources") or {}
+        info = sources.get(source_id)
+        if not info:
+            return None
+        health = info.get("health", "unknown")
+        days_red = info.get("days_red")
+        if days_red and health == "RED":
+            return f"RED da {days_red} giorni, inventories non generati"
+        if health == "RED":
+            return "RED (nessun inventory generato)"
+        return f"health={health}"
+    except Exception:
+        return None
 
 
 # ─── Inventory Diff (read-only, on-demand) ──────────────────────────────────
@@ -1376,10 +1441,16 @@ def inventory_diff(source_id: str) -> dict[str, Any]:
 
     source_info = (report.get("sources") or {}).get(source_id)
     if not source_info:
+        # Check radar for context: maybe source is RED and has no inventory
+        radar_ctx = _source_radar_context(source_id)
+        msg = f"source_id '{source_id}' not found in inventory report"
+        if radar_ctx:
+            msg += f". Radar: {radar_ctx}"
         return {
             "error": "source_not_in_report",
-            "message": f"source_id '{source_id}' not found in inventory report",
+            "message": msg,
             "source_id": source_id,
+            "radar_context": radar_ctx,
         }
 
     baseline = source_info.get("catalog_baseline", {})
@@ -1400,6 +1471,13 @@ def inventory_diff(source_id: str) -> dict[str, Any]:
 
     delta = (current_count or 0) - (baseline_value or 0)
 
+    notes: list[str] = []
+    if not baseline_date:
+        notes.append("baseline_date non disponibile — report non contiene captured_at o last_inventory per questa fonte")
+    if not baseline_value:
+        notes.append("baseline_value non disponibile — delta non calcolabile; current_count è il primo inventario")
+    notes.append("delta calcolato vs baseline nel registry; verificare se baseline_value è aggiornato")
+
     return {
         "source_id": source_id,
         "baseline_date": baseline_date,
@@ -1408,7 +1486,7 @@ def inventory_diff(source_id: str) -> dict[str, Any]:
         "delta": delta,
         "delta_pct": round((delta / baseline_value * 100), 1) if baseline_value else None,
         "cache": cache,
-        "note": "delta calcolato vs baseline nel registry; verificare se baseline_value è aggiornato",
+        "note": " | ".join(notes),
     }
 
 

--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -1396,23 +1396,33 @@ def recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
 
 
 def _source_radar_context(source_id: str) -> str | None:
-    """Check radar_summary.json for source context (health, days_red)."""
+    """Check radar_summary.json for source context (status, red_streak).
+
+    Schema reale di radar_summary.json::
+
+        {"sources": [{"id": "dati_salute", "status": "RED",
+                      "red_streak": 14, ...}, ...]}
+    """
     if not _RADAR_JSON.exists():
         return None
     try:
         with _RADAR_JSON.open(encoding="utf-8") as fh:
             radar = json.load(fh)
-        sources = radar.get("sources") or {}
-        info = sources.get(source_id)
+        sources_list = radar.get("sources") or []
+        info = None
+        for s in sources_list:
+            if isinstance(s, dict) and s.get("id") == source_id:
+                info = s
+                break
         if not info:
             return None
-        health = info.get("health", "unknown")
-        days_red = info.get("days_red")
-        if days_red and health == "RED":
-            return f"RED da {days_red} giorni, inventories non generati"
-        if health == "RED":
+        status = info.get("status", "unknown")
+        red_streak = info.get("red_streak")
+        if red_streak and status == "RED":
+            return f"RED da {red_streak} giorni, inventories non generati"
+        if status == "RED":
             return "RED (nessun inventory generato)"
-        return f"health={health}"
+        return f"status={status}"
     except Exception:
         return None
 

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -501,6 +501,63 @@ def test_inventory_diff_parquet_not_found(tmp_path, monkeypatch) -> None:
     assert result["error"] == "artifact_not_found"
 
 
+# ─── _source_radar_context tests (GAP-7: real radar_summary.json schema) ────
+
+
+def test_source_radar_context_red(tmp_path, monkeypatch) -> None:
+    """RED source with red_streak returns contesto giorni."""
+    radar_path = tmp_path / "radar_summary.json"
+    radar_path.write_text(
+        json.dumps({
+            "sources": [
+                {"id": "dati_salute", "status": "RED", "red_streak": 14},
+                {"id": "istat_sdmx", "status": "GREEN"},
+            ],
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(core, "_RADAR_JSON", radar_path)
+
+    result = core._source_radar_context("dati_salute")
+    assert result is not None
+    assert "RED" in result
+    assert "14 giorni" in result
+
+
+def test_source_radar_context_green(tmp_path, monkeypatch) -> None:
+    """GREEN source returns status=GREEN."""
+    radar_path = tmp_path / "radar_summary.json"
+    radar_path.write_text(
+        json.dumps({
+            "sources": [
+                {"id": "istat_sdmx", "status": "GREEN"},
+            ],
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(core, "_RADAR_JSON", radar_path)
+
+    result = core._source_radar_context("istat_sdmx")
+    assert result == "status=GREEN"
+
+
+def test_source_radar_context_unknown_source(tmp_path, monkeypatch) -> None:
+    """Source not in radar returns None."""
+    radar_path = tmp_path / "radar_summary.json"
+    radar_path.write_text(json.dumps({"sources": []}), encoding="utf-8")
+    monkeypatch.setattr(core, "_RADAR_JSON", radar_path)
+
+    result = core._source_radar_context("unknown_source")
+    assert result is None
+
+
+def test_source_radar_context_no_file(tmp_path, monkeypatch) -> None:
+    """No radar file returns None."""
+    monkeypatch.setattr(core, "_RADAR_JSON", tmp_path / "nonexistent.json")
+    result = core._source_radar_context("dati_salute")
+    assert result is None
+
+
 # ─── Tests for HTTP tools (mocked) ─────────────────────────────────────────────
 
 

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -402,6 +402,7 @@ def test_recommend_sources(tmp_path, monkeypatch) -> None:
     assert result["returned"] == 1
     assert result["sources"][0]["source_id"] == "inps"
     assert result["sources"][0]["item_count"] >= 1
+    assert result["total_items_in_inventory"] == 2  # inps + openbdap in test data
 
 
 def test_recommend_sources_empty_keyword() -> None:
@@ -547,6 +548,61 @@ def test_infer_topic_tasso_not_false_positive(monkeypatch) -> None:
     assert "lavoro" not in result["topics"]
 
 
+# ─── Topic inference — new topics from MCP audit (2026-05-17) ──────────────
+
+
+def test_infer_topic_welfare() -> None:
+    result = core.infer_topic("bonus assistenziali e sostegno alla poverta")
+    assert "welfare" in result["topics"]
+    assert result["topics"]["welfare"] >= 3
+
+
+def test_infer_topic_previdenza() -> None:
+    result = core.infer_topic("pensioni erogate per regione e tipologia, importo medio")
+    assert "previdenza" in result["topics"]
+    assert result["top_match"] == "previdenza"
+
+
+def test_infer_topic_casa() -> None:
+    result = core.infer_topic("edilizia residenziale pubblica e catasto immobiliare")
+    assert "casa" in result["topics"]
+    assert result["topics"]["casa"] >= 3
+
+
+def test_infer_topic_cultura() -> None:
+    result = core.infer_topic("musei e patrimonio artistico, mostre culturali")
+    assert "cultura" in result["topics"]
+    assert result["topics"]["cultura"] >= 3
+
+
+def test_infer_topic_bilancio() -> None:
+    result = core.infer_topic("gettito fiscale IRPEF e spesa pubblica")
+    assert "bilancio" in result["topics"]
+    assert result["topics"]["bilancio"] >= 3
+
+
+def test_infer_topic_innovazione() -> None:
+    result = core.infer_topic("digitale e innovazione tecnologica, open data")
+    assert "innovazione" in result["topics"]
+    assert result["topics"]["innovazione"] >= 3
+
+
+def test_infer_topic_sicurezza() -> None:
+    result = core.infer_topic("protezione civile e prevenzione rischi, emergenza")
+    assert "sicurezza" in result["topics"]
+    assert result["topics"]["sicurezza"] >= 3
+
+
+def test_infer_topic_new_not_overlapping_old() -> None:
+    """New topic keywords should not cause false-positive scoring in old topics."""
+    # Welfare keywords should not accidentally score lavoro or economia
+    result = core.infer_topic("bonus assistenziali e assegno sostegno")
+    assert "welfare" in result["topics"]
+    # These are purely welfare terms - should not trigger old topics
+    for old_topic in ("lavoro", "economia", "sanita"):
+        assert old_topic not in result["topics"]
+
+
 class _FakeSSLFallbackResponse:
     """Fake response returned by SSL fallback when verify=False succeeds."""
     status_code = 200
@@ -681,3 +737,152 @@ def test_html_extract_links_ssl_fallback_failure_returns_reachable_false(monkeyp
     assert result["is_reachable"] is False
     assert "error" in result
     assert result["message"] == "unexpected internal error"
+
+
+# ─── _guess_format tests (GAP-8: content-type inference) ───────────────────
+
+
+def test_guess_format_from_content_type() -> None:
+    assert core._guess_format("https://example.test/file", "text/csv") == "CSV"
+    assert core._guess_format("https://example.test/file", "application/json") == "JSON"
+    assert core._guess_format("https://example.test/file", "text/html") == "HTML"
+    assert core._guess_format("https://example.test/file", "text/plain; charset=utf-8") == "TXT"
+    assert core._guess_format("https://example.test/file", "application/octet-stream") == "BIN"
+    assert core._guess_format("https://example.test/file", "text/tab-separated-values") == "TSV"
+    assert core._guess_format("https://example.test/file", "application/gzip") == "GZ"
+    assert core._guess_format("https://example.test/file", "application/zip") == "ZIP"
+    assert core._guess_format("https://example.test/file", "application/pdf") == "PDF"
+    assert core._guess_format("https://example.test/file", "application/parquet") == "PARQUET"
+
+
+def test_guess_format_from_suffix_fallback() -> None:
+    """When content_type is None or unknown, fallback to URL suffix."""
+    assert core._guess_format("https://example.test/data.csv", None) == "CSV"
+    assert core._guess_format("https://example.test/data.json", None) == "JSON"
+    assert core._guess_format("https://example.test/data.xlsx", None) == "XLSX"
+    assert core._guess_format("https://example.test/file.unknown", None) is None
+    assert core._guess_format("https://example.test/data", "application/octet-stream") == "BIN"
+
+
+def test_guess_format_unknown_content_type() -> None:
+    """Unknown content-type with no suffix should return None."""
+    assert core._guess_format("https://example.test/file", "application/vnd.ms-powerpoint") is None
+    assert core._guess_format("https://example.test/data", None) is None
+
+
+# ─── find_by_url tests (GAP-1: expanded search beyond URL columns) ─────────
+
+
+def _write_source_check_parquet(path, rows: list[dict]) -> None:
+    """Write minimal columns matching source_check_results schema."""
+    _write_parquet(path, rows)
+
+
+def _write_catalog_inventory_parquet(path, rows: list[dict]) -> None:
+    """Write minimal columns matching catalog_inventory schema."""
+    _write_parquet(path, rows)
+
+
+def test_find_by_url_finds_by_url_in_source_check(tmp_path, monkeypatch) -> None:
+    """Search by download URL in source_check_results."""
+    check_path = tmp_path / "source_check_results.parquet"
+    _write_source_check_parquet(
+        check_path,
+        [
+            {"url": "https://inps.example/download/PENSIONI-2024.csv", "url_checked": "", "item_id": "id1"},
+            {"url": "https://inps.example/download/ALTRO.csv", "url_checked": "", "item_id": "id2"},
+        ],
+    )
+    inv_path = tmp_path / "catalog_inventory_latest.parquet"
+    _write_catalog_inventory_parquet(inv_path, [{"dummy": 0}])
+    monkeypatch.setattr(core, "_CHECK_PARQUET", check_path)
+    monkeypatch.setattr(core, "_INVENTORY_PARQUET", inv_path)
+
+    result = core.find_by_url("PENSIONI-2024.csv")
+
+    assert result["query_url"] == "PENSIONI-2024.csv"
+    assert len(result["source_check_results"]) == 1
+    assert result["source_check_results"][0]["item_id"] == "id1"
+
+
+def test_find_by_url_finds_by_item_name_in_inventory(tmp_path, monkeypatch) -> None:
+    """Search by item_name should match in catalog_inventory expanded columns."""
+    check_path = tmp_path / "source_check_results.parquet"
+    _write_source_check_parquet(check_path, [{"url": "", "url_checked": "", "item_id": "none"}])
+    inv_path = tmp_path / "catalog_inventory_latest.parquet"
+    _write_catalog_inventory_parquet(
+        inv_path,
+        [
+            {
+                "source_id": "inps",
+                "item_id": "ID-5257",
+                "item_name": "Pensioni erogate 2024",
+                "title": "Pensioni INPS per regione",
+                "landing_page": "https://inps.example/dataset/5257",
+                "distribution_url": "",
+                "source_url": "",
+                "notes_excerpt": "Dati sulle pensioni erogate",
+                "tags": "",
+            },
+        ],
+    )
+    monkeypatch.setattr(core, "_CHECK_PARQUET", check_path)
+    monkeypatch.setattr(core, "_INVENTORY_PARQUET", inv_path)
+
+    # Search by item_name substring
+    result = core.find_by_url("Pensioni erogate")
+
+    assert len(result["catalog_inventory"]) == 1
+    assert result["catalog_inventory"][0]["item_id"] == "ID-5257"
+
+
+def test_find_by_url_finds_by_item_id_in_inventory(tmp_path, monkeypatch) -> None:
+    """Search by item_id should match in catalog_inventory expanded columns."""
+    check_path = tmp_path / "source_check_results.parquet"
+    _write_source_check_parquet(check_path, [{"url": "", "url_checked": "", "item_id": "none"}])
+    inv_path = tmp_path / "catalog_inventory_latest.parquet"
+    _write_catalog_inventory_parquet(
+        inv_path,
+        [
+            {
+                "source_id": "inps",
+                "item_id": "ID-5257",
+                "item_name": "Pensioni",
+                "title": "Pensioni INPS",
+                "landing_page": "",
+                "distribution_url": "",
+                "source_url": "",
+                "notes_excerpt": "",
+                "tags": "",
+            },
+        ],
+    )
+    monkeypatch.setattr(core, "_CHECK_PARQUET", check_path)
+    monkeypatch.setattr(core, "_INVENTORY_PARQUET", inv_path)
+
+    result = core.find_by_url("ID-5257")
+
+    assert len(result["catalog_inventory"]) == 1
+    assert result["catalog_inventory"][0]["item_name"] == "Pensioni"
+
+
+def test_find_by_url_returns_empty_when_no_match(tmp_path, monkeypatch) -> None:
+    """No match should return empty lists, not errors."""
+    check_path = tmp_path / "source_check_results.parquet"
+    _write_source_check_parquet(check_path, [{"url": "https://example.test/other.csv", "url_checked": "", "item_id": "none"}])
+    inv_path = tmp_path / "catalog_inventory_latest.parquet"
+    _write_catalog_inventory_parquet(inv_path, [{"item_id": "other", "item_name": "Other", "title": "Other"}])
+    monkeypatch.setattr(core, "_CHECK_PARQUET", check_path)
+    monkeypatch.setattr(core, "_INVENTORY_PARQUET", inv_path)
+
+    result = core.find_by_url("nonexistent-filename.csv")
+
+    assert result["source_check_results"] == []
+    assert result["catalog_inventory"] == []
+    assert "source_check_error" not in result
+    assert "catalog_inventory_error" not in result
+
+
+def test_find_by_url_rejects_empty_url() -> None:
+    result = core.find_by_url("")
+    assert result["error"] == "empty_url"

--- a/tests/test_so_server_wrapper.py
+++ b/tests/test_so_server_wrapper.py
@@ -53,3 +53,28 @@ def test_guard_turns_exception_into_error_dict() -> None:
     assert "message" in result
     assert result["error"] == "unexpected_error"
     assert "test error" in result["message"]
+
+
+def test_guard_timed_logs_and_wraps_exception() -> None:
+    """guard_timed() wraps exceptions and includes timing metadata in logs."""
+    from lab_connectors.mcp import guard_timed
+
+    def raising() -> dict:
+        raise ValueError("test timed error")
+
+    result = guard_timed(raising, "test_tool", logger_name="test-server")
+    assert "error" in result
+    assert "message" in result
+    assert result["error"] == "unexpected_error"
+    assert "test timed error" in result["message"]
+
+
+def test_guard_timed_returns_dict_result() -> None:
+    """guard_timed() passes through a successful dict result unchanged."""
+    from lab_connectors.mcp import guard_timed
+
+    def working() -> dict:
+        return {"result_key": 42, "nested": {"a": 1}}
+
+    result = guard_timed(working, "working_tool", logger_name="test-server")
+    assert result == {"result_key": 42, "nested": {"a": 1}}


### PR DESCRIPTION
## Audit MCP Source Observatory

Risolve 6 degli 8 gap identificati nell'audit del 2026-05-17 + migrazione da guard() a guard_timed().

### Gap risolti

| Gap | Tool | Cosa |
|---|---|---|
| GAP-5 | so_infer_topic | 7 nuovi topic: welfare, previdenza, casa, cultura, bilancio, innovazione, sicurezza |
| GAP-8 | so_probe_url | 8 content-type mancanti (HTML, TXT, BIN, TSV, GZ, ZIP, TAR, ODS) |
| GAP-1 | so_find_by_url | Bug LIKE lower + colonne espanse (item_name, item_id, title) |
| GAP-2 | so_ckan_package_show | Errori arricchiti con tried_url, package_id |
| GAP-6 | so_recommend_sources | Nuovo campo total_items_in_inventory |
| GAP-7 | so_inventory_diff | Helper _source_radar_context(), note baseline null/RED |

### Migrazione guard → guard_timed

Tutti i 17 tool MCP passati da guard() a guard_timed() con logger_name='source-observatory'.

### Test

- 16 nuovi test in test_so_mcp.py
- 3 nuovi test in test_so_server_wrapper.py
- 157/157 test passano, 0 regressioni