### PR TITLE
feat: conftest arricchito, -21 righe di sys.path ridondanti

### DIFF
--- a/mcp/so_server_core.py
+++ b/mcp/so_server_core.py
@@ -5,14 +5,14 @@ Artifact paths are resolved relative to the source-observatory repository.
 """
 from __future__ import annotations
 
-import json
 import importlib.util
+import json
 import os
 import re
 import subprocess
-import unicodedata
 import sys
 import tempfile
+import unicodedata
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -23,7 +23,6 @@ from urllib.parse import urlparse
 import duckdb
 import requests
 from lab_connectors.duckdb import safe_connect
-
 from lab_connectors.gcs.paths import CLEAN_BUCKET
 from lab_connectors.http import HttpClient
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "I"]
+ignore = ["E501"]
 
 [tool.pytest.ini_options]
 testpaths = "tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,5 @@ select = ["E4", "E7", "E9", "F", "I"]
 
 [tool.pytest.ini_options]
 testpaths = "tests"
-addopts = "-q --tb=line"
+addopts = "-q --tb=line --cov=scripts/"
 filterwarnings = ["ignore::DeprecationWarning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,9 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
-ignore = ["E501"]
+select = ["E4", "E7", "E9", "F", "I"]
 
 [tool.pytest.ini_options]
 testpaths = "tests"
-addopts = "-q --tb=line --cov=scripts/"
+addopts = "-q --tb=line"
 filterwarnings = ["ignore::DeprecationWarning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F"]
+select = ["E", "F", "W", "I"]
 
 [tool.pytest.ini_options]
 testpaths = "tests"
+addopts = "-q --tb=line --cov=scripts/"
 filterwarnings = ["ignore::DeprecationWarning"]
-addopts = "-q --tb=line"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 pytest>=9.0.3,<10.0
+pytest-cov>=6.0.0
 ruff>=0.15.13,<1.0.0
 mypy>=2.0.0,<3.0.0
 types-requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 pytest>=9.0.3,<10.0
-pytest-cov>=6.0.0
 ruff>=0.15.13,<1.0.0
 mypy>=2.0.0,<3.0.0
 types-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ jsonschema>=4.26.0,<5.0
 mcp>=1.27.1
 fastmcp>=3.2.4
 # Path contract GCS — vedere lab-connectors/gcs/paths.py
-lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.9.0
+lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@feat/testing-module
 dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@9471ddb

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ jsonschema>=4.26.0,<5.0
 mcp>=1.27.1
 fastmcp>=3.2.4
 # Path contract GCS — vedere lab-connectors/gcs/paths.py
-lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@feat/testing-module
+lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.0
 dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ mcp>=1.27.1
 fastmcp>=3.2.4
 # Path contract GCS — vedere lab-connectors/gcs/paths.py
 lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@feat/testing-module
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@9471ddb
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.10.0

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -10,21 +10,21 @@ from pathlib import Path
 from typing import Any, cast
 
 import pandas as pd
-
-from lab_connectors.duckdb import safe_connect
+from _constants import REGISTRY_PATH, load_registry, stale_reason_from_exception
 from collectors import dispatch, supported_protocols
 from collectors.base import inventory_cfg, now_utc_iso
 from collectors.ckan import (
-    collect_ckan_inventory_via_search,
+    collect as _collect_ckan_inventory,
+)
+from collectors.ckan import (
     collect_ckan_inventory_via_current_list,
     collect_ckan_inventory_via_package_list,
     collect_ckan_inventory_via_package_show_sample,
-    collect as _collect_ckan_inventory,
+    collect_ckan_inventory_via_search,
 )
-from collectors.sparql import collect as _collect_sparql_inventory
 from collectors.sdmx import collect as _collect_sdmx_inventory
-
-from _constants import REGISTRY_PATH, load_registry, stale_reason_from_exception
+from collectors.sparql import collect as _collect_sparql_inventory
+from lab_connectors.duckdb import safe_connect
 
 # Backwards-compatible alias for tests
 _error_to_stale_reason = stale_reason_from_exception

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -37,9 +37,17 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from source_check_analyze import (
+    _fallback_infer,
+    _finalize_scores,
+    _infer_granularity,
+    _infer_years,
+    _normalize_format,
+    _parse_ckan_package,
+)
 from source_check_fetch import (
-    SDMX_NS,
     _EMPTY_ENRICH,
+    SDMX_NS,
     _content_type_format,
     _fetch_ckan_package,
     _fetch_data_preview,
@@ -48,14 +56,6 @@ from source_check_fetch import (
     _fetch_sdmx_years,
     _http_head_with_retry,
     configure_source_check_http,
-)
-from source_check_analyze import (
-    _infer_granularity,
-    _infer_years,
-    _parse_ckan_package,
-    _fallback_infer,
-    _normalize_format,
-    _finalize_scores,
 )
 
 logger = logging.getLogger(__name__)

--- a/scripts/catalog_diff.py
+++ b/scripts/catalog_diff.py
@@ -4,8 +4,9 @@ Compara due report di catalog inventory e genera un sommario markdown delle dive
 """
 
 from __future__ import annotations
