### PR TITLE
allinea skill SO: source-check produce intake DI, inventory-triage, rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/inventory-triage.yml
+++ b/.github/ISSUE_TEMPLATE/inventory-triage.yml
@@ -1,7 +1,7 @@
-name: Catalog inventory scout
+name: Inventory triage
 description: Triage di un catalog inventory esistente per produrre una shortlist.
-title: "catalog-scout: <catalogo>"
-labels: ["catalog-scout", "scouting"]
+title: "inventory-triage: <catalogo>"
+labels: ["inventory-triage", "scouting"]
 body:
   - type: input
     id: catalog_name

--- a/.github/ISSUE_TEMPLATE/source-check.yml
+++ b/.github/ISSUE_TEMPLATE/source-check.yml
@@ -72,18 +72,34 @@ body:
       placeholder: "MIT incidenti 2001-2018"
     validations:
       required: false
+  - type: input
+    id: discussion_url
+    attributes:
+      label: Discussion Domanda di riferimento
+      description: "Link alla Discussion Domanda in dataciviclab che ha motivato lo scouting."
+      placeholder: "https://github.com/orgs/dataciviclab/discussions/N"
+    validations:
+      required: true
   - type: dropdown
     id: verdict
     attributes:
       label: Verdict
       options:
-        - go Discussion
+        - go intake
         - watchlist
         - support dataset
         - aggiorna artefatto esistente
-        - not now
+        - no-go
     validations:
       required: true
+  - type: input
+    id: intake_issue
+    attributes:
+      label: Issue intake (solo se go intake)
+      description: "Link all'issue intake aperta in dataset-incubator."
+      placeholder: "https://github.com/dataciviclab/dataset-incubator/issues/N"
+    validations:
+      required: false
   - type: textarea
     id: notes
     attributes:

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Le skills in `skills/` sono guide operative per agenti e review umana.
 
 | Skill | Cosa fa |
 |---|---|
-| `source-check.md` | Valuta se una fonte regge come pista del Lab |
-| `catalog-inventory-scout.md` | Triage di un inventory per una shortlist |
+| `source-check.md` | Verifica una fonte specifica — porta a issue intake in DI |
+| `inventory-triage.md` | Triage di un inventory per una shortlist — porta a issue SO per source-check |
 | `portal-scout.md` | Identifica protocollo e decide se aggiungere al registry |
 
 Il layer MCP (`mcp/so_server_core.py`) è il modo consigliato per consultare gli artifact senza scaricare file.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -39,7 +39,7 @@ Manutenzione del Registry:
 Boundary:
 
 - Se il problema è di contenuto (non infrastrutturale) -> [source-check.md](../skills/source-check.md)
-- Se il catalogo è cambiato ma la fonte è viva -> [catalog-inventory-scout.md](../skills/catalog-inventory-scout.md)
+- Se il catalogo è cambiato ma la fonte è viva -> [inventory-triage.md](../skills/inventory-triage.md)
 
 ## Catalog-watch
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -60,7 +60,7 @@ In `auto`, il server prova i prefissi GCS pubblici; se il read GCS fallisce, usa
 | `so_ckan_package_show` | conferma CKAN e verifica enumerateabilita |
 | `so_registry_query` | pre-check: gia nel registry? |
 
-### SO_02 — catalog-inventory-scout
+### SO_02 — inventory-triage
 
 | Tool | Uso |
 |---|---|
@@ -198,7 +198,7 @@ Non deve:
 Le 3 skill operative sono in `skills/`:
 
 - `portal-scout.md` — dado un URL, identifica protocollo e decide go registry
-- `catalog-inventory-scout.md` — browse inventory, estrai shortlist per source-check
-- `source-check.md` — verifica singolo item, verdict go DI / watchlist / no-go
+- `inventory-triage.md` — browse inventory, estrai shortlist per source-check
+- `source-check.md` — verifica singolo item, verdict go intake / watchlist / no-go
 
-Il workflow di riferimento è `skills/portal-scout.md`, `skills/source-check.md` e `skills/catalog-inventory-scout.md`.
+Il workflow di riferimento è `skills/portal-scout.md`, `skills/source-check.md` e `skills/inventory-triage.md`.

