### PR TITLE
refactor: sostituiti mock locali con lab_connectors.testing (-138 righe)

### DIFF
--- a/scripts/collectors/test_ckan_collector.py
+++ b/scripts/collectors/test_ckan_collector.py
@@ -12,22 +12,7 @@ from collectors.ckan import (
     extract_ckan_inventory_row,
 )
 
-
-class _FakeOk:
-    status_code = 200
-
-    def raise_for_status(self):
-        pass
-
-    def get(self, key, default=None):
-        return default
-
-    def json(self):
-        return {"success": True, "result": self._result}
-
-    def __init__(self, result):
-        self._result = result
-        self.headers = {"content-type": "application/json"}
+pytestmark = pytest.mark.adapter
 
 
 class TestResourceHelpers:
@@ -264,7 +249,7 @@ class TestPackageShowSample:
         original = ckan_module.ckan_get_json
 
         try:
-            monkeypatch.setattr(ckan_module, "ckan_get_json", lambda *a, **k: _FakeOk({}))
+            monkeypatch.setattr(ckan_module, "ckan_get_json", lambda *a, **k: {"success": True, "result": {}})
             enriched, warning = collect_ckan_inventory_via_package_show_sample(
                 source_id="test",
                 source_cfg={"source_kind": "ckan", "protocol": "CKAN", "base_url": "http://api"},

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -6,37 +6,9 @@ import collectors.html as html_collector
 import collectors.sparql
 import pytest
 from lab_connectors.http import HttpResult
+from lab_connectors.testing import FakeHttpClient, fake_response
 
-
-class FakeJsonResponse:
-    def __init__(
-        self,
-        payload: dict | None,
-        *,
-        status_code: int = 200,
-        text: str = "",
-        headers: dict[str, str] | None = None,
-    ) -> None:
-        self._payload = payload
-        self.status_code = status_code
-        self.text = text
-        self.headers = headers or {"content-type": "application/json"}
-
-    def raise_for_status(self) -> None:
-        return None
-
-    def json(self) -> dict:
-        if self._payload is None:
-            raise ValueError("invalid json")
-        return self._payload
-
-
-class _FakeClient:
-    def __init__(self, result_fn):
-        self._result_fn = result_fn
-
-    def get(self, url, **kwargs):
-        return self._result_fn(url, **kwargs)
+pytestmark = pytest.mark.contract
 
 
 def test_collect_ckan_inventory_merges_current_list_metadata(monkeypatch) -> None:
@@ -315,8 +287,8 @@ def test_collect_ckan_inventory_inps_enriches_with_package_show_sample(monkeypat
 
 def test_ckan_get_json_reports_non_json_response(monkeypatch) -> None:
     def fake_get(*_args, **_kwargs):
-        return FakeJsonResponse(
-            None,
+        return fake_response(
+            200,
             text="<html>Request Rejected</html>",
             headers={"content-type": "text/html"},
         )
@@ -402,7 +374,7 @@ def test_collect_sparql_inventory_groups_distribution_bindings(monkeypatch) -> N
         assert kwargs["headers"]["Accept"] == "application/sparql-results+json"
         assert kwargs["params"]["format"] == "application/sparql-results+json"
         assert "LIMIT 10" in kwargs["params"]["query"]
-        return FakeJsonResponse(payload)
+        return fake_response(200, json_data=payload, headers={"content-type": "application/sparql-results+json"})
 
     monkeypatch.setattr(collectors.sparql, "observatory_get", fake_get)
 
@@ -586,23 +558,23 @@ class TestScanAreaPagesPagination:
 
     def test_page_url_template_stops_on_empty_page(self, monkeypatch):
         """Collector stops when a page has no links at all (empty HTML, no <a> tags)."""
-        import collectors.html as html_collector
-
-        call_count = [0]
-
-        def fake_ssl_get(url, **kwargs):
-            call_count[0] += 1
-            page = call_count[0]
-            if page == 1:
-                html = '<a href="https://docs.example.com/file1.csv">file1.csv</a>'
-            elif page == 2:
-                html = '<a href="https://docs.example.com/file2.csv">file2.csv</a>'
-            else:
-                html = "<html><body><p>No results</p></body></html>"
-            response = FakeJsonResponse(payload=None, text=html, headers={"content-type": "text/html"})
-            return HttpResult(response=response, err=None, ssl_fallback_used=None)
-
-        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: _FakeClient(fake_ssl_get))
+        fake = FakeHttpClient()
+        fake.responses["https://example.com/data?page=0"] = HttpResult(
+            response=fake_response(200, text='<a href="https://docs.example.com/file1.csv">file1.csv</a>',
+                                   headers={"content-type": "text/html"}),
+            err=None, ssl_fallback_used=None,
+        )
+        fake.responses["https://example.com/data?page=1"] = HttpResult(
+            response=fake_response(200, text='<a href="https://docs.example.com/file2.csv">file2.csv</a>',
+                                   headers={"content-type": "text/html"}),
+            err=None, ssl_fallback_used=None,
+        )
+        fake.responses["https://example.com/data?page=2"] = HttpResult(
+            response=fake_response(200, text="<html><body><p>No results</p></body></html>",
+                                   headers={"content-type": "text/html"}),
+            err=None, ssl_fallback_used=None,
+        )
+        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: fake)
 
         summary, rows = html_collector._scan_area_pages(
             area_pages=[],
@@ -626,23 +598,28 @@ class TestScanAreaPagesPagination:
 
     def test_page_url_template_continues_when_all_links_are_duplicates(self, monkeypatch):
         """Collector continues past pages where all links are duplicates of previous pages."""
-        call_count = [0]
-
-        def fake_ssl_get(url, **kwargs):
-            call_count[0] += 1
-            page = call_count[0]
-            if page == 1:
-                html = '<a href="https://docs.example.com/file1.csv">file1.csv</a>'
-            elif page == 2:
-                html = '<a href="https://docs.example.com/file1.csv">file1.csv</a>'
-            elif page == 3:
-                html = '<a href="https://docs.example.com/file2.csv">file2.csv</a>'
-            else:
-                html = "<html><body></body></html>"
-            response = FakeJsonResponse(payload=None, text=html, headers={"content-type": "text/html"})
-            return HttpResult(response=response, err=None, ssl_fallback_used=None)
-
-        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: _FakeClient(fake_ssl_get))
+        fake = FakeHttpClient()
+        fake.responses["https://example.com/data?page=0"] = HttpResult(
+            response=fake_response(200, text='<a href="https://docs.example.com/file1.csv">file1.csv</a>',
+                                   headers={"content-type": "text/html"}),
+            err=None, ssl_fallback_used=None,
+        )
+        fake.responses["https://example.com/data?page=1"] = HttpResult(
+            response=fake_response(200, text='<a href="https://docs.example.com/file1.csv">file1.csv</a>',
+                                   headers={"content-type": "text/html"}),
+            err=None, ssl_fallback_used=None,
+        )
+        fake.responses["https://example.com/data?page=2"] = HttpResult(
+            response=fake_response(200, text='<a href="https://docs.example.com/file2.csv">file2.csv</a>',
+                                   headers={"content-type": "text/html"}),
+            err=None, ssl_fallback_used=None,
+        )
+        fake.responses["https://example.com/data?page=3"] = HttpResult(
+            response=fake_response(200, text="<html><body></body></html>",
+                                   headers={"content-type": "text/html"}),
+            err=None, ssl_fallback_used=None,
+        )
+        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: fake)
 
         summary, rows = html_collector._scan_area_pages(
             area_pages=[],
@@ -663,15 +640,14 @@ class TestScanAreaPagesPagination:
 
     def test_page_url_template_respects_page_max(self, monkeypatch):
         """Collector stops at page_max even if pages still have links."""
-        call_count = [0]
-
-        def fake_ssl_get(url, **kwargs):
-            call_count[0] += 1
-            html = f'<a href="https://docs.example.com/file{call_count[0]}.csv">file.csv</a>'
-            response = FakeJsonResponse(payload=None, text=html, headers={"content-type": "text/html"})
-            return HttpResult(response=response, err=None, ssl_fallback_used=None)
-
-        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: _FakeClient(fake_ssl_get))
+        fake = FakeHttpClient()
+        for i in range(3):
+            fake.responses[f"https://example.com/data?page={i}"] = HttpResult(
+                response=fake_response(200, text=f'<a href="https://docs.example.com/file{i}.csv">file.csv</a>',
+                                       headers={"content-type": "text/html"}),
+                err=None, ssl_fallback_used=None,
+            )
+        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: fake)
 
         summary, rows = html_collector._scan_area_pages(
             area_pages=[],
@@ -695,16 +671,19 @@ class TestContentTypeProbe:
 
     def test_probe_updates_by_format_in_summary(self, monkeypatch):
         """Dopo il probe, by_format deve riflettere i formati aggiornati, non quelli pre-probe."""
-        # Un link ZIP -> probe dice CSV -> by_format deve contenere CSV non ZIP
-        html_page = '<a href="https://example.test/data.zip">data</a>'
-
-        def fake_ssl_get(url, **kwargs):
-            return HttpResult(
-                response=FakeJsonResponse(payload=None, text=html_page, headers={"content-type": "text/html"}),
-                err=None, ssl_fallback_used=None,
-            )
-
-        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: _FakeClient(fake_ssl_get))
+        fake = FakeHttpClient()
+        fake.responses["https://example.test/data?page=0"] = HttpResult(
+            response=fake_response(200, text='<a href="https://example.test/data.zip">data</a>',
+                                   headers={"content-type": "text/html"}),
+            err=None, ssl_fallback_used=None,
+        )
+        # Il collector fa anche una GET alla base_url per l'area page iniziale
+        fake.responses["https://example.test"] = HttpResult(
+            response=fake_response(200, text='<a href="https://example.test/data.zip">data</a>',
+                                   headers={"content-type": "text/html"}),
+            err=None, ssl_fallback_used=None,
+        )
+        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: fake)
 
         # Monkeypatch _probe_content_type per simulare che data.zip sia in realtà CSV
         original_probe = html_collector._probe_content_type
