### PR TITLE
fix(so): inventory timeout ISTAT SDMX e OpenBDAP

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -3,6 +3,8 @@ istat_sdmx:
   protocol: sdmx
   observation_mode: catalog-watch
   base_url: https://esploradati.istat.it/SDMXWS/rest/dataflow/IT1
+  inventory:
+    timeout: 300
   last_probed: '2026-05-22'
   catalog_baseline:
     captured_at: '2026-04-10'
@@ -81,12 +83,12 @@ openbdap:
   base_url: 
     https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
   inventory:
-    timeout: 300
+    timeout: 600
     skip_package_search: true
     skip_package_search_reason: timeout sistematico a 60s
     skip_current_list: true
     package_show_sample: true
-    sample_size: 4000
+    sample_size: 2000
   last_probed: '2026-05-22'
   catalog_baseline:
     captured_at: '2026-04-02'

--- a/scripts/collectors/sdmx.py
+++ b/scripts/collectors/sdmx.py
@@ -26,7 +26,7 @@ def _sdmx_api_base(url: str) -> str | None:
 
 def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> CollectorResult:
     endpoint = source_cfg["base_url"]
-    client = HttpClient(timeout=120, max_retries=3)
+    client = HttpClient(timeout=300, max_retries=3)
     result = client.get(endpoint)
 
     if result.is_error:


### PR DESCRIPTION
## Problema

Due fonti perdevano sistematicamente l'inventory build per timeout:

- **ISTAT SDMX**: timeout a 120s durante `dataflow_count` (4212 dataflow)
- **OpenBDAP**: timeout a 300s durante `package_show_sample` (4000 chiamate con 16 workers)

## Fix

### ISTAT SDMX
- Aggiunto `inventory.timeout: 300` nel registry (prima assente → default 120s)
- Allineato `HttpClient(timeout=120→300)` nel collector SDMX

### OpenBDAP
- `inventory.timeout: 300→600` (più margine)
- `sample_size: 4000→2000` (campione rappresentativo di 2000 su 3772 totali)

## Verifica

Build locale eseguito con `scripts/build_catalog_inventory.py`:
- **ISTAT SDMX**: completato in **165s** ✅ (prima timeout a 120s)
- **OpenBDAP**: completato in **140s** ✅, 3781 rows, status OK (prima timeout a 300s)

Per OpenBDAP, `sample_size=2000` è una scelta 20/80: il conteggio totale è preservato via `package_list`, e i metadati arricchiti su 2000 entry sono sufficienti per catalog-watch. Un dataset specifico si scova con source-check dedicato.

## File modificati

- `data/radar/sources_registry.yaml` — timeout per-fonte
- `scripts/collectors/sdmx.py` — allineamento HTTP timeout