### PR TITLE
docs: allineamento documentazione SO con stato reale

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,9 @@ data/catalog_inventory/generated/
 
 I JSON strutturali (`radar_summary`, `radar_history`, `catalog_signals`) sono consumati da **agent-context-builder** per il contesto operativo degli agenti.
 
-Artifact su GCS:
+Artifact su GCS (solo inventory e source-check — il radar vive su git + Actions artifacts):
 - `gs://dataciviclab-clean/catalog_inventory/` — parquet inventory + report
 - `gs://dataciviclab-clean/catalog_inventory/source-check/` — source-check results e snapshots
-- `gs://dataciviclab-clean/radar/` — radar summary
 
 ## Struttura
 

--- a/README.md
+++ b/README.md
@@ -7,36 +7,54 @@ Risponde a una domanda sola: **questa fonte vale il tempo del Lab?**
 ## Il funnel
 
 ```
-gate ── catalog-watch ── catalog-inventory ── source-check
-     └── radar-only
+radar ── gate ── catalog-watch ── catalog-inventory ── source-check
+             └── radar-only
 ```
 
-1. **Gate** — decide il regime di osservazione (`catalog-watch` o `radar-only`)
-2. **Catalog-inventory** — enumera gli item dei cataloghi ammessi
-3. **Source-check** — valuta qualità e granularità dei dataset
+1. **Radar** — probe leggero su tutte le fonti (health check, sempre)
+2. **Gate** — decide il regime di osservazione (`catalog-watch` o `radar-only`)
+3. **Catalog-inventory** — enumera gli item dei cataloghi ammessi
+4. **Source-check** — valuta qualità e granularità dei dataset
 
 Il funnel è alimentato dal `sources_registry.yaml`: ogni fonte ha un `source_id`, un `protocol` e un `observation_mode`. Le fonti nuove vengono aggiunte al registry manualmente.
 
-## La CI
+## CI / Workflow
 
-L'unica Action schedulata è `observatory.yml`. Gira ogni giorno alle 03:15 e in un solo job fa:
+Due workflow schedulati su GitHub Actions:
 
-1. **Radar** — probe leggero di tutte le fonti nel registry (sempre)
-2. **Inventory** — build dell'inventory parquet dei cataloghi enumerabili (solo lunedì o manual dispatch)
-3. **Source-check** — scoring item-level sul parquet inventory (sempre, incrementale)
+| Workflow | Schedule | Cosa fa |
+|---|---|---|
+| `radar.yml` | **daily** 03:15 | Radar check su tutte le fonti + sync `datasets_in_use` da DI catalog |
+| `observatory.yml` | **weekly** (lunedì) 03:20 | Inventory → catalog signals → source-check → upload GCS |
 
-I risultati vengono committati nel repo, caricati su GCS e pubblicati come artifact Actions.
+### `radar.yml` (daily)
+
+Probe leggero HTTP su ogni fonte nel registry. Aggiorna `radar_summary.json`, `radar_history.json`, `STATUS.md` e `sources_registry.yaml`. Committa i risultati su git.
+
+### `observatory.yml` (weekly, lunedì)
+
+1. **Inventory** — build del parquet `catalog_inventory_latest.parquet` per le fonti `catalog-watch`
+2. **Catalog signals** — calcola segnali di drift/inventory, produce `catalog_signals.json` e `CATALOG_WATCH_REPORT.md`
+3. **Source-check** — scoring item-level sul parquet inventory (merge con risultati precedenti da GCS)
+4. **Upload GCS** — parquet, report e snapshot su `gs://dataciviclab-clean/catalog_inventory/`
+5. **Issue alert** — crea/aggiorna automaticamente issue `catalog-alert` in caso di variazioni rilevanti
+
+I risultati vengono committati nel repo (signals), caricati su GCS e pubblicati come artifact Actions.
 
 ## Script
 
 | Script | Cosa fa |
 |---|---|
 | `scripts/radar_check.py` | Health check delle fonti nel registry |
+| `scripts/sync_datasets_in_use.py` | Sincronizza `datasets_in_use` dal catalogo DI (`radar.yml`) |
 | `scripts/build_catalog_inventory.py` | Snapshot tabulare di tutti gli item enumerabili |
 | `scripts/build_catalog_signals.py` | Segnali drift/inventory del catalogo |
 | `scripts/bulk_source_check.py` | Scoring item-level (qualità, granularità, rilevanza) |
+| `scripts/source_check_analyze.py` | Logica di scoring e analisi (usata da `bulk_source_check.py`) |
+| `scripts/source_check_fetch.py` | Fetch HTTP e enrichment per source-check |
 | `scripts/catalog_diff.py` | Diff tra due report inventory per segnalare regressioni |
 | `scripts/collectors/` | Adapter per protocollo: CKAN, SDMX, SPARQL, HTML |