@@ -736,4 +715,3 @@ class TestContentTypeProbe:
         bf = result.summary.get("by_format", {})
         assert "CSV" in bf, f"by_format non contiene CSV dopo probe: {bf}"
         assert "ZIP" not in bf, f"by_format contiene ancora ZIP pre-probe: {bf}"
-pytestmark = pytest.mark.contract

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from collectors.ckan import _ckan_api_base
 from lab_connectors.http import HttpResult
+from lab_connectors.testing import fake_response
 from source_check_analyze import (
     _infer_granularity,
     _infer_years,
@@ -13,13 +14,18 @@ from source_check_analyze import (
 )
 
 
-class _FakeResp:
-    """Minimal response stub for HttpClient mock."""
-    def __init__(self, headers: dict[str, str] | None = None, status_code: int = 200, url: str = "", content: bytes = b""):
-        self.headers = headers or {}
-        self.status_code = status_code
-        self.url = url
-        self.content = content
+def _resp(
+    status_code: int = 200,
+    text: str = "",
+    headers: dict[str, str] | None = None,
+    url: str = "",
+):
+    """Shortcut: fake_response + url."""
+    r = fake_response(status_code, text=text, headers=headers)
+    r.url = url
+    return r
+
+
 
 
 # ── _infer_granularity ────────────────────────────────────────────────────────
@@ -199,7 +205,7 @@ class TestHttpHeadWithRetrySSL:
         def fake_head(self, url, **kwargs):
             head_called[0] = True
             return HttpResult(
-                response=_FakeResp(headers={"Content-Type": "text/csv"}, status_code=200, url=url),
+                response=_resp(200, headers={"Content-Type": "text/csv"}, url=url),
                 err=None,
             )
 
@@ -239,10 +245,10 @@ def test_fetch_data_preview_returns_new_fields(monkeypatch) -> None:
 
     def fake_get(self, url, **kwargs):
         return HttpResult(
-            response=_FakeResp(
-                content=b"col1,col2,col3\n1,2,3\n4,5,6",
+            response=_resp(
+                200,
+                text="col1,col2,col3\n1,2,3\n4,5,6",
                 headers={"Content-Type": "text/csv"},
-                status_code=200,
                 url=url,
             ),
             err=None,
@@ -307,23 +313,14 @@ def test_fetch_data_preview_head_infers_csv_without_extension(monkeypatch) -> No
     def fake_head(self, url, **kwargs):
         calls["head"] += 1
         return HttpResult(
-            response=_FakeResp(
-                headers={"Content-Type": "text/csv; charset=utf-8"},
-                status_code=200,
-                url=url,
-            ),
+            response=_resp(200, headers={"Content-Type": "text/csv; charset=utf-8"}, url=url),
             err=None,
         )
 
     def fake_get(self, url, **kwargs):
         calls["get"] += 1
         return HttpResult(
-            response=_FakeResp(
-                content=b"a,b\n1,2\n",
-                headers={"Content-Type": "text/csv"},
-                status_code=200,
-                url=url,
-            ),
+            response=_resp(200, text="a,b\n1,2\n", headers={"Content-Type": "text/csv"}, url=url),
             err=None,
         )
 
@@ -346,12 +343,12 @@ def test_fetch_data_preview_content_disposition_filename(monkeypatch) -> None:
 
     def fake_head(self, url, **kwargs):
         return HttpResult(
-            response=_FakeResp(
+            response=_resp(
+                200,
                 headers={
                     "Content-Type": "application/octet-stream",
                     "Content-Disposition": 'attachment; filename="report.csv"',
                 },
-                status_code=200,
                 url=url,
             ),
             err=None,
@@ -359,12 +356,7 @@ def test_fetch_data_preview_content_disposition_filename(monkeypatch) -> None:
 
     def fake_get(self, url, **kwargs):
         return HttpResult(
-            response=_FakeResp(
-                content=b"x,y\n3,4\n",
-                headers={"Content-Type": "text/csv"},
-                status_code=200,
-                url=url,
-            ),
+            response=_resp(200, text="x,y\n3,4\n", headers={"Content-Type": "text/csv"}, url=url),
             err=None,
         )
 
@@ -384,12 +376,7 @@ def test_fetch_data_preview_tsv_extension(monkeypatch) -> None:
 
     def fake_get(self, url, **kwargs):
         return HttpResult(
-            response=_FakeResp(
-                content=b"a\tb\tc\n1\t2\t3\n",
-                headers={"Content-Type": "text/tab-separated-values"},
-                status_code=200,
-                url=url,
-            ),
+            response=_resp(200, text="a\tb\tc\n1\t2\t3\n", headers={"Content-Type": "text/tab-separated-values"}, url=url),
             err=None,
         )
 
@@ -408,17 +395,10 @@ def test_fetch_data_preview_xls_fake_tsv_latin1(monkeypatch) -> None:
     from lab_connectors.http import HttpClient
     from source_check_fetch import _fetch_data_preview
 
-    # TSV content with Latin-1 byte 0xf9 (non UTF-8)
-    tsv_content = "col1\tcol2\tcol3\n1\t2\t3\n4\t5\t6".encode("latin-1")
-
     def fake_get(self, url, **kwargs):
         return HttpResult(
-            response=_FakeResp(
-                content=tsv_content,
-                headers={"Content-Type": "application/octet-stream"},
-                status_code=200,
-                url=url,
-            ),
+            response=_resp(200, text="col1\tcol2\tcol3\n1\t2\t3\n4\t5\t6",
+                          headers={"Content-Type": "application/octet-stream"}, url=url),
             err=None,
         )
 

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -8,44 +8,15 @@ import jsonschema
 import pytest
 import radar_check
 from lab_connectors.http import HttpFallbackError, HttpResult
+from lab_connectors.testing import FakeHttpClient, fake_response
+
+pytestmark = pytest.mark.contract
 
 _SCHEMA_DIR = Path(__file__).resolve().parents[1] / "schemas"
 
 
 def _load_schema(name: str) -> dict:
     return json.loads((_SCHEMA_DIR / name).read_text(encoding="utf-8"))
-
-
-class FakeResponse:
-    def __init__(
-        self,
-        status_code: int = 200,
-        json_payload: dict | None = None,
-        content_type: str = "application/json",
-        url: str = "https://example.test/api/3/action/status",
-        headers: dict | None = None,
-    ) -> None:
-        self.status_code = status_code
-        self._json_payload = json_payload
-        self._content_type = content_type
-        self.url = url
-        self.headers = headers or {
-            "content-type": content_type,
-        }
-
-    def json(self) -> dict:
-        if self._json_payload is None:
-            raise json.JSONDecodeError("Expecting value", "doc", 0)
-        return self._json_payload
-
-    def raise_for_status(self) -> None:
-        pass
-
-    def __enter__(self) -> "FakeResponse":
-        return self
-
-    def __exit__(self, *args: object) -> None:
-        pass
 
 
 class TestClassify:
@@ -68,10 +39,8 @@ class TestClassify:
 
 class TestValidateCkan:
     def test_validate_ckan_action_response_ok(self) -> None:
-        response = FakeResponse(
-            status_code=200,
-            json_payload={"success": True, "result": []},
-        )
+        response = fake_response(200, json_data={"success": True, "result": []},
+                                 headers={"content-type": "application/json"})
         status, note = radar_check.validate_ckan_action_response(
             "https://example.test/api/3/action/package_list", response
         )
@@ -79,10 +48,8 @@ class TestValidateCkan:
         assert note is None
 
     def test_validate_ckan_action_response_missing_success(self) -> None:
-        response = FakeResponse(
-            status_code=200,
-            json_payload={"result": []},
-        )
+        response = fake_response(200, json_data={"result": []},
+                                 headers={"content-type": "application/json"})
         status, note = radar_check.validate_ckan_action_response(
             "https://example.test/api/3/action/package_list", response
         )
@@ -90,10 +57,9 @@ class TestValidateCkan:
         assert "missing" in (note or "").lower()
 
     def test_validate_ckan_action_response_non_json(self) -> None:
-        response = FakeResponse(
-            status_code=200,
-            content_type="text/html",
-            json_payload=None,
+        response = fake_response(
+            200,
+            text="<html>",
             headers={"content-type": "text/html"},
         )
         status, note = radar_check.validate_ckan_action_response(
@@ -106,18 +72,14 @@ class TestValidateCkan:
 class TestProbe:
     def test_probe_url_success(self, monkeypatch) -> None:
         """Primary request succeeds — ssl_fallback_used=None."""
-
-        def fake_get(url, **kwargs):
-            return HttpResult(
-                response=FakeResponse(
-                    status_code=200,
-                    json_payload={"success": True, "result": []},
-                ),
-                err=None,
-                ssl_fallback_used=None,
-            )
-
-        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: _FakeClient(fake_get))
+        fake = FakeHttpClient()
+        fake.responses["https://demo.test/api/3/action/package_list"] = HttpResult(
+            response=fake_response(200, json_data={"success": True, "result": []},
+                                   headers={"content-type": "application/json"}),
+            err=None,
+            ssl_fallback_used=None,
+        )
+        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: fake)
         result = radar_check.probe_url("https://demo.test/api/3/action/package_list")
         assert result.status == "GREEN"
         assert result.http_code == "200"
@@ -127,14 +89,13 @@ class TestProbe:
         """Timeout → YELLOW."""
         import requests as real_requests
 
-        def fake_get(url, **kwargs):
-            return HttpResult(
-                response=None,
-                err=real_requests.exceptions.Timeout("Connection timed out"),
-                ssl_fallback_used=False,
-            )
-
-        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: _FakeClient(fake_get))
+        fake = FakeHttpClient()
+        fake.responses["https://slow.test/api/3/action"] = HttpResult(
+            response=None,
+            err=real_requests.exceptions.Timeout("Connection timed out"),
+            ssl_fallback_used=False,
+        )
+        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: fake)
         result = radar_check.probe_url("https://slow.test/api/3/action")
         assert result.status == "YELLOW"
         assert "Timeout" in (result.note or "")
@@ -143,32 +104,27 @@ class TestProbe:
         """ConnectionError → RED."""
         import requests as real_requests
 
-        def fake_get(url, **kwargs):
-            return HttpResult(
-                response=None,
-                err=real_requests.exceptions.ConnectionError("Connection refused"),
-                ssl_fallback_used=False,
-            )
-
-        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: _FakeClient(fake_get))
+        fake = FakeHttpClient()
+        fake.responses["https://dead.test/api/3/action"] = HttpResult(
+            response=None,
+            err=real_requests.exceptions.ConnectionError("Connection refused"),
+            ssl_fallback_used=False,
+        )
+        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: fake)
         result = radar_check.probe_url("https://dead.test/api/3/action")
         assert result.status == "RED"
         assert "Connection error" in (result.note or "")
 
     def test_probe_url_ssl_fallback_success(self, monkeypatch) -> None:
         """SSL error first, fallback succeeds — ssl_fallback_used=True."""
-
-        def fake_get(url, **kwargs):
-            return HttpResult(
-                response=FakeResponse(
-                    status_code=200,
-                    json_payload={"success": True},
-                ),
-                err=None,
-                ssl_fallback_used=True,
-            )
-
-        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: _FakeClient(fake_get))
+        fake = FakeHttpClient()
+        fake.responses["https://ssl-broken.test/api/3/action"] = HttpResult(
+            response=fake_response(200, json_data={"success": True},
+                                   headers={"content-type": "application/json"}),
+            err=None,
+            ssl_fallback_used=True,
+        )
+        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: fake)
         result = radar_check._probe_once("https://ssl-broken.test/api/3/action")
         assert result.ssl_fallback_used is True
         assert result.status == "GREEN"
