### PR TITLE
ci: test marker audit workflow + pytest-timeout

### DIFF
--- a/.github/scripts/audit_test_markers.py
+++ b/.github/scripts/audit_test_markers.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Audit test markers — cross-repo.
+
+Usage:
+    python3 _local/scripts/audit_test_markers.py tests/            # audit entire dir
+    python3 _local/scripts/audit_test_markers.py tests/ --diff     # only unmarked (exit 1 if any)
+    python3 _local/scripts/audit_test_markers.py tests/ --json     # machine-readable
+    python3 _local/scripts/audit_test_markers.py tests/ --files f1.py f2.py  # specific files
+
+Exit code:
+    0 = all tests have markers (or --diff not set)
+    1 = at least one test without marker (only with --diff)
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+MARKERS = {"contract", "policy", "regression", "adapter", "pure_unit", "smoke"}
+_MARKER_RE = re.compile(r"mark\.(\w+)")
+
+
+class TestCollector(ast.NodeVisitor):
+    """Collect test functions and their markers via AST.
+
+    Detects markers from:
+    - @pytest.mark.xxx decorators on test functions/methods
+    - Module-level ``pytestmark = pytest.mark.xxx`` (applied to all tests in file)
+    """
+
+    def __init__(self) -> None:
+        self.results: list[dict] = []
+        self._module_markers: set[str] = set()
+
+    def visit_Module(self, node: ast.Module) -> None:
+        # Collect module-level pytestmark first
+        for stmt in ast.iter_child_nodes(node):
+            if isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    if isinstance(target, ast.Name) and target.id == "pytestmark":
+                        marker = self._get_marker_name(stmt.value)
+                        if marker:
+                            self._module_markers.add(marker)
+                    # Also handle list: pytestmark = [pytest.mark.contract, pytest.mark.smoke]
+                    elif isinstance(target, ast.Name) and target.id == "pytestmark":
+                        if isinstance(stmt.value, ast.List):
+                            for elt in stmt.value.elts:
+                                m = self._get_marker_name(elt)
+                                if m:
+                                    self._module_markers.add(m)
+
+        for stmt in ast.iter_child_nodes(node):
+            if isinstance(stmt, ast.FunctionDef) and stmt.name.startswith("test_"):
+                self._visit_test_function(stmt)
+            elif isinstance(stmt, ast.ClassDef):
+                for child in ast.iter_child_nodes(stmt):
+                    if isinstance(child, ast.FunctionDef) and child.name.startswith("test_"):
+                        self._visit_test_function(child)
+        self.generic_visit(node)
+
+    def _visit_test_function(self, node: ast.FunctionDef) -> None:
+        markers: set[str] = set()
+        # Inherit module-level markers
+        markers.update(self._module_markers)
+        # Add per-function decorator markers
+        for decorator in reversed(node.decorator_list):
+            marker = self._get_marker_name(decorator)
+            if marker:
+                markers.add(marker)
+        self.results.append(
+            {
+                "test": node.name,
+                "markers": sorted(markers & MARKERS),
+                "missing": sorted(MARKERS - markers),
+                "unmarked": not bool(markers & MARKERS),
+            }
+        )
+
+    def _get_marker_name(self, node: ast.expr) -> str | None:
+        try:
+            src = ast.unparse(node)
+            m = _MARKER_RE.search(src)
+            if m and m.group(1) in MARKERS:
+                return m.group(1)
+        except Exception:
+            pass
+        return None
+
+
+def collect_tests(tests_dir: Path, file_filter: list[str] | None = None) -> list[dict]:
+    results = []
+    pattern = "test_*.py"
+    for fpath in sorted(tests_dir.glob(pattern)):
+        if fpath.name == "conftest.py":
+            continue
+        if file_filter and fpath.name not in file_filter:
+            continue
+        # Also look in subdirectories
+        if not fpath.is_file():
+            continue
+        try:
+            tree = ast.parse(fpath.read_text(), filename=fpath.name)
+        except SyntaxError:
+            continue
+        visitor = TestCollector()
+        visitor.visit(tree)
+        for r in visitor.results:
+            r["file"] = fpath.name
+            results.append(r)
+
+    # Also scan subdirectories (e.g. tests/http/ in lab-connectors)
+    for subdir in sorted(tests_dir.iterdir()):
+        if not subdir.is_dir() or subdir.name.startswith("__") or subdir.name == "__pycache__":
+            continue
+        for fpath in sorted(subdir.glob("test_*.py")):
+            if file_filter and fpath.name not in file_filter:
+                continue
+            try:
+                tree = ast.parse(fpath.read_text(), filename=fpath.name)
+            except SyntaxError:
+                continue
+            visitor = TestCollector()
+            visitor.visit(tree)
+            for r in visitor.results:
+                r["file"] = str(Path(subdir.name) / fpath.name)
+                results.append(r)
+
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Audit test markers in any repo's test directory."
+    )
+    parser.add_argument("tests_dir", type=str, help="Path to tests/ directory")
+    parser.add_argument(
+        "--diff",
+        action="store_true",
+        help="Exit 1 if any test is unmarked (for CI gate)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Machine-readable JSON output",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="*",
+        default=None,
+        help="Check only specific test files (for PR diff checks)",
+    )
+    args = parser.parse_args()
+
+    tests_path = Path(args.tests_dir)
+    if not tests_path.is_dir():
+        print(f"ERROR: directory not found: {tests_path}", file=sys.stderr)
+        sys.exit(2)
+
+    results = collect_tests(tests_path, args.files)
+    unmarked = [r for r in results if r["unmarked"]]
+    marked = [r for r in results if not r["unmarked"]]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "total": len(results),
+                    "marked": len(marked),
+                    "unmarked": len(unmarked),
+                    "tests": results,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print("=== Test Marker Audit ===")
+        print(f"Tests: {len(results)} | Marked: {len(marked)} | Unmarked: {len(unmarked)}")
+        print()
+        if unmarked:
+            print(f"--- UNMARKED TESTS ({len(unmarked)}) ---")
+            for r in unmarked:
+                print(f"  {r['file']}::{r['test']}")
+            print()
+            print("Suggested markers (pick one per test):")
+            print("  @pytest.mark.contract  — public interface, artifact format, CLI output")
+            print("  @pytest.mark.policy    — Lab rule not derivable from source code")
+            print("  @pytest.mark.regression — documented bug fix (link issue/PR)")
+            print("  @pytest.mark.adapter   — external service adapter logic")
+            print("  @pytest.mark.pure_unit  — pure logic, zero side effects")
+            print("  @pytest.mark.smoke     — golden path end-to-end")
+            print()
+        if not unmarked:
+            print("All tests have markers. OK")
+
+    if args.diff and unmarked:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/test-audit.yml
+++ b/.github/workflows/test-audit.yml
@@ -1,0 +1,39 @@
+name: Test Marker Audit
+
+on:
+  pull_request:
+    paths:
+      - "tests/**/test_*.py"
+      - "scripts/collectors/test_*.py"
+
+jobs:
+  audit-markers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Audit test markers in tests/
+        run: |
+          changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'tests/**/test_*.py' || true)
+          if [ -z "$changed" ]; then
+            echo "No test files changed in tests/. OK."
+            exit 0
+          fi
+          files=$(echo "$changed" | xargs -n1 basename | tr '\n' ' ')
+          python .github/scripts/audit_test_markers.py tests/ --diff --files $files
+
+      - name: Audit test markers in scripts/collectors/
+        run: |
+          changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'scripts/collectors/test_*.py' || true)
+          if [ -z "$changed" ]; then
+            echo "No test files changed in scripts/collectors/. OK."
+            exit 0
+          fi
+          files=$(echo "$changed" | xargs -n1 basename | tr '\n' ' ')
+          python .github/scripts/audit_test_markers.py scripts/collectors/ --diff --files $files

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -52,6 +52,7 @@ inps:
   observation_mode: catalog-watch
   base_url: https://serviziweb2.inps.it/odapi/package_list?limit=1
   inventory:
