### PR TITLE
feat(registry): ripristino mur_ustat e lavoro_opendata su dati.gov.it

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -281,34 +281,53 @@ consip_open_data:
 lavoro_opendata:
   source_kind: catalog
   protocol: ckan
-  observation_mode: radar-only
-  base_url: 
-    https://dati.lavoro.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
+  observation_mode: catalog-watch
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
+  inventory:
+    fq: organization:ministero-del-lavoro
+    timeout: 180
+    skip_current_list: true
+    skip_current_list_reason: "package_search con fq=organization:ministero-del-lavoro
+      restituisce 83 dataset con metadata completi. current_list non necessario."
   last_probed: '2026-05-24'
-  verdict: hold
-  note: "Declassato a radar-only il 2026-05-18. ValueError sistematico su package_list
-    — CKAN non raggiungibile via HTTP standard (restituisce HTML non JSON). Catalogo
-    ~159 dataset, inventory non aggiornabile fino a ripristino API.\n"
+  catalog_baseline:
+    captured_at: '2026-05-24'
+    metric: package_count
+    value: 83
+    method: package_search
+    reliability: high
+    note: Conteggio via package_search con fq=organization:ministero-del-lavoro su
+      dati.gov.it. 83 dataset harvestati dal portale Ministero del Lavoro.
+  verdict: go
+  note: "Fonte via dati.gov.it (harvesting Ministero del Lavoro). Sostituisce
+    fonte diretta dati.lavoro.gov.it che aveva WAF. 83 dataset su lavoro
+    (rapporti attivati/cessati, missioni, qualifiche professionali, genere,
+    settore ATECO, ripartizione geografica)."
   datasets_in_use: []
 mur_ustat:
   source_kind: catalog
   protocol: ckan
-  observation_mode: radar-only
-  base_url: https://dati-ustat.mur.gov.it/api/3/action/package_list?limit=1
+  observation_mode: catalog-watch
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
+  inventory:
+    fq: organization:ministero-universita-e-ricerca
+    timeout: 180
+    skip_current_list: true
+    skip_current_list_reason: "package_search con fq=organization:ministero-universita-e-ricerca
+      restituisce 69 dataset con metadata completi. current_list non necessario."
   last_probed: '2026-05-24'
   catalog_baseline:
-    captured_at: '2026-04-09'
+    captured_at: '2026-05-24'
     metric: package_count
-    value: 68
-    method: package_list
-    reliability: medium
-    note: Baseline fissata il 2026-04-09. Declassato a radar-only il 2026-05-18 
-      per timeout sistematico di connessione (ConnectTimeout). Inventory non 
-      aggiornabile fino a ripristino endpoint.
-  verdict: hold
-  note: "Declassato a radar-only il 2026-05-18. ConnectTimeout sistematico su CKAN
-    package_list. 68 dataset in baseline storica. Inventory non aggiornabile fino
-    a ripristino endpoint.\n"
+    value: 69
+    method: package_search
+    reliability: high
+    note: Conteggio via package_search con fq=organization:ministero-universita-e-ricerca
+      su dati.gov.it. 69 dataset harvestati dal portale MUR.
+  verdict: go
+  note: "Fonte via dati.gov.it (harvesting MUR). Sostituisce fonte diretta
+    dati-ustat.mur.gov.it che aveva ConnectTimeout. 69 dataset su istruzione
+    universitaria (contribuzione atenei, DSU regionale, collegi, AFAM)."
   datasets_in_use:
     - mur_contribuzione_universitaria
 opencoesione:


### PR DESCRIPTION
## Cosa

Ripristino di due fonti in **hold** (mur_ustat e lavoro_opendata) usando lo stesso pattern di ANAC (PR #272): puntare a dati.gov.it con `inventory.fq`.

## Modifiche

### `mur_ustat` — 69 dataset
- `observation_mode`: `radar-only` → `catalog-watch`
- `base_url`: `dati-ustat.mur.gov.it` → `dati.gov.it`
- `inventory.fq`: `organization:ministero-universita-e-ricerca`
- `verdict`: `hold` → `go`
- Dati: contribuzione atenei, DSU regionale, collegi universitari, AFAM (2013-2025)

### `lavoro_opendata` — 83 dataset
- `observation_mode`: `radar-only` → `catalog-watch`
- `base_url`: `dati.lavoro.gov.it` → `dati.gov.it`
- `inventory.fq`: `organization:ministero-del-lavoro`
- `verdict`: `hold` → `go`
- Dati: rapporti lavoro attivati/cessati, missioni somministrazione, qualifiche, genere, settore ATECO

## Test

```
python scripts/build_catalog_inventory.py --source-ids mur_ustat lavoro_opendata --workers 2

mur_ustat:        OK    69 items
lavoro_opendata:  OK    83 items
```

## Issue collegate

Closes #277 (MUR)
Closes #276 (Ministero Lavoro)