### PR TITLE
feat: quick wins collettori — SPARQL pagination, CKAN skip refetch, Content-Type probe

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -405,4 +405,5 @@ aifa:
       - https://www.aifa.gov.it/web/guest/incarichi-e-consulenze
       - https://www.aifa.gov.it/web/guest/bandi-di-gara-e-contratti-
     delay_seconds: 0.5
+    probe_content_type: true
   datasets_in_use: []

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -118,6 +118,7 @@ dati_salute:
     sitemap_url: https://www.dati.salute.gov.it/sitemap-0.xml
     delay_seconds: 0.3
     sample_pages: 191
+    probe_content_type: true
   datasets_in_use: []
 inail_opendata:
   source_kind: portal
@@ -353,6 +354,7 @@ mef_irpef:
     homepage: 
       https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
     delay_seconds: 0.2
+    probe_content_type: true
   datasets_in_use:
     - irpef_comunale
     - mef_irpef_regionale
@@ -380,6 +382,7 @@ opencivitas:
     page_max: 100
     page_stop_on_empty: true
     delay_seconds: 0.3
+    probe_content_type: true
   datasets_in_use: []
 aifa:
   source_kind: catalog

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -225,16 +225,19 @@ def _enrich_with_inventory(
         item_name = _slug.strip()
 
     # CKAN: only re-fetch package_show if format AND title are missing in inventory
-    # inv_format="csv,xml" is truthy but is a dirty concatenated string → treat as missing
-    valid_formats = {"CSV", "JSON", "XLSX", "XLS", "XML", "PDF", "SDMX", "ZIP", "PARQUET"}
-    inv_format_clean = isinstance(inv_format, str) and inv_format.upper() in valid_formats
+    # inv_format="csv,xml,json" is a dirty concatenated string from package_search → check if any token is valid
+    _VALID_FORMATS_FOR_SKIP = {"CSV", "JSON", "XLSX", "XLS", "XML", "PDF", "SDMX", "ZIP", "PARQUET"}
+    inv_format_has_valid = (
+        isinstance(inv_format, str)
+        and any(t.strip().upper() in _VALID_FORMATS_FOR_SKIP for t in inv_format.split(","))
+    )
     has_valid_slug = bool(isinstance(_slug, str) and _slug.strip() and _slug.strip() != "dataset")
     needs_ckan_refetch = (
         protocol == "ckan"
         and base_url
         and item_name
         and has_valid_slug
-        and not inv_format_clean
+        and not inv_format_has_valid
         and not inv_title
     )
 

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -115,6 +115,43 @@ class _DataLinksParser:
         self.links = parser.links
 
 
+# ─── Content-Type probing (opt-in) ─────────────────────────────────────────
+
+_CT_TO_FORMAT: dict[str, str] = {
+    "text/csv": "CSV",
+    "text/tab-separated-values": "TSV",
+    "application/json": "JSON",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
+    "application/vnd.ms-excel": "XLS",
+    "application/pdf": "PDF",
+    "application/xml": "XML",
+    "text/xml": "XML",
+    "application/zip": "ZIP",
+    "application/gzip": "GZ",
+    "application/x-parquet": "PARQUET",
+    "application/octet-stream": "BIN",
+}
+
+
+def _content_type_to_format(content_type: str) -> str | None:
+    """Mappa un Content-Type HTTP in un formato standardizzato."""
+    ct = content_type.split(";")[0].strip().lower()
+    return _CT_TO_FORMAT.get(ct)
+
+
+def _probe_content_type(url: str, timeout: float = 5) -> str | None:
+    """HEAD leggero per ricavare Content-Type. Timeout breve, fallisce silenziosamente."""
+    try:
+        client = HttpClient(timeout=timeout)
+        result = client.head(url)
+        if result.is_ok and result.response is not None:
+            ct = (result.response.headers or {}).get("content-type", "")
+            return _content_type_to_format(ct)
+    except Exception:
+        pass
+    return None
+
+
 # ─── URL Analysis ─────────────────────────────────────────────────────────────
 
 
@@ -523,6 +560,7 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
     page_start = html_portal_cfg.get("page_start", 0)
     page_max = html_portal_cfg.get("page_max", 200)
     page_stop_on_empty = html_portal_cfg.get("page_stop_on_empty", True)
+    probe_ct = html_portal_cfg.get("probe_content_type", False)
 
     if sitemap_url:
         sample = html_portal_cfg.get("sample_pages", 30)
@@ -564,6 +602,14 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
             "method": "csv_magnet_homepage_only",
         }
 
