### PR TITLE
feat: registra 6 nuove fonti nel sources_registry

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -491,7 +491,7 @@ terna_opendata:
   source_kind: catalog
   protocol: rest
   observation_mode: radar-only
-  base_url: https://dati.terna.it/api/sitecore/dati/downloadcenter/records?f=xlsx&db=dati&pageSize=1
+  base_url: https://dati.terna.it/
   last_probed: '2026-05-18'
   verdict: go
   note: >

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -405,3 +405,133 @@ aifa:
   datasets_in_use:
     - aifa_spesa_consumo
   last_probed: '2026-05-18'
+dait:
+  source_kind: catalog
+  protocol: html
+  observation_mode: radar-only
+  base_url: https://dait.interno.gov.it/contenuti/tipo/open_data
+  last_probed: '2026-05-18'
+  verdict: go
+  note: >
+    DAIT — Anagrafe Amministratori locali. CSV snapshot annuali 1991-2026 + 
+    corrente. 41 su 42 entry sono snapshot dello stesso dataset.
+    radar-only iniziale per evitare rumore catalog inventory sui 41 snapshot.
+  datasets_in_use: []
+mit_opendata:
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://dati.mit.gov.it/catalog/api/3/action/package_list?limit=1
+  last_probed: '2026-05-18'
+  verdict: go
+  note: >
+    Portale CKAN MIT — 67 dataset su trasporti, infrastrutture, incidentalità,
+    veicoli, opere pubbliche. Include dataset già in uso dal Lab
+    (mit_incidentalita_mensile, mit_opere_incompiute).
+  datasets_in_use:
+    - mit_incidentalita_mensile
+    - mit_opere_incompiute_2020
+openga:
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://openga.giustizia-amministrativa.it/api/3/action/package_list?limit=1
+  last_probed: '2026-05-18'
+  verdict: go
+  note: >
+    Portale CKAN Giustizia Amministrativa — ~270 dataset su ricorsi TAR+CDS,
+    sentenze, ordinanze, pareri. CC-BY 4.0. Aggiornamento mensile.
+    Si incastra con civile_flussi (giustizia ordinaria).
+  datasets_in_use: []
+giustizia_statistiche:
+  source_kind: catalog
+  protocol: html
+  observation_mode: catalog-watch
+  base_url: https://datiestatistiche.giustizia.it/
+  last_probed: '2026-05-18'
+  verdict: go
+  note: >
+    Portale statistico Ministero Giustizia — XLSX scaricabili su flussi
+    civili/penali, clearance rate, disposition time, sorveglianza,
+    intercettazioni, monitoraggio tribunali, durata procedimenti.
+    Include dataset già in uso dal Lab.
+  html_portal:
+    topic_hint: giustizia
+    area_pages:
+      - 'https://datiestatistiche.giustizia.it/page/it/flussi-tribunali-ordinari-e-corti-di-appello'
+      - 'https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-civile'
+      - 'https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-penale'
+      - 'https://datiestatistiche.giustizia.it/it/sorveglianza.page'
+      - 'https://datiestatistiche.giustizia.it/it/intercettazioni.page'
+      - 'https://datiestatistiche.giustizia.it/page/it/durata-dei-procedimenti-civili'
+      - 'https://datiestatistiche.giustizia.it/page/it/monitoraggio-mensile-dei-tribunal'
+    delay_seconds: 0.3
+    probe_content_type: true
+  datasets_in_use:
+    - civile_flussi
+    - giustizia_penale_indicatori
+cortecostituzionale:
+  source_kind: catalog
+  protocol: html
+  observation_mode: catalog-watch
+  base_url: https://dati.cortecostituzionale.it/Scarica_i_dati/Scarica_i_dati
+  last_probed: '2026-05-18'
+  verdict: go
+  note: >
+    Portale Open Data Corte Costituzionale — Pronunce (1956-oggi), Massime,
+    Anagrafica Giudici, Atti di promovimento. CSV/XML/JSON in ZIP.
+    Agg. giornaliero. Endpoint SPARQL disponibile.
+  html_portal:
+    topic_hint: giustizia
+    homepage: https://dati.cortecostituzionale.it/Scarica_i_dati/Scarica_i_dati
+    delay_seconds: 0.3
+    probe_content_type: true
+  datasets_in_use: []
+terna_opendata:
+  source_kind: catalog
+  protocol: rest
+  observation_mode: radar-only
+  base_url: https://dati.terna.it/api/sitecore/dati/downloadcenter/records?f=xlsx&db=dati&pageSize=1
+  last_probed: '2026-05-18'
+  verdict: go
+  note: >
+    Portale Dati Terna — API Sitecore REST. 31+ dataset su energia
+    (fabbisogno, generazione, trasmissione, mercato, adeguatezza).
+    API pubblica ritorna XLSX. Già in uso da pipeline Lab.
+    Catalog-watch richiederebbe connector custom.
+  api_discovery:
+    endpoint: https://dati.terna.it/api/sitecore/dati/downloadcenter/records
+    known_datasets:
+      - TotalLoad
+      - MarketLoad
+      - PeakValleyLoad
+      - DailyDataIndexes
+      - InternationalComparisons
+      - IMCEI
+      - IMSER
+      - ElectricalEnergy
+      - Market
+      - IndustrialSector
+      - ServiceSector
+      - Total
+      - ConsumptionBySource
+      - ElectricityItaly
+      - ElectricityByType
+      - ActualGeneration
+      - RenewableGeneration
+      - EnergyBalance
+      - RenewableSources
+      - NonRenewableSources
+      - Storage
+      - ElectricityBySource
+      - ProductionRenewableSources
+      - HydroPower
+      - GrossVsCO2Emissions
+      - ProductionThermal
+      - ThermalHeat
+      - CapacityRenewableSources
+      - CapacityThermal
+      - GenerationPlants
+  datasets_in_use:
+    - terna_capacita_rinnovabile
+    - terna_electricity_by_source


### PR DESCRIPTION
## Cosa cambia

Aggiunte 6 nuove fonti al sources_registry.yaml. Il SO passa da 17 a **23 fonti**.

### Nuove fonti

| source_id | Protocollo | Mode | Dataset |
|---|---|---|---|
| `dait` | html | radar-only | Amministratori locali 1991-2026 |
| `mit_opendata` | ckan | **catalog-watch** | 67 dataset MIT (trasporti, infrastrutture) |
| `openga` | ckan | **catalog-watch** | ~270 dataset Giustizia Amministrativa |
| `giustizia_statistiche` | html | **catalog-watch** | 8+ XLSX flussi civili/penali |
| `cortecostituzionale` | html | **catalog-watch** | Pronunce 1956-oggi, Massime, Giudici |
| `terna_opendata` | rest | radar-only | 31+ dataset energia elettrica |

### Note

- **MIT** e **OpenGA** sono CKAN — catalog-watch nativo, inventory automatico
- **Giustizia Statistiche** e **Corte Costituzionale** sono html — csv_magnet scan con area_pages configurate
- **DAIT** e **Terna** in radar-only (inventory rumoroso o richiederebbe connector custom)

Closes #239
Closes #240
Closes #241
Closes #242
Closes #243