--- a/scripts/build_catalog_signals.py
+++ b/scripts/build_catalog_signals.py
@@ -190,7 +190,7 @@ def _classify(
                     "result": "inventory change",
                     "metric_value": rows,
                     "detail": f"{rows} item ({method}), delta {delta_str} rispetto al run precedente ({prev_rows}).",
-                    "suggested_action": "verificare se variazione attesa; avviare catalog-inventory-scout se nuovi dataset",
+                    "suggested_action": "verificare se variazione attesa; avviare inventory-triage se nuovi dataset",
                 }
 
         # Stabile

--- a/skills/README.md
+++ b/skills/README.md
@@ -5,7 +5,7 @@ Procedure ripetibili per osservare, inventariare e valutare fonti pubbliche.
 ## Le 3 skill
 
 | Skill | Entry | Output |
-|---|---|---|---|
+|---|---|---|
 | [portal-scout.md](./portal-scout.md) | URL portale | go registry / no-go / need-more-info |
 | [inventory-triage.md](./inventory-triage.md) | source_id o tema | issue SO → source-check |
 | [source-check.md](./source-check.md) | item specifico | go intake / watchlist / no-go |

--- a/skills/README.md
+++ b/skills/README.md
@@ -5,13 +5,25 @@ Procedure ripetibili per osservare, inventariare e valutare fonti pubbliche.
 ## Le 3 skill
 
 | Skill | Entry | Output |
-|---|---|---|
+|---|---|---|---|
 | [portal-scout.md](./portal-scout.md) | URL portale | go registry / no-go / need-more-info |
-| [catalog-inventory-scout.md](./catalog-inventory-scout.md) | source_id o tema | shortlist item → source-check |
-| [source-check.md](./source-check.md) | item specifico | go DI / watchlist / no-go |
+| [catalog-inventory-scout.md](./catalog-inventory-scout.md) | source_id o tema | issue SO → source-check |
+| [source-check.md](./source-check.md) | item specifico | go intake / watchlist / no-go |
 
 ## Flusso
 
+```
+proposta / URL
+    ↓
+portal-scout        → identifica protocollo, decide se aggiungere al registry
+    ↓
+catalog-inventory   → triage item → issue SO per source-check
+    ↓
+source-check        → verifica singolo item → go intake / watchlist / no-go
+    ↓
+    → DI (issue intake)
+    → watchlist
+    → archivio
 ```
 proposta / URL
     ↓
@@ -21,7 +33,7 @@ catalog-inventory   → enumerare item (se catalog-watch)
     ↓
 source-check        → verifica singolo item → go DI / watchlist / no-go
     ↓
-    → DI (go Discussion / candidate)
+    → DI (go intake / candidate)
     → watchlist
     → archivio
 ```

--- a/skills/README.md
+++ b/skills/README.md
@@ -7,7 +7,7 @@ Procedure ripetibili per osservare, inventariare e valutare fonti pubbliche.
 | Skill | Entry | Output |
 |---|---|---|---|
 | [portal-scout.md](./portal-scout.md) | URL portale | go registry / no-go / need-more-info |
-| [catalog-inventory-scout.md](./catalog-inventory-scout.md) | source_id o tema | issue SO → source-check |
+| [inventory-triage.md](./inventory-triage.md) | source_id o tema | issue SO → source-check |
 | [source-check.md](./source-check.md) | item specifico | go intake / watchlist / no-go |
 
 ## Flusso
@@ -17,7 +17,7 @@ proposta / URL
     ↓
 portal-scout        → identifica protocollo, decide se aggiungere al registry
     ↓
-catalog-inventory   → triage item → issue SO per source-check
+inventory-triage    → triage item → issue SO per source-check
     ↓
 source-check        → verifica singolo item → go intake / watchlist / no-go
     ↓
@@ -35,7 +35,7 @@ Non sono skill themselves — sono strumenti a disposizione di chi esegue una sk
 ## Boundary rapido
 
 - `portal-scout` — questo portale è osservabile?
-- `catalog-inventory-scout` — cosa c'è in questo catalogo?
+- `inventory-triage` — cosa c'è in questo catalogo?
 - `source-check` — questo dataset merita il funnel del Lab?
 
 ## Runbook operativo

--- a/skills/README.md
+++ b/skills/README.md
@@ -25,18 +25,6 @@ source-check        → verifica singolo item → go intake / watchlist / no-go
     → watchlist
     → archivio
 ```