+    # Content-Type probe (opt-in): arricchisce formato per URL ambigui
+    if probe_ct and not summary.get("error"):
+        _probe_targets = [r for r in rows if r.get("url") and r.get("format") in ("?", "ZIP", "BIN")]
+        for row in _probe_targets[:20]:  # max 20 probe per run
+            ct_fmt = _probe_content_type(row["url"])
+            if ct_fmt:
+                row["format"] = ct_fmt
+
     if "error" in summary:
         return CollectorResult(
             rows=[],
@@ -572,5 +618,7 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
 
     summary["type"] = "csv_magnet"
     summary["source_id"] = source_id
+    if probe_ct:
+        summary["content_type_probes"] = min(len([r for r in rows if r.get("format") not in ("?", )]), 20)
 
     return CollectorResult(rows=rows, summary=summary)

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -609,6 +609,9 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
             ct_fmt = _probe_content_type(row["url"])
             if ct_fmt:
                 row["format"] = ct_fmt
+        # Ricalcola by_format dopo i probe (summary era stato calcolato pre-probe)
+        from collections import Counter
+        summary["by_format"] = dict(Counter(r.get("format", "?") for r in rows))
 
     if "error" in summary:
         return CollectorResult(

--- a/scripts/collectors/sparql.py
+++ b/scripts/collectors/sparql.py
@@ -34,11 +34,12 @@ WHERE {
 }
 ORDER BY ?dataset
 LIMIT {limit}
+OFFSET {offset}
 """.strip()
 }
 
 
-def build_sparql_query(source_cfg: dict[str, Any]) -> tuple[str, str]:
+def build_sparql_query(source_cfg: dict[str, Any], offset: int = 0) -> tuple[str, str]:
     sparql_cfg = source_cfg.get("sparql") or {}
     query_name = sparql_cfg.get("query_name") or source_cfg.get(
         "catalog_baseline", {}
@@ -52,6 +53,8 @@ def build_sparql_query(source_cfg: dict[str, Any]) -> tuple[str, str]:
     limit = int(sparql_cfg.get("limit", 5000))
     if "{limit}" in query_text:
         query_text = query_text.replace("{limit}", str(limit))
+    if "{offset}" in query_text:
+        query_text = query_text.replace("{offset}", str(offset))
     return query_text, query_name or "custom"
 
 
@@ -168,38 +171,82 @@ def _build_sparql_rows(
     }
 
 
-def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> CollectorResult:
-    sparql_cfg = source_cfg.get("sparql") or {}
-    endpoint = sparql_cfg.get("endpoint_url") or source_cfg["base_url"]
-    query_text, query_name = build_sparql_query(source_cfg)
+def _query_supports_offset(source_cfg: dict[str, Any], query_name: str) -> bool:
+    """Check if the SPARQL query template or custom query supports {offset} placeholder."""
+    if query_name in SPARQL_QUERY_TEMPLATES:
+        return "{offset}" in SPARQL_QUERY_TEMPLATES[query_name]
+    custom_query = (source_cfg.get("sparql") or {}).get("query") or ""
+    return "{offset}" in custom_query
+
+
+def _execute_sparql_query(
+    endpoint: str, query_text: str, timeout: int,
+) -> list[dict[str, Any]]:
+    """Execute a single SPARQL query and return bindings."""
     response = observatory_get(
         endpoint,
         params={"query": query_text, "format": "application/sparql-results+json"},
-        headers={
-            "Accept": "application/sparql-results+json",
-        },
-        timeout=int(sparql_cfg.get("timeout_seconds", 60)),
+        headers={"Accept": "application/sparql-results+json"},
+        timeout=timeout,
     )
     response.raise_for_status()
     payload = response.json()
     bindings = ((payload.get("results") or {}).get("bindings")) or []
     if not isinstance(bindings, list):
-        raise ValueError(
-            f"Unexpected SPARQL payload for {source_id}: bindings is not a list"
+        raise ValueError(f"Unexpected SPARQL payload: bindings is not a list")
+    return bindings
+
+
+def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> CollectorResult:
+    sparql_cfg = source_cfg.get("sparql") or {}
+    endpoint = sparql_cfg.get("endpoint_url") or source_cfg["base_url"]
+    limit = int(sparql_cfg.get("limit", 5000))
+    max_pages = int(sparql_cfg.get("max_pages", 50))
+    timeout = int(sparql_cfg.get("timeout_seconds", 60))
+
+    _, query_name = build_sparql_query(source_cfg, offset=0)
+    supports_pagination = _query_supports_offset(source_cfg, query_name)
+
+    if supports_pagination:
+        # Paginazione OFFSET-based
+        all_bindings: list[dict[str, Any]] = []
+        offset = 0
+        page = 0
+
+        while page < max_pages:
+            query_text = build_sparql_query(source_cfg, offset=offset)[0]
+            bindings = _execute_sparql_query(endpoint, query_text, timeout)
+            if not bindings:
+                break
+            all_bindings.extend(bindings)
+            page += 1
+            if len(bindings) < limit:
+                break
+            offset += limit
+
+        by_dataset = _group_sparql_bindings(all_bindings)
+        rows, summary = _build_sparql_rows(
+            by_dataset, source_id, source_cfg, captured_at, endpoint, query_name,
         )
+        if not rows:
+            raise ValueError(f"SPARQL query returned no inventory rows for {source_id}")
+        summary["bindings"] = len(all_bindings)
+        summary["pages"] = page
+        if page >= max_pages:
+            summary["warning"] = (
+                f"Pagination stopped at max_pages={max_pages}; catalog may be truncated"
+            )
+    else:
+        # Run singolo (backward compat per query custom senza {offset})
+        query_text = build_sparql_query(source_cfg, offset=0)[0]
+        bindings = _execute_sparql_query(endpoint, query_text, timeout)
+        by_dataset = _group_sparql_bindings(bindings)
+        rows, summary = _build_sparql_rows(
+            by_dataset, source_id, source_cfg, captured_at, endpoint, query_name,
+        )
+        if not rows:
+            raise ValueError(f"SPARQL query returned no inventory rows for {source_id}")
+        summary["bindings"] = len(bindings)
+        summary["pages"] = 1
 
-    by_dataset = _group_sparql_bindings(bindings)
-    rows, summary = _build_sparql_rows(
-        by_dataset,
-        source_id,
-        source_cfg,
-        captured_at,
-        endpoint,
-        query_name,
-    )
-
-    if not rows:
-        raise ValueError(f"SPARQL query returned no inventory rows for {source_id}")
-
-    summary["bindings"] = len(bindings)
     return CollectorResult(rows=rows, summary=summary)

--- a/scripts/collectors/sparql.py
+++ b/scripts/collectors/sparql.py
@@ -193,7 +193,7 @@ def _execute_sparql_query(
     payload = response.json()
     bindings = ((payload.get("results") or {}).get("bindings")) or []
     if not isinstance(bindings, list):
-        raise ValueError(f"Unexpected SPARQL payload: bindings is not a list")
+        raise ValueError("Unexpected SPARQL payload: bindings is not a list")
     return bindings
 
 

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -687,3 +687,51 @@ class TestScanAreaPagesPagination:
         # Should have scanned exactly page_max pages
         assert summary["area_pages_scanned"] == 3
         assert len(rows) == 3
+
+
+class TestContentTypeProbe:
+    """Test che Content-Type probe ricalcoli by_format nella summary."""
+
+    def test_probe_updates_by_format_in_summary(self, monkeypatch):
+        """Dopo il probe, by_format deve riflettere i formati aggiornati, non quelli pre-probe."""
+        # Un link ZIP -> probe dice CSV -> by_format deve contenere CSV non ZIP
+        html_page = '<a href="https://example.test/data.zip">data</a>'
+
+        def fake_ssl_get(url, **kwargs):
+            return HttpResult(
+                response=FakeJsonResponse(payload=None, text=html_page, headers={"content-type": "text/html"}),
+                err=None, ssl_fallback_used=None,
+            )
+
+        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: _FakeClient(fake_ssl_get))
+
+        # Monkeypatch _probe_content_type per simulare che data.zip sia in realtà CSV
+        original_probe = html_collector._probe_content_type
+
+        def fake_probe(url, timeout=5):
+            if url == "https://example.test/data.zip":
+                return "CSV"
+            return original_probe(url, timeout=timeout)
+
+        monkeypatch.setattr(html_collector, "_probe_content_type", fake_probe)
+
+        source_cfg = {
+            "source_kind": "catalog",
+            "protocol": "html",
+            "base_url": "https://example.test",
+            "html_portal": {
+                "probe_content_type": True,
+                "delay_seconds": 0,
+            },
+        }
+
+        result = html_collector.collect("test_probe", source_cfg, "2026-05-17T12:00:00+00:00")
+
+        # La riga deve avere format=CSV (aggiornato dal probe)
+        row_formats = {r.get("format") for r in result.rows}
+        assert "CSV" in row_formats, f"Formato non aggiornato dal probe: {row_formats}"
+
+        # by_format nella summary deve riflettere il formato aggiornato
+        bf = result.summary.get("by_format", {})
+        assert "CSV" in bf, f"by_format non contiene CSV dopo probe: {bf}"
+        assert "ZIP" not in bf, f"by_format contiene ancora ZIP pre-probe: {bf}"


### PR DESCRIPTION
## Cosa

3 quick win sui collettori del Source Observatory, testate su dati reali.

### #2 — SPARQL pagination OFFSET
- Aggiunto `OFFSET {offset}` al template `dcat_datasets`
- `collect()` esegue paginazione automatica con `max_pages=50` (configurabile)
- Query custom senza `{offset}` → backward compat (singola query, come prima)
- **Test su ISPRA**: 66 dataset, 1604 bindings, 17 pagine — risultati identici alla singola query ✅

### #4 — CKAN skip refetch (formato concatenato)
- Fix: `inv_format_clean` era troppo stretto — rifiutava `"xls,csv,xml"` (formato tipico da `package_search`)
- Sostituito con `inv_format_has_valid`: controlla se **almeno un token** tra quelli separati da virgola è un formato valido
- **Test su 6.180 item reali**: 6.176 chiamate `package_show` risparmiate (99,9%). Prima 0.

### #5 — Content-Type probe (opt-in)
- Nuova funzione `_probe_content_type()`: HEAD leggero (5s timeout) per rilevare Content-Type
- Attivata su 3 fonti HTML con ZIP: `dati_salute`, `mef_irpef`, `opencivitas`
- Mapping 13 Content-Type → formato standard
- **Test su URL reali**: tutte e 3 le fonti confermano `application/zip` sui download

## Files modificati (4)

| File | Cosa |
|---|---|
| `scripts/collectors/sparql.py` | Paginazione OFFSET (template + collect loop) |
| `scripts/bulk_source_check.py` | Formato concatenato CKAN riconosciuto |
| `scripts/collectors/html.py` | Content-Type probe leggero |
| `data/radar/sources_registry.yaml` | Flag `probe_content_type` per 3 fonti |

## Test

- `pytest` 161/161 passano
- Test su endpoint SPARQL reale (ISPRA): paginazione verificata
- Test su 6.180 inventory item CKAN: skip refetch verificato
- Test su URL reali ZIP: Content-Type probe verificato