+| `scripts/gha/` | Helper per CI (issue body, publish summary) |
 
 ```bash
 # Radar (giornaliero)
@@ -63,7 +81,7 @@ Il layer MCP (`mcp/so_server_core.py`) è il modo consigliato per consultare gli
 
 ## Output e artefatti
 
-Gli artifact strutturali (`radar_summary.json`, `radar_history.json`, `catalog_signals.json`, `STATUS.md`) sono versionati nel repo e aggiornati dalla CI. I parquet in `generated/` sono cache operative.
+Gli artifact strutturali (`radar_summary.json`, `radar_history.json`, `catalog_signals.json`, `STATUS.md`) sono versionati nel repo e aggiornati dalla CI. I parquet in `generated/` sono cache operative, sovrascritti a ogni run.
 
 ```
 data/radar/
@@ -82,9 +100,12 @@ data/catalog_inventory/generated/
   source_check_results.parquet       # scoring item-level
 ```
 
-I tre JSON (`radar_summary`, `catalog_signals`, `radar_history`) sono consumati da **agent-context-builder** per il contesto operativo degli agenti.
+I JSON strutturali (`radar_summary`, `radar_history`, `catalog_signals`) sono consumati da **agent-context-builder** per il contesto operativo degli agenti.
 
-L'artifact parquet su GCS: `gs://dataciviclab-clean/catalog_inventory/`
+Artifact su GCS:
+- `gs://dataciviclab-clean/catalog_inventory/` — parquet inventory + report
+- `gs://dataciviclab-clean/catalog_inventory/source-check/` — source-check results e snapshots
+- `gs://dataciviclab-clean/radar/` — radar summary
 
 ## Struttura
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,10 +9,17 @@ scripts/
     ckan.py            # collector CKAN
     sdmx.py            # collector SDMX
     sparql.py          # collector SPARQL
+    html.py            # collector HTML (scraping pagine con link a dati)
   build_catalog_inventory.py   # entry point: enumera fonti → parquet
   build_catalog_signals.py     # entry point: drift/inventory del catalogo
   bulk_source_check.py         # entry point: enrichment e scoring per intake
+  source_check_analyze.py      # logica scoring e analisi (chiamata da bulk_source_check)
+  source_check_fetch.py        # fetch HTTP e enrichment per source-check
+  radar_check.py               # health check HTTP su tutte le fonti (radar)
+  sync_datasets_in_use.py      # sincronizza datasets_in_use dal catalogo DI
+  catalog_diff.py              # diff tra report inventory
   _constants.py                # costanti condivise tra script
+  gha/                         # helper per CI (issue body, publish summary)
 ```
 
 ## Regola fondamentale: riusa collectors/base.py
@@ -70,6 +77,15 @@ if __name__ == "__main__":
 - **Nessuna eccezione silenziata senza motivo.** Se catturi `Exception`, logga o restituisci un valore sentinel esplicito (es. `None`, `enrich_method: "error"`).
 - **Tipi espliciti** sulle firme delle funzioni pubbliche.
 - **No dipendenze nuove** senza discussione — il progetto usa `requests`, `pandas`, `pyyaml`, `duckdb`. Per parsing XML usa `xml.etree.ElementTree` stdlib.
+- **lab_connectors**: dependency esterna per `safe_connect()` a DuckDB e utility HTTP condivise con altri repo del Lab.
+
+## Circuit breaker host-level
+
+Il source-check implementa un circuit breaker host-level per evitare di martellare fonti che rispondono con errori persistenti.
+
+- `--circuit-fail-threshold 2` (default): dopo 2 fallimenti consecutivi su uno stesso host, il circuito si apre e salta le richieste successive verso quell'host nel run corrente
+- Il circuito si resetta a ogni nuovo run di source-check
+- Utile per fonti con WAF o rate limiting (es. ANAC, opencoesione)
 
 ## Boundary segnali: radar vs catalog
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -19,12 +19,11 @@ Output:
 
 - [STATUS.md](../data/radar/STATUS.md)
 
-Scheduling v0:
+Scheduling:
 
-- run giornaliero via GitHub Actions (`observatory.yml`)
-- `workflow_dispatch` disponibile per run manuali
-- il modello v0 è `report-only`: aggiorna `STATUS.md` e `sources_registry.yaml`
-- nessuna issue automatica o alerting complesso in questa fase
+- `radar.yml`: run **daily** 03:15 — health check, aggiorna `STATUS.md`, `radar_summary.json`, `radar_history.json`, `sources_registry.yaml`
+- `observatory.yml`: run **weekly** (lunedì) 03:20 — inventory, catalog signals, source-check, upload GCS
+- `workflow_dispatch` disponibile per entrambi i workflow per run manuali
 
 Comportamento probe:
 
@@ -57,11 +56,12 @@ Usa `catalog-watch` quando la domanda è:
 
 Modello v0:
 
-- i segnali vengono prodotti automaticamente dal workflow schedulato `observatory.yml` (ogni lunedì 03:15)
+- i segnali vengono prodotti automaticamente dal workflow schedulato `observatory.yml` (ogni lunedì 03:20)
 - il follow-up resta `human-run`: il report non sostituisce la review umana sui cambi rilevanti
 - il run manuale va usato quando serve un check metodologicamente difendibile fuori schedule
 - gli output canonici restano `CATALOG_WATCH_REPORT.md` e `catalog_signals.json`
 - problemi di connessione/HTTP vanno letti in `radar_summary.json`, non in `catalog_signals.json`
+- **Issue automatiche**: in caso di variazioni rilevanti nel catalogo, `observatory.yml` crea o aggiorna una issue `catalog-alert` su GitHub
 
 ## Catalog inventory
 
@@ -88,9 +88,11 @@ Disciplina:
 - il perimetro segue le fonti `catalog-watch` del registry
 - una fonte può restare osservata in SO ma non essere inventariabile
 - `anac` oggi resta escluso dall'inventory automatico per vincoli WAF
-- l'upload su GCS è opzionale e richiede secret espliciti
+- l'upload su GCS richiede secret espliciti (GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT, CATALOG_INVENTORY_GCS_PREFIX)
 - in assenza di GCS il workflow resta valido: usa baseline locale vuota e salta i passaggi opzionali di storage/diff
 - il workflow gira ogni lunedì (schedule) ed è disponibile anche via `workflow_dispatch`
+- `--skip-red-sources` usato in CI per evitare tentativi su fonti già RED (timeout, WAF)
+- `sync_datasets_in_use.py` viene eseguito nel workflow `radar.yml` per allineare il catalogo DI
 
 ## Ordine consigliato
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -11,7 +11,7 @@ Gli artifact di catalog-inventory sono cache locali sotto `data/catalog_inventor
 | Workflow | Schedule | Prodotto principale | Dove finisce |
 |---|---|---|---|
 | `radar.yml` | **daily** 03:15 | `radar_summary.json`, `radar_history.json`, `sources_registry.yaml`, `STATUS.md` | commit su git |