-import json
+
 import argparse
+import json
 import sys
 
 

--- a/scripts/collectors/__init__.py
+++ b/scripts/collectors/__init__.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from typing import Any
+
+from . import ckan, html, sdmx, sparql
 from .base import CollectorResult
-from . import ckan, sdmx, sparql, html
 
 COLLECTORS = {
     "ckan": ckan.collect,

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 from datetime import datetime, timezone
+from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 import requests
-
 
 USER_AGENT = "DataCivicLab-SourceObservatory/1.0"
 DEFAULT_TIMEOUT_SECONDS = 60

--- a/scripts/collectors/ckan.py
+++ b/scripts/collectors/ckan.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-import requests
 from typing import Any
 
-from .base import CollectorResult, strip_query, inventory_cfg, observatory_get
+import requests
 
+from .base import CollectorResult, inventory_cfg, observatory_get, strip_query
 
 CKAN_ACTION_NAMES = {
     "package_list",

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -25,9 +25,9 @@ import time
 from typing import Any
 from urllib.parse import urljoin
 
-from .base import CollectorResult
 from lab_connectors.http import HttpClient
 
+from .base import CollectorResult
 
 DATA_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls", ".ods", ".zip", ".xml", ".geojson"}
 

--- a/scripts/collectors/sparql.py
+++ b/scripts/collectors/sparql.py
@@ -4,13 +4,12 @@ from typing import Any
 
 from .base import (
     CollectorResult,
-    sparql_binding_value,
-    compact_uri_name,
     append_unique,
-    parse_int,
+    compact_uri_name,
     observatory_get,
+    parse_int,
+    sparql_binding_value,
 )
-
 
 SPARQL_QUERY_TEMPLATES = {
     "dcat_datasets": """

--- a/scripts/collectors/test_ckan_collector.py
+++ b/scripts/collectors/test_ckan_collector.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from collectors.ckan import (
-    extract_ckan_inventory_row,
-    _resource_format,
+    _ckan_api_base,
     _has_datastore_active,
     _resource_count,
-    _ckan_api_base,
+    _resource_format,
     ckan_action_endpoint,
     collect_ckan_inventory_via_package_show_sample,
+    extract_ckan_inventory_row,
 )
 
 

--- a/scripts/collectors/test_ckan_helpers.py
+++ b/scripts/collectors/test_ckan_helpers.py
@@ -1,4 +1,5 @@
-from collectors.ckan import _resource_format, _has_datastore_active, _resource_count
+from collectors.ckan import _has_datastore_active, _resource_count, _resource_format
+
 
 def test_resource_format():
     item = {

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -1,29 +1,27 @@
 from __future__ import annotations
 
 import argparse
+import json
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
-import json
 from pathlib import Path
 from typing import Any, Literal
 
+import jsonschema
 import requests
-
 from _constants import (
-    REGISTRY_PATH,
-    RADAR_SUMMARY_PATH,
     RADAR_HISTORY_PATH,
-    load_registry,
-    save_registry,
-    load_radar_history,
-    save_radar_history,
+    RADAR_SUMMARY_PATH,
+    REGISTRY_PATH,
     append_radar_probe,
+    load_radar_history,
+    load_registry,
+    save_radar_history,
+    save_registry,
 )
 from lab_connectors.http import HttpClient, HttpFallbackError
-
-import jsonschema
 
 _SCHEMA_DIR = Path(__file__).resolve().parents[1] / "schemas"
 

--- a/scripts/source_check_analyze.py
+++ b/scripts/source_check_analyze.py
@@ -11,7 +11,6 @@ from typing import Optional
 
 import pandas as pd
 
-
 # ── euristica granularità ─────────────────────────────────────────────────────
 
 

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -575,7 +575,7 @@ def _fetch_data_preview(
         import tempfile
         from pathlib import Path
 
-        from toolkit.profile.raw import sniff_source_file, profile_with_read_cfg
+        from toolkit.profile.raw import profile_with_read_cfg, sniff_source_file
 
         columns: list[str] = []
         col_types: dict[str, str] = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,63 @@
 """Conftest per source-observatory.
 
-Aggiunge scripts/ a sys.path in modo che i test possano importare
-i moduli direttamente senza importlib.util boilerplate.
+Aggiunge ``scripts/`` e ``mcp/`` a ``sys.path`` in modo che i test
+possano importare i moduli senza boilerplate.
+
+Fornisce anche fixture condivise per mock HTTP e artifact locali.
 """
+from __future__ import annotations
+
 import sys
 from pathlib import Path
+from typing import Any
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import pytest
+
+# Aggiungi percorsi di import prima di qualsiasi test
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+_MCP_DIR = Path(__file__).resolve().parent.parent / "mcp"
+
+for _p in (_SCRIPTS_DIR, _MCP_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+
+# ------------------------------------------------------------------
+# Fixture: artifact backend locale (default per tutti i test)
+# ------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _use_local_artifacts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tutti i test SO usano artifact backend locale per default."""
+    monkeypatch.setenv("SO_ARTIFACT_BACKEND", "local")
+
+
+# ------------------------------------------------------------------
+# Fixture: FakeHttpClient (da lab_connectors.testing)
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_http() -> Any:
+    """Fixture che restituisce un ``FakeHttpClient`` pulito.
+
+    Ogni test riceve un'istanza nuova con ``responses`` e ``requests``
+    vuoti.  È un alias per ``FakeHttpClient()`` importato da
+    ``lab_connectors.testing``.
+
+    Usage::
+
+        def test_something(fake_http):
+            from lab_connectors.http import HttpResult
+            from lab_connectors.testing import fake_response
+
+            fake_http.responses["https://example.test/data"] = HttpResult(
+                response=fake_response(200, "ok"), err=None,
+            )
+            result = fake_http.get("https://example.test/data")
+            assert result.is_ok
+    """
+    from lab_connectors.testing import FakeHttpClient
+
+    return FakeHttpClient()

--- a/tests/test_build_catalog_signals.py
+++ b/tests/test_build_catalog_signals.py
@@ -1,12 +1,9 @@
 """Tests for build_catalog_signals.py."""
 
 import json
-import sys
 from pathlib import Path
 
 import jsonschema
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
 from build_catalog_signals import build_signals, build_watch_report, _classify
 

--- a/tests/test_build_catalog_signals.py
+++ b/tests/test_build_catalog_signals.py
@@ -4,8 +4,7 @@ import json
 from pathlib import Path
 
 import jsonschema
-
-from build_catalog_signals import build_signals, build_watch_report, _classify
+from build_catalog_signals import _classify, build_signals, build_watch_report
 
 _SCHEMA_DIR = Path(__file__).resolve().parents[1] / "schemas"
 

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from collectors.ckan import _ckan_api_base
 from lab_connectors.http import HttpResult
-
 from source_check_analyze import (
     _infer_granularity,
     _infer_years,
     _intake_score,
 )
-from collectors.ckan import _ckan_api_base
 
 
 class _FakeResp:
@@ -464,7 +463,6 @@ def test_normalize_preview_columns_for_parquet_handles_existing_nested_rows(tmp_
 
     import numpy as np
     import pandas as pd
-
     from bulk_source_check import _normalize_preview_columns_for_parquet
 
     df = pd.DataFrame(
@@ -499,8 +497,8 @@ class TestEnrichWithInventoryHtmlFallback:
 
     def _make_row(self, source_id: str, **overrides) -> dict:
         """Costruisce una pd.Series finta con i campi minimi dell'inventory."""
-        import pandas as pd
         import numpy as np
+        import pandas as pd
         base = {
             "source_id": source_id,
             "item_id": "test-item-001",
@@ -523,8 +521,8 @@ class TestEnrichWithInventoryHtmlFallback:
         return pd.Series(base)
 
     def test_aifa_produces_org_tags_notes(self):
-        from bulk_source_check import _enrich_with_inventory
         import yaml
+        from bulk_source_check import _enrich_with_inventory
         with open("data/radar/sources_registry.yaml") as f:
             registry = yaml.safe_load(f)
 
@@ -537,8 +535,8 @@ class TestEnrichWithInventoryHtmlFallback:
             f"expected AIFA note, got {result['enriched_notes']!r}"
 
     def test_mim_opendata_produces_org_tags_notes(self):
-        from bulk_source_check import _enrich_with_inventory
         import yaml
+        from bulk_source_check import _enrich_with_inventory
         with open("data/radar/sources_registry.yaml") as f:
             registry = yaml.safe_load(f)
 
@@ -551,9 +549,9 @@ class TestEnrichWithInventoryHtmlFallback:
 
     def test_preserves_existing_org_non_nan(self):
         """Se organization è già popolata (stringa), non deve essere sovrascritta."""
-        from bulk_source_check import _enrich_with_inventory
-        import yaml
         import numpy as np
+        import yaml
+        from bulk_source_check import _enrich_with_inventory
         with open("data/radar/sources_registry.yaml") as f:
             registry = yaml.safe_load(f)
 
@@ -598,6 +596,7 @@ class TestSdmxParseAnnotations:
 
     def test_extracts_version_and_agency(self) -> None:
         import xml.etree.ElementTree as ET
+
         from bulk_source_check import _parse_sdmx_annotations
         root = ET.fromstring(_SDMX_XML)
         result = _parse_sdmx_annotations(root, "https://example.test/dataflow/IT1", "32_221")
@@ -610,6 +609,7 @@ class TestSdmxParseAnnotations:
     def test_no_agency_returns_none(self) -> None:
         """Se l'attributo agencyID non c'è, sdmx_agency deve essere None, non un default."""
         import xml.etree.ElementTree as ET
+
         from bulk_source_check import _parse_sdmx_annotations
         root = ET.fromstring(_SDMX_XML_NO_AGENCY)
         result = _parse_sdmx_annotations(root, "https://example.test/dataflow/IT1", "42_999")
@@ -621,6 +621,7 @@ class TestSdmxParseAnnotations:
     def test_extracts_keywords(self) -> None:
         """Le annotation keywords continuano a funzionare."""
         import xml.etree.ElementTree as ET
+
         from bulk_source_check import _parse_sdmx_annotations
         xml_with_ann = _SDMX_XML.replace(
             "<common:Name>Test dataflow</common:Name>",
@@ -721,8 +722,8 @@ class TestSdmxCheckRowPassthrough:
     """contract: _check_row passa sdmx_flow/version/agency nel result dict."""
 
     def test_sdmx_fields_in_result(self, monkeypatch) -> None:
-        import pandas as pd
         import numpy as np
+        import pandas as pd
         import yaml
         from bulk_source_check import _check_row
 

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -1,11 +1,6 @@
 """Tests per bulk_source_check: regole non ovvie, edge case, bug già visti."""
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
-
 from lab_connectors.http import HttpResult
 
 from source_check_analyze import (

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -1,6 +1,8 @@
 """Tests per bulk_source_check: regole non ovvie, edge case, bug già visti."""
 from __future__ import annotations
 
+from pathlib import Path
+
 from lab_connectors.http import HttpResult
 
 from source_check_analyze import (

--- a/tests/test_catalog_diff.py
+++ b/tests/test_catalog_diff.py
@@ -1,11 +1,6 @@
 """Tests for catalog_diff.py — generate_diff."""
 from __future__ import annotations
 
-import sys
-import os
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
-
 from catalog_diff import generate_diff
 
 

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -1,25 +1,13 @@
 from __future__ import annotations
 
 import json
-import sys
-from pathlib import Path
 
 import pandas as pd  # must be before so_server_core import
 
-# Aggiungi mcp/ a sys.path: senza __init__.py non c'è collisione col package PyPI `mcp`.
-# so_server_core è un modulo normale, non un sottomodulo di un package `mcp`.
-_mcp_dir = Path(__file__).resolve().parents[1] / "mcp"
-sys.path.insert(0, str(_mcp_dir))
-
-import so_server_core as core  # noqa: E402
+import so_server_core as core  # noqa: E402  # conftest aggiunge mcp/ a sys.path
 
 import duckdb  # noqa: E402
 import pytest  # noqa: E402
-
-
-@pytest.fixture(autouse=True)
-def _use_local_artifacts(monkeypatch) -> None:
-    monkeypatch.setenv("SO_ARTIFACT_BACKEND", "local")
 
 
 def _write_parquet(path, rows: list[dict]) -> None:

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -7,7 +7,6 @@ import pandas as pd  # must be before so_server_core import
 import so_server_core as core  # noqa: E402  # conftest aggiunge mcp/ a sys.path
 
 import duckdb  # noqa: E402
-import pytest  # noqa: E402
 
 
 def _write_parquet(path, rows: list[dict]) -> None:

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 import json
 
-import pandas as pd  # must be before so_server_core import
-
-import so_server_core as core  # noqa: E402  # conftest aggiunge mcp/ a sys.path
-
 import duckdb  # noqa: E402
+import pandas as pd  # must be before so_server_core import
+import so_server_core as core  # noqa: E402  # conftest aggiunge mcp/ a sys.path
 
 
 def _write_parquet(path, rows: list[dict]) -> None:

--- a/tests/test_so_server_wrapper.py
+++ b/tests/test_so_server_wrapper.py
@@ -2,15 +2,8 @@
 from __future__ import annotations
 
 import asyncio
-import sys
-from pathlib import Path
 
-# Aggiungi mcp/ a sys.path: senza __init__.py non c'è collisione col package PyPI `mcp`.
-# so_server.py importa so_server_core come sibling module (stessa directory).
-_mcp_dir = Path(__file__).resolve().parents[1] / "mcp"
-sys.path.insert(0, str(_mcp_dir))
-
-import so_server  # noqa: E402
+import so_server  # noqa: E402  # conftest aggiunge mcp/ a sys.path
 
 
 def test_mcp_server_registers_17_tools() -> None:


### PR DESCRIPTION
## Cosa

Pulizia dell'infrastruttura di test:

- **`tests/conftest.py`** ora aggiunge anche `mcp/` a sys.path e fornisce fixture `fake_http` (FakeHttpClient da lab_connectors.testing)
- **5 file** avevano `sys.path.insert(0, ...)` ridondante (già coperto da conftest) — rimossi
- **`test_so_mcp.py`**: rimossa fixture `_use_local_artifacts` duplicata (già in conftest), rimosso `sys.path.insert` per `mcp/`
- **`test_so_server_wrapper.py`**: rimosso blocco `sys.path.insert` per `mcp/`

### Dipendenza
- `requirements.txt` aggiornato a `lab-connectors@feat/testing-module`

## Test
`pytest tests/ -q` → 174 passed, 0 failed
