### PR TITLE
fix(so): attiva circuit breaker in source_check (threshold=3)

### DIFF
--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -691,7 +691,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--circuit-fail-threshold",
         type=int,
-        default=0,
+        default=3,
         metavar="N",
         help="Dopo N errori consecutivi (timeout/connessione/HTTP 5xx) sullo stesso host, "
         "salta ulteriori HEAD/GET per quel host nel run (0 = disabilitato).",

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -65,7 +65,7 @@ _EMPTY_ENRICH: dict[str, Any] = {
 
 def configure_source_check_http(
     *,
-    circuit_fail_threshold: int = 0,
+    circuit_fail_threshold: int = 3,
     http_timeout: tuple[float, float] | None = None,
     http_max_retries: int = 1,
 ) -> None:


### PR DESCRIPTION
## Problema

Il circuit breaker in `source_check_fetch.py` era disabilitato (`circuit_fail_threshold=0`). Durante i bulk source-check, se una fonte dava errori consecutivi (timeout, connessione, 5xx), continuava a essere martellata a ogni item, sprecando tempo e risorse.

## Fix

- Default `circuit_fail_threshold` cambiato da 0 (disabilitato) a 3 in `configure_source_check_http()`
- Default CLI `--circuit-fail-threshold` cambiato da 0 a 3

Dopo 3 errori consecutivi sullo stesso host (stesso netloc), il circuito apre e salta ulteriori HEAD/GET per quell'host nel run corrente. Il recupero è automatico al run successivo.

Il comportamento è overrideabile via CLI per casi specifici (`--circuit-fail-threshold 0` per disabilitare).

## File modificati

- `scripts/source_check_fetch.py:68` — default parametro
- `scripts/bulk_source_check.py:694` — default argparse