### PR TITLE
fix: ottimizzazione tempi observatory + timing per-source reali

### DIFF
--- a/.github/workflows/observatory.yml
+++ b/.github/workflows/observatory.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           python scripts/build_catalog_inventory.py \
             --out-dir data/catalog_inventory/generated \
-            --workers 8 \
+            --workers 16 \
             --skip-red-sources
 
       - name: Build catalog signals + diff

--- a/.github/workflows/observatory.yml
+++ b/.github/workflows/observatory.yml
@@ -149,7 +149,7 @@ jobs:
             --no-sdmx-years \
             --circuit-fail-threshold 2 \
             --max-items 1000 \
-            --workers 8
+            --workers 16
 
       # ═══════════════════════════════════════════════════════════════════
       # STEP 3 — UPLOAD GCS

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ data/portal_scout/*
 !data/portal_scout/discovered_portals_summary.json
 !data/portal_scout/portal_scout_shortlist.md
 
+observatory-results/

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -79,7 +79,10 @@ openbdap:
     skip_package_search_reason: timeout sistematico a 60s
     skip_current_list: true
     package_show_sample: true
-    sample_size: 4000
+    sample_size: 100
+    sample_size_reason: Ridotto da 4000 a 100 il 2026-05-18 — package_show su
+      3772 dataset consuma risorse e spesso va in timeout. Sample 100 sufficiente
+      per rilevare variazioni significative nel catalogo.
   last_probed: '2026-05-18'
   catalog_baseline:
     captured_at: '2026-04-02'
@@ -270,32 +273,21 @@ consip_open_data:
 lavoro_opendata:
   source_kind: catalog
   protocol: ckan
-  observation_mode: catalog-watch
+  observation_mode: radar-only
   base_url: 
     https://dati.lavoro.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
-  inventory:
-    skip_package_search: true
-    skip_package_search_reason: count inaffidabile
-    skip_current_list: true
-    package_show_sample: true
-    sample_size: 10000
   last_probed: '2026-05-18'
-  catalog_baseline:
-    captured_at: '2026-04-11'
-    metric: package_count
-    value: 159
-    method: package_list
-    reliability: medium
-    note: Baseline iniziale su SPOD CKAN (package_list). Package_search count 
-      inaffidabile.
-  verdict: go
-  note: Portale Ministero del Lavoro (SPOD CKAN) con API stabile e catalogo ~159
-    dataset.
+  verdict: hold
+  note: >
+    Declassato a radar-only il 2026-05-18. ValueError sistematico su
+    package_list — CKAN non raggiungibile via HTTP standard (restituisce
+    HTML non JSON). Catalogo ~159 dataset, inventory non aggiornabile
+    fino a ripristino API.
   datasets_in_use: []
 mur_ustat:
   source_kind: catalog
   protocol: ckan
-  observation_mode: catalog-watch
+  observation_mode: radar-only
   base_url: https://dati-ustat.mur.gov.it/api/3/action/package_list?limit=1
   last_probed: '2026-05-18'
   catalog_baseline:
@@ -304,11 +296,14 @@ mur_ustat:
     value: 68
     method: package_list
     reliability: medium
-    note: Baseline iniziale su CKAN package_list; portale con 68 dataset e 
-      metadata completi, aggiornamenti recenti.
-  verdict: go
-  note: Portale MUR USTAT (istruzione superiore/AFAM/DSU) con CKAN stabile e 
-    aggiornamenti recenti. Rinominato da mim_ustat (naming errato).
+    note: Baseline fissata il 2026-04-09. Declassato a radar-only il
+      2026-05-18 per timeout sistematico di connessione (ConnectTimeout).
+      Inventory non aggiornabile fino a ripristino endpoint.
+  verdict: hold
+  note: >
+    Declassato a radar-only il 2026-05-18. ConnectTimeout sistematico
+    su CKAN package_list. 68 dataset in baseline storica.
+    Inventory non aggiornabile fino a ripristino endpoint.
   datasets_in_use:
     - mur_contribuzione_universitaria
 opencoesione:
@@ -382,7 +377,6 @@ opencivitas:
     page_max: 100
     page_stop_on_empty: true
     delay_seconds: 0.3
-    probe_content_type: true
   datasets_in_use: []
 aifa:
   source_kind: catalog

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -52,6 +52,9 @@ inps:
   base_url: https://serviziweb2.inps.it/odapi/package_list?limit=1
   inventory:
     skip_current_list: true
+    skip_current_list_reason: >
+      current_package_list_with_resources degrada a offset alti
+      (2300+ timeout 30s) — package_show_sample +16 workers è più veloce.
     package_show_sample: true
     sample_size: 10000
   last_probed: '2026-05-18'
@@ -60,11 +63,13 @@ inps:
     metric: package_count
     value: 2323
     method: package_list
-    reliability: medium
-    note: Conteggio totale package rilevati via package_list; baseline 
-      precedente (544) risultata stale rispetto all'inventario corrente.
+    reliability: high
+    note: Inventory via package_list + package_show_sample (16 workers).
+      current_package_list_with_resources testato ma scartato:
+      degrada a offset alti. package_show_sample più veloce.
   verdict: go
-  note: Catalogo CKAN ricco e ad alto potenziale per candidati e source-check.
+  note: Catalogo CKAN INPS — inventory via package_list + package_show_sample
+    (current_package_list_with_resources lento a offset alti).
   datasets_in_use:
     - inps_pensioni_trimestrale
     - pensioni_pa_dag

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -79,10 +79,7 @@ openbdap:
     skip_package_search_reason: timeout sistematico a 60s
     skip_current_list: true
     package_show_sample: true
-    sample_size: 100
-    sample_size_reason: Ridotto da 4000 a 100 il 2026-05-18 — package_show su
-      3772 dataset consuma risorse e spesso va in timeout. Sample 100 sufficiente
-      per rilevare variazioni significative nel catalogo.
+    sample_size: 4000
   last_probed: '2026-05-18'
   catalog_baseline:
     captured_at: '2026-04-02'
@@ -377,6 +374,7 @@ opencivitas:
     page_max: 100
     page_stop_on_empty: true
     delay_seconds: 0.3
+    probe_content_type: true
   datasets_in_use: []
 aifa:
   source_kind: catalog

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -64,9 +64,9 @@ inps:
     value: 2323
     method: package_list
     reliability: high
-    note: Inventory via package_list + package_show_sample (16 workers).
-      current_package_list_with_resources testato ma scartato:
-      degrada a offset alti. package_show_sample più veloce.
+    note: "Inventory via package_list + package_show_sample (16 workers).
+      current_package_list_with_resources testato ma scartato per lentezza
+      a offset alti. package_show_sample più veloce."
   verdict: go
   note: Catalogo CKAN INPS — inventory via package_list + package_show_sample
     (current_package_list_with_resources lento a offset alti).

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -112,8 +112,8 @@ def parse_args() -> argparse.Namespace:
         "--workers",
         type=int,
         default=1,
-        choices=range(1, 9),
-        metavar="N (1-8)",
+        choices=range(1, 17),
+        metavar="N (1-16)",
         help="Thread per la raccolta parallela (default: 1 = seriale).",
     )
     parser.add_argument(

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -211,10 +211,14 @@ def main() -> None:
             future_to_id[f] = source_id
             submit_times[source_id] = time.time()
             # Timing per-fonte: registra quando il future completa,
-            # non quando wait() ritorna (che e' il tempo del piu' lento)
-            def _record_timing(_sid: str = source_id) -> None:
-                source_timing.setdefault(_sid, time.time() - submit_times[_sid])
-            f.add_done_callback(lambda _: _record_timing())
+            # non quando wait() ritorna (che e' il tempo del piu' lento).
+            # NOTA: chiudere _sid nel default del lambda per evitare
+            # il bug classico di chiusura su variabile di loop.
+            f.add_done_callback(
+                lambda _f, _sid=source_id: source_timing.setdefault(
+                    _sid, time.time() - submit_times[_sid]
+                )
+            )
 
         # wait() timeout globale per il batch (rete di sicurezza). Il timeout
         # reale per fonte è in _collect_source (_SOURCE_TIMEOUT = 300s).

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -214,11 +214,9 @@ def main() -> None:
             # non quando wait() ritorna (che e' il tempo del piu' lento).
             # NOTA: chiudere _sid nel default del lambda per evitare
             # il bug classico di chiusura su variabile di loop.
-            f.add_done_callback(
-                lambda _f, _sid=source_id: source_timing.setdefault(
-                    _sid, time.time() - submit_times[_sid]
-                )
-            )
+            def _record_timing(_f: object, _sid: str = source_id) -> None:
+                source_timing.setdefault(_sid, time.time() - submit_times[_sid])
+            f.add_done_callback(_record_timing)
 
         # wait() timeout globale per il batch (rete di sicurezza). Il timeout
         # reale per fonte è in _collect_source (_SOURCE_TIMEOUT = 300s).

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -65,7 +65,7 @@ DEFAULT_IN = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_i
 DEFAULT_OUT = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "source_check_results.parquet"
 REGISTRY_PATH = REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
 
-MAX_WORKERS = 8
+MAX_WORKERS = 16
 _NO_SDMX_YEARS = False  # set via --no-sdmx-years flag
 
 
@@ -549,20 +549,31 @@ def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame
     check_ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
     results = []
 
+    # Per-source timing (stesso pattern di build_catalog_inventory)
+    source_first_submit: dict[str, float] = {}
+    source_last_done: dict[str, float] = {}
+    source_item_count: dict[str, int] = {}
+    source_error_count: dict[str, int] = {}
+
     _BULK_CHECK_TIMEOUT = 900  # 15 minuti per batch source-check (safety net)
     pool = ThreadPoolExecutor(max_workers=workers)
     try:
         # Usa enumerate per avere un indice posizionale garantito come int.
         # df.iterrows() restituisce un indice generico (Hashable) che mypy
         # non accetta per df.loc/df.iloc — con enumerate pos abbiamo int certo.
-        future_to_idx = {
-            pool.submit(_check_row, row, check_ts, registry): pos
-            for pos, (_idx, row) in enumerate(df.iterrows())
-        }
+        future_to_idx = {}
+        for pos, (_idx, row) in enumerate(df.iterrows()):
+            f = pool.submit(_check_row, row, check_ts, registry)
+            future_to_idx[f] = pos
+            sid = str(row.get("source_id", ""))
+            source_first_submit.setdefault(sid, time.time())
+            source_item_count[sid] = source_item_count.get(sid, 0) + 1
+
         done = 0
         total = len(future_to_idx)
         for future in as_completed(future_to_idx, timeout=_BULK_CHECK_TIMEOUT):
             pos = future_to_idx[future]
+            sid = str(df.iloc[pos].get("source_id", "")) if pos < len(df) else ""
             try:
                 results.append(_finalize_scores(future.result()))
             except Exception as exc:
@@ -577,6 +588,8 @@ def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame
                     "check_notes": f"check failed: {exc}",
                     "enrich_method": "error",
                 })
+                source_error_count[sid] = source_error_count.get(sid, 0) + 1
+            source_last_done[sid] = time.time()
             done += 1
             if done % 50 == 0 or done == total:
                 logger.info("  %d/%d completed", done, total)
@@ -585,6 +598,20 @@ def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame
                        _BULK_CHECK_TIMEOUT, done, total)
     finally:
         pool.shutdown(wait=False, cancel_futures=True)
+
+    # ── Per-source timing table ───────────────────────────────────────────────────
+    if source_item_count:
+        print()
+        print(f"{'Source':<24} {'Items':<8} {'Errors':<8} {'Time':<8}  {'Note'}")
+        print("-" * 64)
+        for sid in sorted(source_item_count):
+            elapsed = source_last_done.get(sid, 0) - source_first_submit.get(sid, 0)
+            errs = source_error_count.get(sid, 0)
+            note = "ok"
+            if errs:
+                note = f"{errs} error(s)"
+            print(f"{sid:<24} {source_item_count[sid]:<8} {errs:<8} {elapsed:>6.1f}s  {note}")
+        print()
 
     return pd.DataFrame(results)
 

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -604,10 +604,18 @@ def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame
         print()
         print(f"{'Source':<24} {'Items':<8} {'Errors':<8} {'Time':<8}  {'Note'}")
         print("-" * 64)
+        now = time.time()
         for sid in sorted(source_item_count):
-            elapsed = source_last_done.get(sid, 0) - source_first_submit.get(sid, 0)
+            first = source_first_submit.get(sid, now)
+            last = source_last_done.get(sid)
+            if last is None:
+                # fonte non completata (timeout batch): stima con timeout globale
+                elapsed = float(_BULK_CHECK_TIMEOUT)
+                note = "timeout"
+            else:
+                elapsed = last - first
+                note = "ok"
             errs = source_error_count.get(sid, 0)
-            note = "ok"
             if errs:
                 note = f"{errs} error(s)"
             print(f"{sid:<24} {source_item_count[sid]:<8} {errs:<8} {elapsed:>6.1f}s  {note}")


### PR DESCRIPTION
## Cosa cambia

Basato su analisi del run #33 (21m 30s) e build locale di verifica.

### Performance

| Area | Prima (CI #33) | Dopo (locale) |
|---|---|---|
| Inventory build | 16m 41s | **4m 21s** |
| Workers | 8 | **16** |
| Fonti catalog-watch | 13 | **11** (-2 rotte) |

### Modifiche al registry

- `lavoro_opendata` → **radar-only** (ValueError sistematico, restituisce HTML)
- `mur_ustat` → **radar-only** (ConnectTimeout sistematico)
- `inps` → mantenuto `package_show_sample` con nota motivata (testato `current_package_list`, degrada a offset alti)

### Fix tecnici

- **Timing per-source reali**: fixato bug di chiusura lambda in `_record_timing` (`build_catalog_inventory.py`). Ora ogni fonte stampa il proprio tempo reale invece di ereditare l'ultimo della loop.
- **Per-source timing source-check**: aggiunto tracking in `run_bulk_check()` (`bulk_source_check.py`) — stampa tabella riassuntiva per fonte al termine.
- **Workers 16**: aumentato `--workers` in workflow e `MAX_WORKERS` default. Argparse aggiornato per accettare range 1-16.

### Test effettuati

- Build inventory completo locale: 11 fonti, 13.397 items, **4m 21s**
- Source-check con per-source timing: funzionante
- YAML valido, import collector OK, `--workers 16` accettato