@@ -180,18 +136,17 @@ class TestProbe:
         """
         import requests as real_requests
 
-        def fake_get(url, **kwargs):
-            ssl_exc = real_requests.exceptions.SSLError("SSL cert verify failed")
-            fallback_exc = real_requests.exceptions.ConnectionError(
-                "Connection refused after fallback"
-            )
-            return HttpResult(
-                response=None,
-                err=HttpFallbackError(primary_error=ssl_exc, fallback_error=fallback_exc),
-                ssl_fallback_used=False,
-            )
-
-        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: _FakeClient(fake_get))
+        ssl_exc = real_requests.exceptions.SSLError("SSL cert verify failed")
+        fallback_exc = real_requests.exceptions.ConnectionError(
+            "Connection refused after fallback"
+        )
+        fake = FakeHttpClient()
+        fake.responses["https://ssl-broken.test/api/3/action"] = HttpResult(
+            response=None,
+            err=HttpFallbackError(primary_error=ssl_exc, fallback_error=fallback_exc),
+            ssl_fallback_used=False,
+        )
+        monkeypatch.setattr(radar_check, "HttpClient", lambda **kw: fake)
         result = radar_check._probe_once("https://ssl-broken.test/api/3/action")
         # ssl_failure_err is the primary SSLError → ssl_fallback_used=True in ProbeResult
         assert result.ssl_fallback_used is True
@@ -264,20 +219,3 @@ class TestBuildReport:
         jsonschema.validate(instance=summary, schema=schema)
         # Verify sources_list mirrors summary.sources
         assert len(sources_list) == summary["sources_total"]
-
-
-# ── helper ────────────────────────────────────────────────────────────────────────
-
-
-class _FakeClient:
-    """Fake HttpClient that returns a predetermined HttpResult for any get() call."""
-
-    def __init__(self, result_fn):
-        self._result_fn = result_fn
-
-    def get(self, url, **kwargs):
-        return self._result_fn(url, **kwargs)
-
-    def head(self, url, **kwargs):
-        return self._result_fn(url, **kwargs)
-pytestmark = pytest.mark.contract

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -547,25 +547,6 @@ def test_source_radar_context_no_file(tmp_path, monkeypatch) -> None:
 # ─── Tests for HTTP tools (mocked) ─────────────────────────────────────────────
 
 
-class FakeResponse:
-    def __init__(self, *, status_code: int = 200, json_data: dict, headers: dict | None = None):
-        self._json = json_data
-        self.status_code = status_code
-        self.headers = headers or {"content-type": "application/json"}
-
-    def raise_for_status(self) -> None:
-        if self.status_code >= 400:
-            raise Exception(f"HTTP {self.status_code}")
-
-    @property
-    def text(self) -> str:
-        return json.dumps(self._json)
-
-
-def _fake_observatory_get(url: str, **kwargs):
-    return FakeResponse(json_data={"success": True, "result": {}})
-
-
 def test_ckan_package_show_invalid_endpoint() -> None:
     """Test that _ckan_package_show rejects empty params."""
     result = core._ckan_package_show("", "544")


### PR DESCRIPTION
## Cosa cambia

Rimpiazzate 6 classi mock locali in 5 file di test con le utility condivise da `lab_connectors.testing` (`FakeHttpClient`, `fake_response`).

### File modificati

| File | Rimossa | Sostituita con | Δ |
|---|---|---|---|
| `test_radar_check.py` | `FakeResponse` (30 righe) + `_FakeClient` | `fake_response` + `FakeHttpClient` | **-62** |
| `test_build_catalog_inventory.py` | `FakeJsonResponse` + `_FakeClient` | `fake_response` + `FakeHttpClient` | **-22** |
| `test_bulk_source_check.py` | `_FakeResp` | helper `_resp` basato su `fake_response` | **-20** |
| `test_ckan_collector.py` | `_FakeOk` (dead code) | rimosso e sostituito con dict diretto | **-19** |
| `test_so_mcp.py` | `FakeResponse` + `_fake_observatory_get` (dead code) | rimossi | **-19** |
| **Totale** | **6 classi** | — | **-138 righe** |

### Perché

I test SO erano gli unici a definire classi mock locali invece di usare `lab_connectors.testing.FakeHttpClient` (già usato da ACB e connectors). Questo refactor:
- Riduce duplicazione
- Usa utility testate centralmente
- Rende i test più manutenibili

### Verifica

- `python -m pytest tests/ scripts/collectors/ -q`: 164 passed
- `ruff check .`: all checks passed
- `audit_test_markers.py --diff`: 199/199 marked

Closes: —