### PR TITLE
feat(ckan): supporto parametro fq nel collector CKAN

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -26,27 +26,28 @@ istat_sdmx:
 anac:
   source_kind: catalog
   protocol: ckan
-  observation_mode: radar-only
-  base_url: 
-    https://dati.anticorruzione.it/opendata/api/3/action/package_list?limit=1
+  observation_mode: catalog-watch
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
   inventory:
-    non_inventoriable: true
-    reason: WAF strutturale - restituisce HTML 'Request Rejected' su qualsiasi 
-      client HTTP non browser. Confermato 2026-04-16.
-    scraping_blocked: true
-    scraping_blocked_reason: reCAPTCHA / WAF blocca richieste HTTP non-browser
+    fq: organization:anac
+    timeout: 180
+    skip_current_list: true
+    skip_current_list_reason: "package_search con fq=organization:anac restituisce
+      tutti i 70 dataset ANAC con metadata completi. current_list non necessario."
   last_probed: '2026-05-24'
   catalog_baseline:
-    captured_at: '2026-03-28'
+    captured_at: '2026-05-24'
     metric: package_count
-    value: 69
-    method: package_list
-    reliability: low
-    note: Conteggio rilevato prima del blocco WAF. Non aggiornabile con HTTP 
-      standard.
-  verdict: hold
-  note: WAF blocca endpoint CKAN. Declassato a radar-only finche' non 
-    disponibile endpoint alternativo o accesso istituzionale.
+    value: 70
+    method: package_search
+    reliability: high
+    note: Conteggio via package_search con fq=organization:anac su dati.gov.it.
+      70 dataset harvestati dal portale ANAC.
+  verdict: go
+  note: "Fonte via dati.gov.it (harvesting ANAC). I download raw vanno al portale
+    diretto dati.anticorruzione.it con User-Agent browser (WAF blocca solo
+    python-requests). 70 dataset: CIG (2007-2023), SMARTCIG, OCDS, stazioni
+    appaltanti, aggiudicatari, subappalti, varianti, PNRR indicatori, SOA. CC-BY-SA 4.0."
   datasets_in_use: []
 inps:
   source_kind: catalog

--- a/scripts/collectors/ckan.py
+++ b/scripts/collectors/ckan.py
@@ -183,6 +183,16 @@ def extract_ckan_inventory_row(
     }
 
 
+def _ckan_search_params(source_cfg: dict[str, Any], *, page_size: int, start: int) -> dict[str, Any]:
+    """Build package_search params, optionally adding fq from inventory config."""
+    inv = source_cfg.get("inventory", {})
+    params: dict[str, Any] = {"rows": page_size, "start": start}
+    fq = inv.get("fq")
+    if fq:
+        params["fq"] = fq
+    return params
+
+
 def collect_ckan_inventory_via_search(
     source_id: str, source_cfg: dict[str, Any], captured_at: str
 ) -> list[dict[str, Any]]:
@@ -193,7 +203,7 @@ def collect_ckan_inventory_via_search(
     rows: list[dict[str, Any]] = []
 
     while True:
-        payload = ckan_get_json(endpoint, params={"rows": page_size, "start": start})
+        payload = ckan_get_json(endpoint, params=_ckan_search_params(source_cfg, page_size=page_size, start=start))
         if not payload.get("success"):
             raise ValueError(f"CKAN package_search failed for {source_id}")
 
@@ -459,7 +469,10 @@ def collect_ckan_inventory_via_package_search_offset(
     offset = 0
 
     while True:
+        _fq = (source_cfg.get("inventory") or {}).get("fq")
         params = f"rows={page_size}&offset={offset}&q=*:*"
+        if _fq:
+            params += f"&fq={_fq}"
         try:
             payload = ckan_get_json(endpoint, params=params, timeout=60)
         except Exception as exc:

--- a/scripts/collectors/ckan.py
+++ b/scripts/collectors/ckan.py
@@ -185,7 +185,7 @@ def extract_ckan_inventory_row(
 
 def _ckan_search_params(source_cfg: dict[str, Any], *, page_size: int, start: int) -> dict[str, Any]:
     """Build package_search params, optionally adding fq from inventory config."""
-    inv = source_cfg.get("inventory", {})
+    inv = source_cfg.get("inventory") or {}
     params: dict[str, Any] = {"rows": page_size, "start": start}
     fq = inv.get("fq")
     if fq:
@@ -468,11 +468,12 @@ def collect_ckan_inventory_via_package_search_offset(
     total_count: int | None = None
     offset = 0
 
+    _fq = (source_cfg.get("inventory") or {}).get("fq")
+
     while True:
-        _fq = (source_cfg.get("inventory") or {}).get("fq")
-        params = f"rows={page_size}&offset={offset}&q=*:*"
+        params: dict[str, Any] = {"rows": page_size, "offset": offset, "q": "*:*"}
         if _fq:
-            params += f"&fq={_fq}"
+            params["fq"] = _fq
         try:
             payload = ckan_get_json(endpoint, params=params, timeout=60)
         except Exception as exc:

--- a/scripts/collectors/test_ckan_collector.py
+++ b/scripts/collectors/test_ckan_collector.py
@@ -4,11 +4,13 @@ import pytest
 
 from collectors.ckan import (
     _ckan_api_base,
+    _ckan_search_params,
     _has_datastore_active,
     _resource_count,
     _resource_format,
     ckan_action_endpoint,
     collect_ckan_inventory_via_package_show_sample,
+    collect_ckan_inventory_via_search,
     extract_ckan_inventory_row,
 )
 
@@ -261,4 +263,94 @@ class TestPackageShowSample:
             assert warning is None
         finally:
             monkeypatch.setattr(ckan_module, "ckan_get_json", original)
+
+
+class TestCkanSearchParams:
+    """Test per _ckan_search_params — costruzione params con/senza fq."""
+
+    def test_without_fq(self):
+        params = _ckan_search_params({"inventory": {}}, page_size=100, start=0)
+        assert params == {"rows": 100, "start": 0}
+
+    def test_with_fq(self):
+        params = _ckan_search_params(
+            {"inventory": {"fq": "organization:anac"}},
+            page_size=100, start=0,
+        )
+        assert params == {"rows": 100, "start": 0, "fq": "organization:anac"}
+
+    def test_with_fq_no_inventory_key(self):
+        """Se inventory non esiste, non crasha."""
+        params = _ckan_search_params({}, page_size=50, start=25)
+        assert params == {"rows": 50, "start": 25}
+
+    def test_with_fq_inventory_is_none(self):
+        params = _ckan_search_params({"inventory": None}, page_size=10, start=5)
+        assert params == {"rows": 10, "start": 5}
+
+    def test_fq_with_spaces_and_special_chars(self):
+        """Verifica che fq con caratteri speciali venga passato così com'è
+        (la codifica URL è gestita da requests.get(params=...))."""
+        fq_val = 'organization:"ministero-delle-imprese-e-del-made-in-italy"'
+        params = _ckan_search_params(
+            {"inventory": {"fq": fq_val}},
+            page_size=100, start=0,
+        )
+        assert params["fq"] == fq_val
+
+
+class TestSearchWithFqPropagation:
+    """Test che fq venga propagato da source_cfg a ckan_get_json."""
+
+    def test_via_search_passes_fq_to_ckan_get_json(self, monkeypatch):
+        captured_params: dict | None = None
+
+        def fake_ckan_get_json(endpoint, **kwargs):
+            nonlocal captured_params
+            captured_params = kwargs.get("params")
+            return {"success": True, "result": {"results": [], "count": 0}}
+
+        monkeypatch.setattr("collectors.ckan.ckan_get_json", fake_ckan_get_json)
+
+        source_cfg = {
+            "base_url": "https://dati.gov.it/opendata/api/3/action/package_list?limit=1",
+            "inventory": {"fq": "organization:anac"},
+        }
+        try:
+            collect_ckan_inventory_via_search(
+                source_id="test-fq", source_cfg=source_cfg, captured_at="2026-05-24"
+            )
+        except Exception:
+            pass  # può sollevare ValueError per results vuoti
+
+        assert captured_params is not None, "ckan_get_json non è stata chiamata"
+        assert captured_params.get("fq") == "organization:anac", (
+            f"expected fq='organization:anac', got {captured_params}"
+        )
+
+    def test_via_search_without_fq(self, monkeypatch):
+        captured_params: dict | None = None
+
+        def fake_ckan_get_json(endpoint, **kwargs):
+            nonlocal captured_params
+            captured_params = kwargs.get("params")
+            return {"success": True, "result": {"results": [], "count": 0}}
+
+        monkeypatch.setattr("collectors.ckan.ckan_get_json", fake_ckan_get_json)
+
+        source_cfg = {
+            "base_url": "https://dati.gov.it/opendata/api/3/action/package_list?limit=1",
+            "inventory": {},
+        }
+        try:
+            collect_ckan_inventory_via_search(
+                source_id="test-no-fq", source_cfg=source_cfg, captured_at="2026-05-24"
+            )
+        except Exception:
+            pass
+
+        assert captured_params is not None, "ckan_get_json non è stata chiamata"
+        assert "fq" not in captured_params, (
+            f"fq non dovrebbe essere presente, ma c'è: {captured_params}"
+        )
 pytestmark = pytest.mark.adapter


### PR DESCRIPTION
## Cosa

Aggiunto supporto per il parametro `inventory.fq` nel registry per i collettori CKAN. Quando presente, viene passato come `fq` alla `package_search`, permettendo di filtrare i dataset per organizzazione (o altro filtro Solr).

## Perché

ANAC ha un WAF sul portale diretto (`dati.anticorruzione.it`) che blocca le API CKAN. Su `dati.gov.it` i dataset ANAC sono harvestati (70 dataset) ma accessibili solo filtrando per `organization:anac`. Senza questo fix, il collector prova a scaricare **tutti** i dataset del portale (es. `dati.gov.it` ha decine di migliaia di dataset) e va in timeout.

## Cosa cambia

**collector CKAN** (`scripts/collectors/ckan.py`):
- Nuova helper `_ckan_search_params()` che costruisce i params di `package_search` includendo `fq` se presente in `source_cfg.inventory.fq`
- `collect_ckan_inventory_via_search` usa la helper
- `collect_ckan_inventory_via_package_search_offset` aggiunge `&fq=` se presente

**registry** (`data/radar/sources_registry.yaml`):
- ANAC: `observation_mode` → `catalog-watch`, `verdict` → `go`, `base_url` → `dati.gov.it`
- Aggiunto `inventory.fq: organization:anac`
- Nota aggiornata con lo split discovery/dati.gov.it + download/ANAC-diretto

## Test

```
python scripts/build_catalog_inventory.py --source-ids anac --workers 1

Source           Status     Items    Time     Note
anac             OK         70        2.3s    70 items
```

70 dataset ANAC harvestati in 2.3 secondi.

## Vedi anche

Issue #... (da creare per eventuale fix User-Agent nel toolkit per download raw ANAC)