+    timeout: 180
     skip_current_list: true
     skip_current_list_reason: "current_package_list_with_resources degrada a offset
       alti (2300+ timeout 30s) — package_show_sample +16 workers è più veloce.\n"
@@ -80,6 +81,7 @@ openbdap:
   base_url: 
     https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
   inventory:
+    timeout: 300
     skip_package_search: true
     skip_package_search_reason: timeout sistematico a 60s
     skip_current_list: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ select = ["E4", "E7", "E9", "F", "I", "W"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "scripts/collectors"]
-addopts = "-q --tb=line --cov=scripts/ --cov=mcp/"
+addopts = "-q --tb=line --cov=scripts/ --cov=mcp/ --timeout=30"
 filterwarnings = ["ignore::DeprecationWarning"]
 markers = [
     "contract: interfaccia pubblica, artifact format, contratto API",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 pytest>=9.0.3,<10.0
 pytest-cov>=6.0.0
+pytest-timeout>=2.3.0
 ruff>=0.15.13,<1.0.0
 mypy>=2.0.0,<3.0.0
 types-requests

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, wait
@@ -62,7 +63,7 @@ DEFAULT_OUT_PARQUET = "catalog_inventory_latest.parquet"
 DEFAULT_OUT_REPORT = "catalog_inventory_report.json"
 
 
-_SOURCE_TIMEOUT = 300  # timeout individuale per fonte (5 min)
+_SOURCE_TIMEOUT = 120  # timeout individuale per fonte (2 min)
 
 
 def _collect_source(
@@ -70,33 +71,18 @@ def _collect_source(
 ) -> tuple[str, list[dict[str, Any]], dict[str, Any] | None, dict[str, Any] | None, Exception | None]:
     """Worker per ThreadPoolExecutor: raccoglie una fonte e cattura eccezioni.
 
-    Usa threading.Thread(daemon=True) per timeout reale. Se dispatch() non
-    completa in _SOURCE_TIMEOUT secondi, la fonte viene marcata fallita.
-    Il thread va in timeout ma non blocca l'uscita dello script (daemon=True).
+    NON usa threading.Thread annidato — dispatch() ha già timeout HTTP
+    esplicito via HttpClient. Il timeout globale per fonte è gestito dal
+    chiamante via source_timing check nel loop wait()/heartbeat.
+
+    Il vantaggio: niente GIL contention su join(), niente daemon thread leak,
+    niente doppio annidamento di thread.
     """
-    import threading as _threading
-
-    _result: list = []
-    _error: list = []
-
-    def _run() -> None:
-        try:
-            _result.append(dispatch(source_id, source_cfg, captured_at))
-        except Exception as exc:
-            _error.append(exc)
-
-    t = _threading.Thread(target=_run, daemon=True)
-    t.start()
-    t.join(timeout=_SOURCE_TIMEOUT)
-
-    if t.is_alive():
-        return source_id, [], None, None, TimeoutError(
-            f"Source {source_id} timed out after {_SOURCE_TIMEOUT}s"
-        )
-    if _error:
-        return source_id, [], None, None, _error[0]
-    res = _result[0]
-    return source_id, res.rows, res.warning, res.summary, None
+    try:
+        res = dispatch(source_id, source_cfg, captured_at)
+        return source_id, res.rows, res.warning, res.summary, None
+    except Exception as exc:
+        return source_id, [], None, None, exc
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -202,6 +188,15 @@ def main() -> None:
 
     collected: dict[str, tuple[list[dict[str, Any]], dict[str, Any] | None, dict[str, Any] | None, Exception | None]] = {}
     source_timing: dict[str, float] = {}
+
+    # Timeout per-fonte: leggibile dal blocco inventory.timeout nel registry,
+    # fallback a _SOURCE_TIMEOUT (120s). Permette a fonti lente (es. openbdap
+    # con sample_size=4000) di avere più tempo senza impattare le altre.
+    source_timeout: dict[str, int] = {}
+    for source_id, source_cfg in inventoriable:
+        inv = inventory_cfg(source_cfg)
+        source_timeout[source_id] = int(inv.get("timeout", _SOURCE_TIMEOUT))
+
     executor = ThreadPoolExecutor(max_workers=args.workers)
     try:
         future_to_id: dict[Any, str] = {}
@@ -218,23 +213,77 @@ def main() -> None:
                 source_timing.setdefault(_sid, time.time() - submit_times[_sid])
             f.add_done_callback(_record_timing)
 
-        # wait() timeout globale per il batch (rete di sicurezza). Il timeout
-        # reale per fonte è in _collect_source (_SOURCE_TIMEOUT = 300s).
+        # wait() con heartbeat ogni 30s. Il timeout per-fonte è imposto
+        # via submission time, non via thread join annidato (eliminato).
+        # Questa è la root cause fix: niente daemon thread leak, niente
+        # GIL contention su join() in C extension (XML parsing).
         _BATCH_TIMEOUT = 3600
-        done, not_done = wait(future_to_id, timeout=_BATCH_TIMEOUT)
+        _HEARTBEAT_INTERVAL = 30
+        pending: set[Any] = set(future_to_id.keys())
+        batch_start = time.time()
+        while pending:
+            remaining = _BATCH_TIMEOUT - (time.time() - batch_start)
+            if remaining <= 0:
+                break
+
+            batch_done, pending = wait(
+                pending, timeout=min(_HEARTBEAT_INTERVAL, remaining)
+            )
+
+            # Process completed futures from this batch
+            now = time.time()
+            for f in batch_done:
+                sid = future_to_id[f]
+                try:
+                    _, rows, warning, summary, err = f.result()
+                except Exception as exc:
+                    collected[sid] = ([], None, None, exc)
+                else:
+                    if sid not in source_timing:
+                        source_timing[sid] = now - submit_times[sid]
+                    collected[sid] = (rows, warning, summary, err)
+
+            # Per-source timeout: usa source_timeout[sid] dal registry,
+            # fallback a _SOURCE_TIMEOUT (120s).
+            for f in list(pending):
+                sid = future_to_id[f]
+                to = source_timeout.get(sid, _SOURCE_TIMEOUT)
+                if now - submit_times[sid] >= to:
+                    pending.discard(f)
+                    f.cancel()
+                    if sid not in source_timing:
+                        source_timing[sid] = now - submit_times[sid]
+                    collected[sid] = ([], None, None,
+                        TimeoutError(f"Source {sid} timed out after {to}s"))
+                    print(
+                        f"  [timeout] {sid} — {(now - submit_times[sid]):.0f}s"
+                        f" exceeded {to}s limit",
+                        file=sys.stderr, flush=True,
+                    )
+
+            # Heartbeat
+            if pending:
+                elapsed = now - batch_start
+                print(
+                    f"  [heartbeat] {len(collected)}/{len(inventoriable)} sources done"
+                    f" in {elapsed:.0f}s — still waiting:"
+                    f" {[f'{future_to_id[f]}({now - submit_times[future_to_id[f]]:.0f}s)' for f in pending]}",
+                    file=sys.stderr, flush=True,
+                )
+
+        # Batch timeout: sources that still haven't completed
         now = time.time()
-        for f in not_done:
+        for f in pending:
             sid = future_to_id[f]
             if sid not in source_timing:
                 source_timing[sid] = now - submit_times[sid]
             f.cancel()
-            logger.warning("Source %s non completato entro %ds (batch timeout), treat as failed", sid, _BATCH_TIMEOUT)
-            collected[sid] = ([], None, None, TimeoutError(f"Batch timeout after {_BATCH_TIMEOUT}s"))
-        for f in done:
-            sid, rows, warning, summary, err = f.result()
-            if sid not in source_timing:
-                source_timing[sid] = time.time() - submit_times[sid]
-            collected[sid] = (rows, warning, summary, err)
+            if sid not in collected:
+                logger.warning(
+                    "Source %s non completato entro %ds (batch timeout), treat as failed",
+                    sid, _BATCH_TIMEOUT,
+                )
+                collected[sid] = ([], None, None, TimeoutError(f"Batch timeout after {_BATCH_TIMEOUT}s"))
     finally:
         # shutdown(wait=False) non aspetta task bloccati — il timeout HTTP
         # (5s) li terminerà prima o poi, ma non blocca il workflow.
@@ -369,6 +418,12 @@ def main() -> None:
 
     print(f"Wrote {len(all_rows)} rows to {out_parquet}")
     print(f"Wrote report to {out_report}")
+
+    # os._exit(0) necessario perché i worker thread di ThreadPoolExecutor
+    # sono non-daemon in Python 3.12. Quando main() ritorna, Python chiama
+    # threading._shutdown() che fa join dei worker — e possono essere bloccati
+    # su HTTP request per minuti (fonti in timeout). Il lavoro è già completato.
+    os._exit(0)
 
 
 if __name__ == "__main__":

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -64,6 +64,9 @@ DEFAULT_OUT_REPORT = "catalog_inventory_report.json"
 
 
 _SOURCE_TIMEOUT = 120  # timeout individuale per fonte (2 min)
+# Timestamp di effettivo avvio thread executor (non di submission).
+# Usato dal timeout loop per non timeoutare fonti in coda (queued).
+_SOURCE_STARTED: dict[str, float] = {}
 
 
 def _collect_source(
@@ -75,9 +78,13 @@ def _collect_source(
     esplicito via HttpClient. Il timeout globale per fonte è gestito dal
     chiamante via source_timing check nel loop wait()/heartbeat.
 
+    Registra l'effettivo avvio in _SOURCE_STARTED per evitare che fonti
+    in coda (queued) vengano timeoutate prima di partire.
+
     Il vantaggio: niente GIL contention su join(), niente daemon thread leak,
     niente doppio annidamento di thread.
     """
+    _SOURCE_STARTED[source_id] = time.time()
     try:
         res = dispatch(source_id, source_cfg, captured_at)
         return source_id, res.rows, res.warning, res.summary, None
@@ -126,6 +133,8 @@ def main() -> None:
     registry = load_registry()
     captured_at = now_utc_iso()
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    _SOURCE_STARTED.clear()
 
     all_rows: list[dict[str, Any]] = []
     report: dict[str, Any] = {
@@ -243,12 +252,17 @@ def main() -> None:
                         source_timing[sid] = now - submit_times[sid]
                     collected[sid] = (rows, warning, summary, err)
 
-            # Per-source timeout: usa source_timeout[sid] dal registry,
-            # fallback a _SOURCE_TIMEOUT (120s).
+            # Per-source timeout: usa source_timeout[sid] dal registry
+            # (fallback _SOURCE_TIMEOUT) MA solo per fonti effettivamente
+            # avviate (presenti in _SOURCE_STARTED). Fonti in coda (queued)
+            # non vengono timeoutate — il timeout parte dall'effettiva
+            # esecuzione, non dalla submission.
             for f in list(pending):
                 sid = future_to_id[f]
+                if sid not in _SOURCE_STARTED:
+                    continue
                 to = source_timeout.get(sid, _SOURCE_TIMEOUT)
-                if now - submit_times[sid] >= to:
+                if now - _SOURCE_STARTED[sid] >= to:
                     pending.discard(f)
                     f.cancel()
                     if sid not in source_timing:
@@ -419,12 +433,12 @@ def main() -> None:
     print(f"Wrote {len(all_rows)} rows to {out_parquet}")
     print(f"Wrote report to {out_report}")
 
-    # os._exit(0) necessario perché i worker thread di ThreadPoolExecutor
-    # sono non-daemon in Python 3.12. Quando main() ritorna, Python chiama
-    # threading._shutdown() che fa join dei worker — e possono essere bloccati
-    # su HTTP request per minuti (fonti in timeout). Il lavoro è già completato.
-    os._exit(0)
-
 
 if __name__ == "__main__":
     main()
+    # os._exit(0) fuori da main() così main() è testabile.
+    # Necessario perché i worker thread di ThreadPoolExecutor sono non-daemon
+    # in Python 3.12: quando main() ritorna, Python chiama threading._shutdown()
+    # che fa join dei worker — bloccati su HTTP request in timeout.
+    # Il lavoro (parquet, report) è già completato.
+    os._exit(0)

--- a/scripts/collectors/ckan.py
+++ b/scripts/collectors/ckan.py
@@ -177,6 +177,9 @@ def extract_ckan_inventory_row(
         "distribution_url": _distribution_url(item),
         "datastore_active": _has_datastore_active(item),
         "resource_count": _resource_count(item),
+        # Data di creazione/modifica lato fonte (CKAN metadata_created/modified)
+        "issued": item.get("metadata_created") or None,
+        "modified": item.get("metadata_modified") or None,
     }
 
 

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -157,7 +157,9 @@ def _probe_content_type(url: str, timeout: float = 5) -> str | None:
             headers={"User-Agent": USER_AGENT},
         )
         if response.ok:
-            ct = (response.headers or {}).get("content-type", "")
+            # dict() esplicito evita mypy error su CaseInsensitiveDict.get()
+            # (tipi Never negli stub di types-requests)
+            ct = dict(response.headers).get("content-type", "")
             return _content_type_to_format(ct)
     except Exception:
         pass

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -140,12 +140,24 @@ def _content_type_to_format(content_type: str) -> str | None:
 
 
 def _probe_content_type(url: str, timeout: float = 5) -> str | None:
-    """HEAD leggero per ricavare Content-Type. Timeout breve, fallisce silenziosamente."""
+    """HEAD leggero per ricavare Content-Type. Timeout breve, fallisce silenziosamente.
+
+    Usa requests.head diretto (no HttpClient) per evitare SSL fallback
+    warning log che inondano il log CI. Se SSL fallisce, ritorna None
+    (best-effort — probe ott-in).
+    """
     try:
-        client = HttpClient(timeout=timeout)
-        result = client.head(url)
-        if result.is_ok and result.response is not None:
-            ct = (result.response.headers or {}).get("content-type", "")
+        import requests
+
+        from .base import USER_AGENT
+
+        response = requests.head(
+            url,
+            timeout=timeout,
+            headers={"User-Agent": USER_AGENT},
+        )
+        if response.ok:
+            ct = (response.headers or {}).get("content-type", "")
             return _content_type_to_format(ct)
     except Exception:
         pass

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -688,6 +688,10 @@ class TestSdmxEnrichWithInventory:
 
         import bulk_source_check as bsc
         monkeypatch.setattr(bsc, "_fetch_sdmx_dataflow", _mock_fetch)
+        # _fetch_sdmx_years non mockato → farebbe HTTP request reale verso ISTAT
+        # (down). La logica SDMX enrichment non dipende dagli anni per i campi
+        # sdmx_flow/version/agency — solo per year_min/year_max (facoltativi).
+        monkeypatch.setattr(bsc, "_fetch_sdmx_years", lambda *a, **kw: (None, None))
 
         row = pd.Series(self._make_sdmx_row())
         result = _enrich_with_inventory(row, registry)
@@ -747,6 +751,9 @@ class TestSdmxCheckRowPassthrough:
         monkeypatch.setattr(bsc, "_fetch_sdmx_dataflow", _mock_fetch)
         monkeypatch.setattr(bsc, "_fetch_data_preview", _mock_preview)
         monkeypatch.setattr(bsc, "_http_head_with_retry", _mock_head)
+        # _fetch_sdmx_years mockato per evitare HTTP request reale verso ISTAT
+        # (down). Gli anni sono accessori — non servono per i campi SDMX testati.
+        monkeypatch.setattr(bsc, "_fetch_sdmx_years", lambda *a, **kw: (None, None))
 
         row = pd.Series({
             "source_id": "istat_sdmx",


### PR DESCRIPTION
## Cosa cambia

1. **Workflow `test-audit.yml`** — verifica pytest marker su file test_*.py modificati in PR
   - Copre sia `tests/` che `scripts/collectors/` (entrambi i test path del repo)

2. **pytest-timeout** (--timeout=30) già presente su questo branch (PR #261)

## Perché

SO ha marker compliance al 100% (grazie a module-level pytestmark) ma nessun enforcement. Il workflow CI impedisce regressioni future.

## Dipende da

#261 — contiene i fix inventory timeout + mock SDMX. Questo branch è basato su quello.

Closes: —