-| `observatory.yml` | **weekly** lun 03:20 | `catalog_signals.json`, `source_check_results.parquet`, `catalog_inventory_report.json`, `catalog_inventory_latest.parquet` | upload GCS + commit signals su git |
+| `observatory.yml` | **weekly** lun 03:20 | inventory parquet, source-check parquet, `catalog_signals.json`, `CATALOG_WATCH_REPORT.md` | upload GCS + commit signals su git. Crea/aggiorna issue `catalog-alert` in caso di variazioni |
 | `ci.yml` | PR/push su main | test, lint, mypy, smoke test | solo CI — non produce artifact |
 
 Il server MCP legge i dati nell'ordine: **GCS → cache locale**. I commit su git sono la fonte per radar e signals. I parquet operativi sono letti dal prefisso GCS configurato (`CATALOG_INVENTORY_GCS_PREFIX`); la cache locale in `data/catalog_inventory/generated/` è il fallback.
@@ -146,7 +146,7 @@ In `auto`, il server prova i prefissi GCS pubblici; se il read GCS fallisce, usa
 
 - `so_infer_topic`
   - inferisce tema da qualunque testo (item_name, title, tags, notes)
-  - tassonomia 13 temi: lavoro, economia, sanita, istruzione, trasporti, ambiente, agricoltura, turismo, giustizia, demografia, energia, commercio
+  - tassonomia 20 temi: lavoro, economia, sanita, istruzione, trasporti, ambiente, agricoltura, turismo, giustizia, demografia, energia, commercio, welfare, previdenza, casa, cultura, bilancio, innovazione, sicurezza
   - ritorna: topics (dict ordinato), top_match (se score>=3), matched_count
 
 - `so_recommend_sources`


### PR DESCRIPTION
## Cosa

Audit completo della documentazione di `source-observatory` — 17 file `.md` analizzati vs stato reale del repo (workflow CI, script, artifact, registry).

A giro: README.md, docs/runbook.md, docs/architecture.md, mcp/README.md.

## Perché

La documentazione era obsoleta su punti strutturali: descriveva un unico workflow schedulato quando in realtà ce ne sono due (radar.yml daily, observatory.yml weekly), non menzionava script esistenti (html.py, source_check_analyze.py, etc.), nascondeva le issue automatiche catalog-alert, e riportava tassonomia temi errata (13→20).

## Cosa cambia

| File | Correzione |
|---|---|
| `README.md` | Funnel con radar come primo step, due workflow separati, script table completa, GCS paths, radar_history.json tra gli artifact |
| `docs/runbook.md` | Scheduling corretto (radar daily, observatory weekly), issue automatiche catalog-alert, flag `--skip-red-sources`, sync_datasets_in_use |
| `docs/architecture.md` | Aggiunti html.py, source_check_analyze.py, source_check_fetch.py, sync_datasets_in_use.py, gha/, lab_connectors, circuit breaker |
| `mcp/README.md` | Tabella workflow aggiornata con issue alert, tassonomia so_infer_topic 13→20 temi |

## Verdetto

Primo giro di allineamento. I LOW (skills/source-check, data/radar/README) rimandati a giro successivo.