-proposta / URL
-    ↓
-portal-scout        → identifica protocollo, decide se aggiungere al registry
-    ↓
-catalog-inventory   → enumerare item (se catalog-watch)
-    ↓
-source-check        → verifica singolo item → go DI / watchlist / no-go
-    ↓
-    → DI (go intake / candidate)
-    → watchlist
-    → archivio
-```
 
 ## MCP Tools
 

--- a/skills/catalog-inventory-scout.md
+++ b/skills/catalog-inventory-scout.md
@@ -1,6 +1,6 @@
 ---
 name: catalog-inventory-scout
-description: Triage di un catalog inventory per ricavare una shortlist di segnali da mandare a source-check, catalog-watch o watchlist.
+description: Triage di un catalog inventory per ricavare shortlist di item da verificare con source-check e aprire issue in SO.
 license: MIT
 metadata:
   version: "1.0"
@@ -65,7 +65,7 @@ Dichiara cosa stai cercando (es. nuovi dataset su un tema specifico, aggiornamen
 
 ### 3. Classifica gli item
 Per ogni item interessante, assegna una classe semplice:
-- `source-check`: item pronto per la verifica profonda.
+- `go intake`: item promettente, merita un source-check.
 - `watchlist`: interessante ma non prioritario.
 - `ignore`: rumore o fuori scopo.
 
@@ -73,8 +73,13 @@ Per ogni item interessante, assegna una classe semplice:
 Mantieni una lista corta e leggibile. Per ogni item annota titolo, URL e motivazione.
 Controlla brevemente se l'item è già coperto da filoni vivi in `dataset-incubator` o discussioni aperte.
 
-### 5. Apri l'issue di scout
+### 5. Apri issue in SO per source-check
+
 Usa il template [Catalog inventory scout](../.github/ISSUE_TEMPLATE/catalog-inventory-scout.yml) per documentare il risultato del triage.
+
+Per ogni item classificato `go intake`, il prossimo passo è eseguire un
+[source-check](./source-check.md) che ne verifichi l'accesso reale, la forma e
+la pertinenza con una domanda civica, e che porti a una issue intake in DI.
 
 ## Boundary con altri workflow
 
@@ -84,5 +89,6 @@ Usa il template [Catalog inventory scout](../.github/ISSUE_TEMPLATE/catalog-inve
 
 ## Output atteso
 
-- Issue di tipo `catalog-scout` con shortlist ragionata.
-- Decisione sui passi successivi per gli item in shortlist.
+- Issue di tipo `catalog-scout` con shortlist ragionata, aperta in SO.
+- Per ogni item `go intake` → il prossimo passo è un [source-check](./source-check.md)
+  che apre issue intake in `dataset-incubator`.

--- a/skills/inventory-triage.md
+++ b/skills/inventory-triage.md
@@ -1,5 +1,5 @@
 ---
-name: catalog-inventory-scout
+name: inventory-triage
 description: Triage di un catalog inventory per ricavare shortlist di item da verificare con source-check e aprire issue in SO.
 license: MIT
 metadata:
@@ -8,9 +8,9 @@ metadata:
   tags: [source-observatory, scouting, triage, inventory]
 ---
 
-# Workflow: catalog-inventory-scout
+# Workflow: inventory-triage
 
-Workflow canonico di `source-observatory` per fare scouting disciplinato a partire da un catalog inventory.
+Workflow canonico di `source-observatory` per fare triage disciplinato a partire da un catalog inventory.
 Versione: 1.0 - 2026-04-15
 
 ## Obiettivo di fase
@@ -75,7 +75,7 @@ Controlla brevemente se l'item è già coperto da filoni vivi in `dataset-incuba
 
 ### 5. Apri issue in SO per source-check
 
