### PR TITLE
fix: allinea dipendenza toolkit a v1.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ mcp>=1.27.1
 fastmcp>=3.2.4
 # Path contract GCS — vedere lab-connectors/gcs/paths.py
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.0
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.10.0
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.10.1


### PR DESCRIPTION
## Cosa

`requirements.txt` punta a `dataciviclab-toolkit @ git+https://...@v1.10.1`.

## Perché

La PR #268 è stata mergiata mentre il tag `v1.10.0` non era ancora stabilizzato (puntava a un commit senza `toolkit.scout`). `v1.10.1` è un tag immutabile che contiene il package scout.

## Verifica

- [ ] CI test verde
- [ ] `pip install -r requirements.txt` installa toolkit con `toolkit.scout`

## Merge gate

Solo con CI verde.