### PR TITLE
fix: org/tags/notes per fonti HTML nel source-check

### DIFF
--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -218,6 +218,26 @@ def _enrich_with_inventory(
     inv_notes = row.get("notes_excerpt")
     inv_granularity = row.get("granularity")  # may be None
 
+    # Fallback per fonti HTML: inventory non ha org/tags/notes perché il
+    # csv_magnet scan cattura solo URL e titolo, non i metadati del portale.
+    # Deriviamo dai campi noti del registry (source_id, topic_hint, note).
+    inv_org = row.get("organization")
+    if not inv_org:
+        # source_id come organizzazione implicita (es. "aifa"→"AIFA")
+        inv_org = source_id.upper() if source_id else None
+    # NaN safeguard: pandas NaN è truthy in Python, ma `not x` su NaN è False.
+    # Usiamo pd.isna() per rilevare valori NaN/non popolati.
+    if pd.isna(inv_org) or pd.isna(inv_tags) or pd.isna(inv_notes):
+        hp = source_cfg.get("html_portal") or {}
+        topic_hint = hp.get("topic_hint") if isinstance(hp, dict) else None
+        src_note = source_cfg.get("note", "") or ""
+        if pd.isna(inv_org):
+            inv_org = source_id.upper() if source_id else None
+        if pd.isna(inv_tags) and topic_hint:
+            inv_tags = topic_hint
+        if pd.isna(inv_notes) and src_note:
+            inv_notes = src_note[:300]
+
     _raw_name = row.get("item_name") or row.get("item_id")
     item_name = "" if pd.isna(_raw_name) else str(_raw_name)
     _slug = row.get("item_slug")
@@ -259,12 +279,20 @@ def _enrich_with_inventory(
             return _parse_sdmx_annotations(xml_root, sdmx_base, item_name)
 
     def _enc(r: dict) -> dict:
-        """Aggiunge encoding dall'inventory row a qualsiasi result dict."""
+        """Aggiunge encoding dall'inventory row a qualsiasi result dict,
+        più organization derivata dal registry per fonti senza metadati."""
         r["encoding_suggested"] = _safe_str(row.get("encoding_suggested"))
         r["delim_suggested"] = _safe_str(row.get("delim_suggested"))
         r["decimal_suggested"] = _safe_str(row.get("decimal_suggested"))
         _skip = row.get("skip_suggested")
         r["skip_suggested"] = 0 if pd.isna(_skip) else int(_skip)
+        # Fallback per fonti HTML: inventory non ha organization/tags/notes
+        # (csv_magnet scan cattura solo URL e titolo).
+        # Assegnamento diretto (non setdefault): _EMPTY_ENRICH ha già queste
+        # chiavi a None, setdefault non sovrascriverebbe.
+        r["enriched_org"] = inv_org
+        r["enriched_tags"] = inv_tags
+        r["enriched_notes"] = inv_notes
         return r
 
     # HTML: use inventory url + content-type format detection
@@ -293,7 +321,12 @@ def _enrich_with_inventory(
             path = parsed.path or ""
             fmt_ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
             if fmt_ext in ("csv", "json", "xlsx", "xls"):
-                return _fetch_data_preview(data_url)
+                preview = _fetch_data_preview(data_url)
+                # Merge con _enc per arricchire org/tags/notes dal registry
+                if preview:
+                    # Unisce i campi del registry (enriched_org, encoding, etc.)
+                    _enc(preview)
+                return preview
 
     # HTML fallback: landing_page reachable
     landing = row.get("landing_page")
@@ -513,7 +546,7 @@ def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
         "item_id": row.get("item_id"),
         "item_name": row.get("item_name"),
         "title": enrich["enriched_title"] or row.get("title"),
-        "organization": row.get("organization"),
+        "organization": row.get("organization") if pd.notna(row.get("organization")) else enrich.get("enriched_org") or str(row.get("source_id", "")).upper(),
         "tags": enrich["enriched_tags"] or row.get("tags"),
         "notes": enrich["enriched_notes"],
         "url_checked": url_to_check,

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -492,3 +492,76 @@ def test_normalize_preview_columns_for_parquet_handles_existing_nested_rows(tmp_
     reloaded = pd.read_parquet(out)
     assert json.loads(reloaded.loc[reloaded["item_id"] == "old", "col_types"].iloc[0]) == {"b": "object"}
     assert json.loads(reloaded.loc[reloaded["item_id"] == "old", "columns"].iloc[0]) == ["b"]
+
+
+# ── _enrich_with_inventory: HTML NaN fallback ──────────────────────────────────
+
+class TestEnrichWithInventoryHtmlFallback:
+    """Regressione: organization/tags/notes_excerpt NaN nelle fonti HTML devono
+    essere derivati dal registry (source_id, topic_hint, note)."""
+
+    def _make_row(self, source_id: str, **overrides) -> dict:
+        """Costruisce una pd.Series finta con i campi minimi dell'inventory."""
+        import pandas as pd
+        import numpy as np
+        base = {
+            "source_id": source_id,
+            "item_id": "test-item-001",
+            "item_name": "test-item",
+            "title": "Test Dataset",
+            "organization": np.nan,
+            "tags": np.nan,
+            "notes_excerpt": np.nan,
+            "url": "https://example.com/test.csv",
+            "landing_page": np.nan,
+            "format": "CSV",
+            "granularity": np.nan,
+            "year_signal": np.nan,
+            "encoding_suggested": np.nan,
+            "delim_suggested": np.nan,
+            "decimal_suggested": np.nan,
+            "skip_suggested": np.nan,
+        }
+        base.update(overrides)
+        return pd.Series(base)
+
+    def test_aifa_produces_org_tags_notes(self):
+        from bulk_source_check import _enrich_with_inventory
+        import yaml
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
+
+        row = self._make_row("aifa")
+        result = _enrich_with_inventory(row, registry)
+
+        assert result["enriched_org"] == "AIFA", f"expected AIFA, got {result['enriched_org']!r}"
+        assert result["enriched_tags"] == "sanita", f"expected sanita, got {result['enriched_tags']!r}"
+        assert "Portale Open Data AIFA" in (result["enriched_notes"] or ""), \
+            f"expected AIFA note, got {result['enriched_notes']!r}"
+
+    def test_mim_opendata_produces_org_tags_notes(self):
+        from bulk_source_check import _enrich_with_inventory
+        import yaml
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
+
+        row = self._make_row("mim_opendata")
+        result = _enrich_with_inventory(row, registry)
+
+        assert result["enriched_org"] == "MIM_OPENDATA"
+        assert result["enriched_tags"] == "istruzione"
+        assert "Ministero Istruzione" in (result["enriched_notes"] or "")
+
+    def test_preserves_existing_org_non_nan(self):
+        """Se organization è già popolata (stringa), non deve essere sovrascritta."""
+        from bulk_source_check import _enrich_with_inventory
+        import yaml
+        import numpy as np
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
+
+        row = self._make_row("mim_opendata", organization="MIM ufficiale", tags=np.nan)
+        result = _enrich_with_inventory(row, registry)
+
+        assert result["enriched_org"] == "MIM ufficiale", \
+            f"non deve sovrascrivere org esistente: {result['enriched_org']!r}"


### PR DESCRIPTION
## Cosa cambia

Le fonti HTML (aifa, mef_irpef, mim_opendata, opencivitas) avevano `organization`, `tags` e `notes` sempre vuoti (286 item a 0%) nel source_check_results.parquet. Il csv_magnet scan dell'inventory cattura solo URL e titolo, non i metadati del portale.

### Fix

Derivazione automatica dal registry quando l'inventory non ha i dati:

| Campo | Fonte nel registry |
|---|---|
| `organization` | `source_id` uppercase (es. `mim_opendata` → `MIM_OPENDATA`) |
| `tags` | `html_portal.topic_hint` (es. `istruzione`, `sanita`, `fisco`) |
| `notes` | `note` del source (es. "Portale Ministero Istruzione...") |

### Bug tecnici fixati

1. **NaN è truthy in Python**: `float("nan") or X` → restituisce NaN. Sostituito `not x` con `pd.isna(x)` per rilevare valori mancanti.
2. **setdefault non sovrascrive**: `_fetch_data_preview` eredita da `_EMPTY_ENRICH` che ha già `enriched_tags: None`. Sostituito `setdefault` con assegnamento diretto.

### Test

```
mim_opendata   org='MIM_OPENDATA'   tags='istruzione'    notes='Portale Ministero Istruzione...'
aifa           org='AIFA'           tags='sanita'         notes='Portale Open Data AIFA...'
mef_irpef      org='MEF_IRPEF'      tags='fisco'          notes='Portale MEF Dipartimento Finanze...'
opencivitas    org='OPENCIVITAS'    tags='trasparenza'    notes='Portale OpenCivitas...'
```

Da 0/286 a **286/286** per organization e tags.
