### PR TITLE
refactor: rimuovere logger_name esplicito da guard_timed

### DIFF
--- a/mcp/so_server.py
+++ b/mcp/so_server.py
@@ -34,7 +34,7 @@ def so_inventory_query(
     limit: int = 50,
     has_results: bool | None = None,
 ) -> dict[str, Any]:
-    return guard_timed(so_server_core.query_inventory, "so_inventory_query", source_id, min_score, limit, has_results, logger_name="source-observatory")
+    return guard_timed(so_server_core.query_inventory, "so_inventory_query", source_id, min_score, limit, has_results)
 
 
 @mcp.tool(
@@ -42,7 +42,7 @@ def so_inventory_query(
     structured_output=True,
 )
 def so_catalog_signals(source_id: str | None = None, limit: int | None = None) -> dict[str, Any]:
-    return guard_timed(so_server_core.query_signals, "so_catalog_signals", source_id, limit, logger_name="source-observatory")
+    return guard_timed(so_server_core.query_signals, "so_catalog_signals", source_id, limit)
 
 
 @mcp.tool(
@@ -50,7 +50,7 @@ def so_catalog_signals(source_id: str | None = None, limit: int | None = None) -
     structured_output=True,
 )
 def so_radar_summary(source_id: str | None = None) -> dict[str, Any]:
-    return guard_timed(so_server_core.radar_summary, "so_radar_summary", source_id, logger_name="source-observatory")
+    return guard_timed(so_server_core.radar_summary, "so_radar_summary", source_id)
 
 
 @mcp.tool(
@@ -58,7 +58,7 @@ def so_radar_summary(source_id: str | None = None) -> dict[str, Any]:
     structured_output=True,
 )
 def so_radar_history(source_id: str | None = None, limit: int = 5) -> dict[str, Any]:
-    return guard_timed(so_server_core.radar_history, "so_radar_history", source_id, limit, logger_name="source-observatory")
+    return guard_timed(so_server_core.radar_history, "so_radar_history", source_id, limit)
 
 
 @mcp.tool(
@@ -66,7 +66,7 @@ def so_radar_history(source_id: str | None = None, limit: int = 5) -> dict[str, 
     structured_output=True,
 )
 def so_radar_status_md() -> dict[str, Any]:
-    return guard_timed(so_server_core.radar_status_md, "so_radar_status_md", logger_name="source-observatory")
+    return guard_timed(so_server_core.radar_status_md, "so_radar_status_md")
 
 
 @mcp.tool(
@@ -74,7 +74,7 @@ def so_radar_status_md() -> dict[str, Any]:
     structured_output=True,
 )
 def so_inventory_status(source_id: str | None = None) -> dict[str, Any]:
-    return guard_timed(so_server_core.inventory_status, "so_inventory_status", source_id, logger_name="source-observatory")
+    return guard_timed(so_server_core.inventory_status, "so_inventory_status", source_id)
 
 
 @mcp.tool(
@@ -87,7 +87,7 @@ def so_catalog_inventory_search(
     protocol: str | None = None,
     limit: int = 25,
 ) -> dict[str, Any]:
-    return guard_timed(so_server_core.catalog_inventory_search, "so_catalog_inventory_search", query, source_id, protocol, limit, logger_name="source-observatory")
+    return guard_timed(so_server_core.catalog_inventory_search, "so_catalog_inventory_search", query, source_id, protocol, limit)
 
 
 @mcp.tool(
@@ -95,7 +95,7 @@ def so_catalog_inventory_search(
     structured_output=True,
 )
 def so_probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
-    return guard_timed(so_server_core.probe_url, "so_probe_url", url, timeout, logger_name="source-observatory")
+    return guard_timed(so_server_core.probe_url, "so_probe_url", url, timeout)
 
 
 @mcp.tool(
@@ -103,7 +103,7 @@ def so_probe_url(url: str, timeout: int = 15) -> dict[str, Any]:
     structured_output=True,
 )
 def so_discover_sdmx(keywords: list[str], limit: int = 30) -> dict[str, Any]:
-    return guard_timed(so_server_core.discover_sdmx, "so_discover_sdmx", keywords, limit, logger_name="source-observatory")
+    return guard_timed(so_server_core.discover_sdmx, "so_discover_sdmx", keywords, limit)
 
 
 @mcp.tool(
@@ -112,7 +112,7 @@ def so_discover_sdmx(keywords: list[str], limit: int = 30) -> dict[str, Any]:
     structured_output=True,
 )
 def so_find_by_url(url: str) -> dict[str, Any]:
-    return guard_timed(so_server_core.find_by_url, "so_find_by_url", url, logger_name="source-observatory")
+    return guard_timed(so_server_core.find_by_url, "so_find_by_url", url)
 
 
 @mcp.tool(
@@ -125,7 +125,7 @@ def so_registry_query(
     observation_mode: str | None = None,
     source_id: str | None = None,
 ) -> dict[str, Any]:
-    return guard_timed(so_server_core.registry_query, "so_registry_query", protocol, source_kind, observation_mode, source_id, logger_name="source-observatory")
+    return guard_timed(so_server_core.registry_query, "so_registry_query", protocol, source_kind, observation_mode, source_id)
 
 
 @mcp.tool(
@@ -140,7 +140,7 @@ def so_sparql_query(
     timeout: int = 60,
     max_rows: int = 500,
 ) -> dict[str, Any]:
-    return guard_timed(so_server_core._sparql_query_raw, "so_sparql_query", endpoint, query, timeout, max_rows, logger_name="source-observatory")
+    return guard_timed(so_server_core._sparql_query_raw, "so_sparql_query", endpoint, query, timeout, max_rows)
 
 
 @mcp.tool(
@@ -150,7 +150,7 @@ def so_sparql_query(
     structured_output=True,
 )
 def so_html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
-    return guard_timed(so_server_core._html_extract_links, "so_html_extract_links", url, timeout, logger_name="source-observatory")
+    return guard_timed(so_server_core._html_extract_links, "so_html_extract_links", url, timeout)
 
 
 @mcp.tool(
@@ -163,7 +163,7 @@ def so_html_extract_links(url: str, timeout: int = 20) -> dict[str, Any]:
     structured_output=True,
 )
 def so_ckan_package_show(endpoint: str, package_id: str, timeout: int = 30) -> dict[str, Any]:
-    return guard_timed(so_server_core._ckan_package_show, "so_ckan_package_show", endpoint, package_id, timeout, logger_name="source-observatory")
+    return guard_timed(so_server_core._ckan_package_show, "so_ckan_package_show", endpoint, package_id, timeout)
 
 
 @mcp.tool(
@@ -175,7 +175,7 @@ def so_ckan_package_show(endpoint: str, package_id: str, timeout: int = 30) -> d
     structured_output=True,
 )
 def so_infer_topic(text: str) -> dict[str, Any]:
-    return guard_timed(so_server_core.infer_topic, "so_infer_topic", text, logger_name="source-observatory")
+    return guard_timed(so_server_core.infer_topic, "so_infer_topic", text)
 
 
 @mcp.tool(
@@ -185,7 +185,7 @@ def so_infer_topic(text: str) -> dict[str, Any]:
     structured_output=True,
 )
 def so_recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
-    return guard_timed(so_server_core.recommend_sources, "so_recommend_sources", keyword, limit, logger_name="source-observatory")
+    return guard_timed(so_server_core.recommend_sources, "so_recommend_sources", keyword, limit)
 
 
 @mcp.tool(
@@ -195,7 +195,7 @@ def so_recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
     structured_output=True,
 )
 def so_inventory_diff(source_id: str) -> dict[str, Any]:
-    return guard_timed(so_server_core.inventory_diff, "so_inventory_diff", source_id, logger_name="source-observatory")
+    return guard_timed(so_server_core.inventory_diff, "so_inventory_diff", source_id)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ jsonschema>=4.20.0,<5.0
 mcp>=1.27.1
 fastmcp>=3.2.4
 lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.8.0
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@6b3367c
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@fca6bd28

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ ddgs>=9.14.2,<10.0
 jsonschema>=4.20.0,<5.0
 mcp>=1.27.1
 fastmcp>=3.2.4
-lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.7.0
+lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.8.0
 dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@6b3367c


### PR DESCRIPTION
## Summary

Rimosso `logger_name="source-observatory"` da tutti i 17 tool MCP — ora `guard_timed` deriva il nome del logger automaticamente da `tool_name`.

### Perché

Con la semplificazione di `guard_timed` in lab-connectors#18, `logger_name` è diventato opzionale (default = `tool_name`). Passarlo era rumore.

### Impatto

Nessuno — comportamento identico (il logger usato era comunque `"source-observatory"`).

### Test

source-observatory: 162 passed