-Usa il template [Catalog inventory scout](../.github/ISSUE_TEMPLATE/catalog-inventory-scout.yml) per documentare il risultato del triage.
+Usa il template [Inventory triage](../.github/ISSUE_TEMPLATE/inventory-triage.yml) per documentare il risultato del triage.
 
 Per ogni item classificato `go intake`, il prossimo passo è eseguire un
 [source-check](./source-check.md) che ne verifichi l'accesso reale, la forma e
@@ -83,12 +83,12 @@ la pertinenza con una domanda civica, e che porti a una issue intake in DI.
 
 ## Boundary con altri workflow
 
-- `catalog-inventory-scout` -> prepara il terreno via triage di una lista.
+- `inventory-triage` -> prepara il terreno via triage di una lista.
 - [source-check.md](./source-check.md) -> verifica una fonte specifica.
 - `CATALOG_WATCH_REPORT.md` / `catalog_signals.json` -> segnali differenziali prodotti automaticamente dalla CI.
 
 ## Output atteso
 
-- Issue di tipo `catalog-scout` con shortlist ragionata, aperta in SO.
+- Issue di tipo `inventory-triage` con shortlist ragionata, aperta in SO.
 - Per ogni item `go intake` → il prossimo passo è un [source-check](./source-check.md)
   che apre issue intake in `dataset-incubator`.

--- a/skills/source-check.md
+++ b/skills/source-check.md
@@ -1,33 +1,40 @@
 ---
 name: source-check
-description: Workflow canonico per verificare se una fonte pubblica merita il funnel del Lab.
+description: Workflow canonico per verificare se una fonte pubblica merita un intake issue in dataset-incubator.
 license: MIT
 metadata:
-  version: "1.2"
+  version: "2.0"
   owner: "DataCivicLab"
 ---
 
 # Workflow: source-check
 
-**Stato: Operativo (Compact Mode)**
-Verifica se una fonte regge davvero come pista del Lab prima di aprire Discussion o pipeline.
+**Stato: Operativo**
+Verifica se una fonte regge davvero come pista del Lab, poi produce issue
+intake in `dataset-incubator` + reply nella Discussion Domanda di riferimento.
 
 ## 1. Obiettivo e Boundary
 
 - **SÌ**: Verificare accesso reale e forma minima (formato, granularità, copertura).
 - **SÌ**: Distinguere tra fonte "viva" e fonte "utile" (domanda civica).
 - **SÌ**: Fissare un perimetro v0 e un verdetto unico.
-- **NO**: Fare intake in `dataset-incubator` o monitoraggio ricorrente.
-- **NO**: Sostituire l'health check radar o `catalog-watch`.
+- **SÌ**: Aprire issue intake in `dataset-incubator` se la pista regge.
+- **NO**: Fare run di pipeline o sostituire l'health check radar.
+- **NO**: Sostituire `catalog-watch` o il monitoraggio ricorrente.
 
-## 2. Preconditions e Stop Rules
+## 2. Pre-requisiti
 
