### PR TITLE
feat: upload GCS via lab_connectors.gcs (upload #221)

### DIFF
--- a/.github/workflows/observatory.yml
+++ b/.github/workflows/observatory.yml
@@ -160,9 +160,11 @@ jobs:
           stamp=$(python3 -c "from datetime import datetime, timezone; print(datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S'))")
           prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
           prefix="${prefix%/}"
-          gcloud storage cp data/catalog_inventory/generated/source_check_results.parquet \
+          python scripts/gha/gcs_upload.py \
+            data/catalog_inventory/generated/source_check_results.parquet \
             "$prefix/source-check/source_check_results.parquet"
-          gcloud storage cp data/catalog_inventory/generated/source_check_results.parquet \
+          python scripts/gha/gcs_upload.py \
+            data/catalog_inventory/generated/source_check_results.parquet \
             "$prefix/source-check/snapshots/source_check_${stamp}.parquet"
 
       - name: Upload inventory snapshot to GCS
@@ -175,10 +177,18 @@ jobs:
           ")
           prefix='${{ env.CATALOG_INVENTORY_GCS_PREFIX }}'
           prefix="${prefix%/}"
-          gcloud storage cp data/catalog_inventory/generated/catalog_inventory_latest.parquet "$prefix/catalog_inventory_latest.parquet"
-          gcloud storage cp data/catalog_inventory/generated/catalog_inventory_report.json "$prefix/catalog_inventory_report.json"
-          gcloud storage cp data/catalog_inventory/generated/catalog_inventory_latest.parquet "$prefix/snapshots/catalog_inventory_${stamp}.parquet"
-          gcloud storage cp data/catalog_inventory/generated/catalog_inventory_report.json "$prefix/snapshots/catalog_inventory_report_${stamp}.json"
+          python scripts/gha/gcs_upload.py \
+            data/catalog_inventory/generated/catalog_inventory_latest.parquet \
+            "$prefix/catalog_inventory_latest.parquet"
+          python scripts/gha/gcs_upload.py \
+            data/catalog_inventory/generated/catalog_inventory_report.json \
+            "$prefix/catalog_inventory_report.json"
+          python scripts/gha/gcs_upload.py \
+            data/catalog_inventory/generated/catalog_inventory_latest.parquet \
+            "$prefix/snapshots/catalog_inventory_${stamp}.parquet"
+          python scripts/gha/gcs_upload.py \
+            data/catalog_inventory/generated/catalog_inventory_report.json \
+            "$prefix/snapshots/catalog_inventory_report_${stamp}.json"
 
       # ═══════════════════════════════════════════════════════════════════
       # STEP 4 — ARTIFACTS + SUMMARIES

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ jsonschema>=4.26.0,<5.0
 mcp>=1.27.1
 fastmcp>=3.2.4
 # Path contract GCS — vedere lab-connectors/gcs/paths.py
-lab-connectors[duckdb] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.0
+lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.0
 dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.10.0

--- a/scripts/gha/gcs_upload.py
+++ b/scripts/gha/gcs_upload.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Upload file to GCS via lab_connectors.gcs.
+
+Usage:
+    python scripts/gha/gcs_upload.py <local_path> <gs://bucket/path>
+
+Parses gs:// URLs, calls lab_connectors.gcs.upload_file().
+Requires: pip install "lab-connectors[gcs]"
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _parse_gs_url(url: str) -> tuple[str, str]:
+    """Parse 'gs://bucket/key/path' into (bucket, key/path)."""
+    if not url.startswith("gs://"):
+        raise ValueError(f"URL must start with gs://, got: {url}")
+    parts = url[5:].split("/", 1)
+    bucket = parts[0]
+    key = parts[1] if len(parts) > 1 else ""
+    return bucket, key
+
+
+def main() -> None:
+    if len(sys.argv) != 3 or sys.argv[1] in ("-h", "--help"):
+        print(__doc__.strip())
+        sys.exit(1)
+
+    local_path = Path(sys.argv[1])
+    gs_url = sys.argv[2]
+
+    if not local_path.exists():
+        print(f"ERROR: file non trovato: {local_path}", file=sys.stderr)
+        sys.exit(1)
+
+    bucket, key = _parse_gs_url(gs_url)
+    from lab_connectors.gcs import upload_file
+
+    upload_file(str(local_path), bucket, key)
+    print(f"OK: {local_path} → gs://{bucket}/{key}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gcs_upload.py
+++ b/tests/test_gcs_upload.py
@@ -1,0 +1,26 @@
+"""Test per scripts/gha/gcs_upload.py — _parse_gs_url."""
+from __future__ import annotations
+
+import pytest
+from gha.gcs_upload import _parse_gs_url
+
+
+class TestParseGsUrl:
+    @pytest.mark.pure_unit
+    def test_full_url(self):
+        assert _parse_gs_url("gs://bucket/path/to/file.parquet") == ("bucket", "path/to/file.parquet")
+
+    @pytest.mark.pure_unit
+    def test_bucket_only(self):
+        assert _parse_gs_url("gs://bucket") == ("bucket", "")
+
+    @pytest.mark.pure_unit
+    def test_nested_path(self):
+        assert _parse_gs_url("gs://my-bucket/snapshots/catalog_20260522.parquet") == (
+            "my-bucket", "snapshots/catalog_20260522.parquet"
+        )
+
+    @pytest.mark.pure_unit
+    def test_invalid_scheme_raises(self):
+        with pytest.raises(ValueError, match="gs://"):
+            _parse_gs_url("https://bucket/file.txt")


### PR DESCRIPTION
## Cosa cambia

Rimpiazzati i 6 comandi `gcloud storage cp` di upload in `observatory.yml` con chiamate Python a `lab_connectors.gcs.upload_file()`, via script `scripts/gha/gcs_upload.py`.

### Download rimasti su gcloud

I download (previous report, previous inventory, source-check merge) restano con `gcloud storage cp` perché `lab_connectors.gcs.download_file()` non esiste ancora — fuori scope.

### File toccati

- `scripts/gha/gcs_upload.py` (nuovo) — uploada file su GCS, parse `gs://bucket/key`
- `.github/workflows/observatory.yml` — 6 upload rimpiazzati (+download invariati)
- `requirements.txt` → `lab-connectors[duckdb,gcs]`

### Verifica

- `ruff check scripts/gha/gcs_upload.py`: OK
- syntax check: OK
- CI non eseguibile in locale (richiede GCS+credenziali), ma la logica è semplice: `upload_file()` da lab-connectors + parsing gs:// URL

### Dipende da

Installa `google-cloud-storage` extra via `lab-connectors[gcs]`.

Closes #221 (upload only - download resta aperto)