### PR TITLE
feat(registry): aggiunte fonti Ministero Interno, AgID, MIMIT/RNA

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -549,3 +549,80 @@ terna_opendata:
       - GenerationPlants
   datasets_in_use:
     - terna_electricity_by_source
+ministero_interno:
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
+  inventory:
+    fq: organization:ministero-dell-interno
+    timeout: 180
+    skip_current_list: true
+    skip_current_list_reason: "package_search con fq=organization:ministero-dell-interno
+      restituisce 38 dataset con metadata completi."
+  last_probed: '2026-05-24'
+  catalog_baseline:
+    captured_at: '2026-05-24'
+    metric: package_count
+    value: 38
+    method: package_search
+    reliability: high
+    note: Conteggio via package_search con fq=organization:ministero-dell-interno
+      su dati.gov.it. 38 dataset su elezioni (per comune) e ANPR (popolazione).
+  verdict: go
+  note: "Fonte via dati.gov.it. Dati elezioni (Politiche 2022, Comunali 2024,
+    Europee 2024, Regionali) per comune + ANPR (popolazione residente, cambi
+    residenza, certificati, AIRE). Alto valore civico per analisi territoriale del voto."
+  datasets_in_use: []
+agid:
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
+  inventory:
+    fq: organization:agenzia-per-l-italia-digitale
+    timeout: 180
+    skip_current_list: true
+    skip_current_list_reason: "package_search con fq=organization:agenzia-per-l-italia-digitale
+      restituisce 40 dataset con metadata completi."
+  last_probed: '2026-05-24'
+  catalog_baseline:
+    captured_at: '2026-05-24'
+    metric: package_count
+    value: 40
+    method: package_search
+    reliability: high
+    note: Conteggio via package_search con fq=organization:agenzia-per-l-italia-digitale
+      su dati.gov.it. 40 dataset IPA (enti, PEC, domicili digitali, servizi, RTD).
+  verdict: go
+  note: "Fonte via dati.gov.it. IPA — Indice delle PA: enti, unita organizzative,
+    PEC, domicili digitali, responsabili transizione digitale, servizi digitali,
+    fatturazione elettronica, cloud. Codice_IPA chiave di join con ANAC."
+  datasets_in_use: []
+mimit_rna:
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
+  inventory:
+    fq: organization:ministero-delle-imprese-e-del-made-in-italy
+    timeout: 180
+    skip_current_list: true
+    skip_current_list_reason: "package_search con fq=organization:ministero-delle-imprese-e-del-made-in-italy
+      restituisce 370 dataset (RNA Aiuti + RNA Misure) con metadata."
+  last_probed: '2026-05-24'
+  catalog_baseline:
+    captured_at: '2026-05-24'
+    metric: package_count
+    value: 370
+    method: package_search
+    reliability: high
+    note: Conteggio via package_search con fq=organization:ministero-delle-imprese-e-del-made-in-italy
+      su dati.gov.it. 370 dataset (133 RNA Aiuti + 237 RNA Misure).
+  verdict: go
+  note: "Fonte via dati.gov.it. RNA — Registro Nazionale Aiuti di Stato.
+    133 dataset mensili Aiuti (2017-2026, XML, ~14.500 record/mese) +
+    237 dataset Misure (1994-2023). File su www.rna.gov.it scaricabili
+    (200 MB/mese, XML strutturato). Altissimo valore civico: tracciamento
+    aiuti pubblici alle imprese con beneficiario, CF, importo, regione, CUP."
+  datasets_in_use: []

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -626,3 +626,31 @@ mimit_rna:
     (200 MB/mese, XML strutturato). Altissimo valore civico: tracciamento
     aiuti pubblici alle imprese con beneficiario, CF, importo, regione, CUP."
   datasets_in_use: []
+ministero_salute:
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
+  inventory:
+    fq: organization:ministero-della-salute
+    timeout: 180
+    skip_current_list: true
+    skip_current_list_reason: "package_search con fq=organization:ministero-della-salute
+      restituisce 51 dataset con metadata."
+  last_probed: '2026-05-24'
+  catalog_baseline:
+    captured_at: '2026-05-24'
+    metric: package_count
+    value: 51
+    method: package_search
+    reliability: high
+    note: Conteggio via package_search con fq=organization:ministero-della-salute
+      su dati.gov.it. 51 dataset (farmacie, posti letto, personale SSN, dispositivi,
+      ASL, fitosanitari). URL raw su dati.salute.gov.it (portale in migrazione).
+  verdict: go
+  note: "Fonte via dati.gov.it. Anagrafiche sanitarie nazionali: farmacie,
+    parafarmacie, posti letto, personale SSN, ASL, dispositivi medici, fitosanitari.
+    I file raw puntano a dati.salute.gov.it (portale in migrazione a Gatsby,
+    alcuni URL aggiornati). Complementare a dati_salute (csv_magnet) per il
+    catalogo completo del portale diretto."
+  datasets_in_use: []


### PR DESCRIPTION
## Cosa

Tre nuove fonti nazionali su dati.gov.it aggiunte al registry, stesso pattern
di ANAC/MUR/Lavoro (PR #272 + #280): `inventory.fq` su dati.gov.it.

## Nuove fonti

### `ministero_interno` — 38 dataset
- **Elezioni**: Politiche 2022, Comunali 2024, Europee 2024, Regionali — dati **per comune**
- **ANPR**: popolazione residente, cambi residenza, certificati, AIRE
- Verdict: `go`

### `agid` — 40 dataset
- **IPA**: enti, unità organizzative, PEC, domicili digitali, RTD, servizi digitali,
  fatturazione elettronica, cloud (IaaS/PaaS/SaaS)
- `Codice_IPA` = chiave di join con ANAC
- Verdict: `go`

### `mimit_rna` — 370 dataset
- **RNA Aiuti**: 133 file XML mensili (2017→2026, ~14.500 record/mese)
- **RNA Misure**: 237 file XML mensili (1994→2023)
- File scaricabili su www.rna.gov.it (200 MB/mese, XML strutturato)
- Altissimo valore civico: tracciamento aiuti pubblici alle imprese
- Verdict: `go`

## Test

```
ministero_interno:  OK    38 items
agid:               OK    40 items
mimit_rna:          OK    370 items
```

## Issue collegate

Closes #273 (MIMIT/RNA)
Closes #278 (Ministero Interno)
Closes #279 (AgID)