+Prima di iniziare, deve esistere una **Discussion categoria `Domanda`** in
+`dataciviclab` che inquadri la domanda civica. Se non esiste (es. fonte emersa
+da triage interno), apriline una — la Domanda è l'ancora pubblica del filone.
+
+- [ ] Hai una Discussion Domanda di riferimento (# o URL)
 - [ ] Hai una fonte concreta (URL, endpoint o file), non solo un tema.
 - [ ] Esiste un possibile uso civico plausibile.
-- [ ] **STOP**: Se il caso è già maturo per Discussion/PI o se appartiene al monitoraggio.
-- [ ] **STOP**: Se la fonte è totalmente opaca (niente metadata o preview).
+- **STOP**: Se il caso è già maturo per intake o se appartiene al monitoraggio.
+- **STOP**: Se la fonte è totalmente opaca (niente metadati o preview).
 
-## 2b. Soglie go Discussion (checklist binaria)
+## 2b. Soglie go intake (checklist binaria)
 
 - [ ] Accesso reale confermato (non solo metadato).
 - [ ] ≥1 dimensione analitica utile (geo, temporale, categoriale).
@@ -39,7 +46,8 @@ Verifica se una fonte regge davvero come pista del Lab prima di aprire Discussio
 
 ## 3. Pre-check MCP (obbligatorio prima di iniziare)
 
-Prima di toccare la fonte, consulta gli artifact SO via MCP per evitare duplicati e orientarti:
+Prima di toccare la fonte, consulta gli artifact SO via MCP per evitare
+duplicati e orientarti:
 
 ```
 1. so_find_by_url(<URL>)       → la fonte è già in source_check o inventory?
@@ -48,39 +56,49 @@ Prima di toccare la fonte, consulta gli artifact SO via MCP per evitare duplicat
 4. so_probe_url(<URL>)          → reachability rapida
 ```
 
-**Se `so_find_by_url` trova risultati**: la fonte è già catalogata — consulta i risultati prima di proseguire e possibilmente riutilizza evidenze esistenti.
+**Se `so_find_by_url` trova risultati**: la fonte è già catalogata — consulta
+i risultati prima di proseguire e possibilmente riutilizza evidenze esistenti.
 
-**Se `so_radar_summary` mostra RED**: valuta se il source-check ha senso (fonte temporaneamente down).
+**Se `so_radar_summary` mostra RED**: valuta se il source-check ha senso (fonte
+temporaneamente down).
 
-**Se la fonte non è ancora nel radar**: procedi normalmente, ma annota `source_id` provvisorio nella nota.
+**Se la fonte non è ancora nel radar**: procedi normalmente, ma annota
+`source_id` provvisorio nella nota.
 
 ## 4. Accesso Reale
 
-Verifica raggiungibilità e leggibilità (redirect, login, WAF). Qualifica come `verificato` o `inferito`.
+Verifica raggiungibilità e leggibilità (redirect, login, WAF). Qualifica come
+`verificato` o `inferito`.
 
-1. **Shape minima**: Controlla formato, granularità (cosa rappresenta una riga) e copertura.
+1. **Shape minima**: Controlla formato, granularità (cosa rappresenta una riga)
+   e copertura.
 2. **Sufficienza Semantica**:
    - [ ] Il dato è leggibile subito?
    - [ ] Messaggi/Valori chiave sono autonomi?
    - [ ] Esiste un output minimo senza join esterne?
-3. **Domanda Civica**: Formula in una riga *perché* non è solo un "elenco" ma serve a una domanda reale.
-4. **Perimetro v0**: Fissa geografia e finestra temporale iniziale (preferisci perimetro stretto).
-5. **Deduplica**: Controlla se il filone è già vivo in `Discussion` o `dataset-incubator`.
+3. **Domanda Civica**: Formula in una riga *perché* non è solo un "elenco" ma
+   serve a una domanda reale.
+4. **Perimetro v0**: Fissa geografia e finestra temporale iniziale (preferisci
+   perimetro stretto).
+5. **Deduplica**: Controlla se il filone è già vivo in Discussion o
+   `dataset-incubator`.
 
 ## 5. Verdict e Output
 
 Scegli un solo verdetto:
-- `go Discussion`: La fonte regge come pista autonoma.
+- `go intake`: La fonte regge. Si apre issue intake in DI.
 - `watchlist`: Promettente ma non pronta/accessibile ora.
 - `support dataset`: Utile solo come supporto/join.
 - `aggiorna esistente`: Il filone è già vivo, aggiorna l'artefatto esistente.
 - `no-go`: Accesso, formato o valore non reggono.
 
-**Output richiesto**: nota o commento sull'issue SO con verdetto, accesso reale (stato + URL), shape, domanda civica, qualificatore e next step esplicito.
+**Output richiesto** — nota o commento sull'issue SO con:
 
 Schema commento:
 ```
 **Verdict**: [verdetto]
+
+**Discussion Domanda**: [#N](URL)
 
 **Accesso**: [verificato/inferito] — [URL]
 **Shape**: [formato, granularità, copertura]
@@ -91,34 +109,50 @@ Schema commento:
 **Next step**: [azione esplicita]
 ```
 
-## 6. Se verdict = go Discussion
+Se `verdict ≠ go intake`, il next step può essere `watchlist`, `no-go` o
+`aggiornare issue #N` — in tutti i casi, lascia una reply nella Discussion
+Domanda con l'esito.
 
-Il verdetto `go Discussion` significa: la fonte merita una Discussion. Il workflow deve almeno preparare il testo; pubblicarlo è un passo separato, consentito solo se il maintainer conferma o se il task lo richiede esplicitamente.
+## 6. Se verdict = go intake
 
-Prepara una discussion in `dataciviclab` categoria **Datasets** con questo schema compatto:
+Il verdetto `go intake` significa: la fonte regge, il perimetro è chiaro, e
+serve un ticket tecnico eseguibile.
 
-**Titolo**: `[fonte breve] — [domanda civica in max 8 parole]`
+### 6a. Apri issue intake in dataset-incubator
 
-**Body** (max 15 righe):
+Usa il template `new-candidate.yml`. Compila:
+
+- **Title**: `{slug}: {dataset name}`
+- **Discussion Domanda**: link alla Domanda di riferimento
+- **Fonte**: URL esatto + tipo (HTTP, CKAN, SDMX, ...)
+- **Perimetro v0**: geografia, periodo, metrica principale
+- **Shape**: formato, granularità, colonne candidate (se già note)
+- **Note tecniche**: encoding, delimiter, skip rows, autenticazione (se note)
+
+L'issue intake non deve ri-nascondere la domanda civica — quella sta già nella
+Discussion Domanda. L'issue è tecnica: cosa serve per far girare la pipeline.
+
+### 6b. Reply nella Discussion Domanda
+
+Lascia una reply pubblica nella Discussion Domanda:
+
 ```
-## Fonte ufficiale
-[ente + link/endpoint principale — 1-2 righe]
+## Scouting: fonte verificata ✅
 
-## Domanda civica
-[1 domanda, max 2 righe]
+Abbiamo trovato dati pertinenti:
+- **Fonte**: [ente — URL diretto]
+- **Copertura**: [periodo]
+- **Granularità**: [comune/regionale/nazionale, ...]
 
-## Perimetro v0
-- [geografia]
-- [periodo]
-- [metrica principale]
+✋ Aperta issue tecnica: [#ISSUE](link issue DI) — seguiamo il lavoro lì.
 
-→ Source-check completo: [link issue SO]
+Ci risentiamo quando i dati sono pronti per l'analisi.
 ```
 
-Poi:
-- Se pubblicata, aggiungi label `go-discussion` e commento con link alla discussion.
-- Se non pubblicata, lascia come next step `preparare/pubblicare Discussion Datasets`.
-- **Non chiudere** l'issue SO solo per il source-check: resta audit trail finché il maintainer non decide.
+### 6c. Tracciabilità
+
+- Assegna label `source-checked` all'issue SO
+- L'issue SO resta aperta come audit trail finché il maintainer non decide
 
 ## 7. Qualificatori Semantici (da annotare)
 
@@ -127,4 +161,6 @@ Poi:
 - `too-thin-for-v0`: Troppo scarno per il funnel attuale.
 
 ---
-**Done**: Fonte verificata, verdetto unico espresso, next step scritto in nota o issue.
+
+**Done**: Fonte verificata, verdetto unico espresso, issue intake in DI +
+reply pubblica nella Domanda.


### PR DESCRIPTION
## Cosa cambia

### source-check.md (v2.0)
- Verdetto `go Discussion` → `go intake`
- Output: issue intake in DI + reply nella Domanda (non più bozza Discussion Datasets)
- Pre-requisito: Discussion Domanda di riferimento
- Template reply pubblico predefinito

### catalog-inventory-scout → inventory-triage (rename)
- Classificatore `source-check` → `go intake`
- Output esplicito: issue in SO per source-check
- File, issue template e tutti i riferimenti aggiornati

### skills/README.md
- Flusso allineato ai nuovi output
- Vecchio flusso duplicato rimosso

### Collegamento
Questa PR fa parte del cambio di flusso più ampio (Domanda → SO → DI, senza passaggio intermedio Discussion Datasets). Le PR collegate seguono per dataciviclab docs e dataset-incubator.