### PR TITLE
refactor: unifica path artifact in scripts/_constants.py

### DIFF
--- a/mcp/_artifact.py
+++ b/mcp/_artifact.py
@@ -35,23 +35,39 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 # ── Script paths ──────────────────────────────────────────────────────────────
 
 _COLLECTORS_BASE = _REPO_ROOT / "scripts" / "collectors" / "base.py"
+_CONSTANTS_FILE = _REPO_ROOT / "scripts" / "_constants.py"
 
-# ── Artifact paths ────────────────────────────────────────────────────────────
+# ── Artifact paths (canonical source: scripts/_constants.py) ──────────────────
 
-_CHECK_PARQUET = (
-    _REPO_ROOT / "data" / "catalog_inventory" / "generated" / "source_check_results.parquet"
-)
-_INVENTORY_PARQUET = (
-    _REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_latest.parquet"
-)
-_INVENTORY_REPORT = (
-    _REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_report.json"
-)
-_SIGNALS_JSON = _REPO_ROOT / "data" / "catalog" / "catalog_signals.json"
-_RADAR_JSON = _REPO_ROOT / "data" / "radar" / "radar_summary.json"
-_RADAR_HISTORY_JSON = _REPO_ROOT / "data" / "radar" / "radar_history.json"
-_STATUS_MD = _REPO_ROOT / "data" / "radar" / "STATUS.md"
-_REGISTRY_YAML = _REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
+# I path degli artifact sono definiti in scripts/_constants.py per avere un'unica
+# fonte canonica. Qui vengono caricati via importlib per evitare duplicazione
+# (mcp/ non ha scripts/ in sys.path a runtime).
+
+_constants_mod = None
+
+
+def _get_constants():
+    """Lazy-load scripts/_constants.py come modulo separato."""
+    global _constants_mod
+    if _constants_mod is None:
+        spec = importlib.util.spec_from_file_location("_so_constants", _CONSTANTS_FILE)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load _constants from {_CONSTANTS_FILE}")
+        _constants_mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = _constants_mod
+        spec.loader.exec_module(_constants_mod)
+    return _constants_mod
+
+
+_c = _get_constants()
+_CHECK_PARQUET = _c.CHECK_PARQUET_PATH
+_INVENTORY_PARQUET = _c.INVENTORY_PARQUET_PATH
+_INVENTORY_REPORT = _c.CATALOG_INVENTORY_REPORT_PATH
+_SIGNALS_JSON = _c.CATALOG_SIGNALS_PATH
+_RADAR_JSON = _c.RADAR_SUMMARY_PATH
+_RADAR_HISTORY_JSON = _c.RADAR_HISTORY_PATH
+_STATUS_MD = _c.STATUS_MD_PATH
+_REGISTRY_YAML = _c.REGISTRY_PATH
 _DEFAULT_CACHE_MAX_AGE_HOURS = 24
 
 # ── GCS prefix defaults ──────────────────────────────────────────────────────

--- a/scripts/_constants.py
+++ b/scripts/_constants.py
@@ -5,11 +5,26 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# ── Registry ──────────────────────────────────────────────────────────────────
 REGISTRY_PATH = REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
-CATALOG_INVENTORY_REPORT_PATH = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_report.json"
+
+# ── Radar (scripts/radar_check.py → mcp/_radar.py) ───────────────────────────
 RADAR_SUMMARY_PATH = REPO_ROOT / "data" / "radar" / "radar_summary.json"
-CATALOG_SIGNALS_PATH = REPO_ROOT / "data" / "catalog" / "catalog_signals.json"
 RADAR_HISTORY_PATH = REPO_ROOT / "data" / "radar" / "radar_history.json"
+STATUS_MD_PATH = REPO_ROOT / "data" / "radar" / "STATUS.md"
+
+# ── Catalog inventory (scripts/build_catalog_inventory.py → mcp/_inventory.py) ─
+INVENTORY_PARQUET_PATH = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_latest.parquet"
+CATALOG_INVENTORY_REPORT_PATH = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_report.json"
+CATALOG_WATCH_REPORT_PATH = REPO_ROOT / "data" / "catalog" / "CATALOG_WATCH_REPORT.md"
+
+# ── Source check (scripts/bulk_source_check.py → mcp/_signals.py) ────────────
+CHECK_PARQUET_PATH = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "source_check_results.parquet"
+CATALOG_SIGNALS_PATH = REPO_ROOT / "data" / "catalog" / "catalog_signals.json"
+
+# ── Schemas (scripts/build_catalog_signals.py) ────────────────────────────────
+SCHEMA_DIR_PATH = REPO_ROOT / "schemas"
 
 # Canonical stale_reason taxonomy for catalog-inventory error classification.
 # Used by build_catalog_inventory.py to tag stale rows.

--- a/scripts/_constants.py
+++ b/scripts/_constants.py
@@ -15,8 +15,9 @@ RADAR_HISTORY_PATH = REPO_ROOT / "data" / "radar" / "radar_history.json"
 STATUS_MD_PATH = REPO_ROOT / "data" / "radar" / "STATUS.md"
 
 # ── Catalog inventory (scripts/build_catalog_inventory.py → mcp/_inventory.py) ─
-INVENTORY_PARQUET_PATH = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_latest.parquet"
-CATALOG_INVENTORY_REPORT_PATH = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_report.json"
+CATALOG_INVENTORY_DIR_PATH = REPO_ROOT / "data" / "catalog_inventory" / "generated"
+INVENTORY_PARQUET_PATH = CATALOG_INVENTORY_DIR_PATH / "catalog_inventory_latest.parquet"
+CATALOG_INVENTORY_REPORT_PATH = CATALOG_INVENTORY_DIR_PATH / "catalog_inventory_report.json"
 CATALOG_WATCH_REPORT_PATH = REPO_ROOT / "data" / "catalog" / "CATALOG_WATCH_REPORT.md"
 
 # ── Source check (scripts/bulk_source_check.py → mcp/_signals.py) ────────────

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -11,7 +11,13 @@ from pathlib import Path
 from typing import Any, cast
 
 import pandas as pd
-from _constants import REGISTRY_PATH, load_registry, stale_reason_from_exception
+from _constants import (
+    CATALOG_INVENTORY_DIR_PATH,
+    RADAR_SUMMARY_PATH,
+    REGISTRY_PATH,
+    load_registry,
+    stale_reason_from_exception,
+)
 from collectors import dispatch, supported_protocols
 from collectors.base import inventory_cfg, now_utc_iso
 from collectors.ckan import (
@@ -57,8 +63,7 @@ def collect_sdmx_inventory(source_id: str, source_cfg: dict[str, Any], captured_
     return res.rows, res.warning
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_OUT_DIR = REPO_ROOT / "data" / "catalog_inventory" / "generated"
+DEFAULT_OUT_DIR = CATALOG_INVENTORY_DIR_PATH
 DEFAULT_OUT_PARQUET = "catalog_inventory_latest.parquet"
 DEFAULT_OUT_REPORT = "catalog_inventory_report.json"
 
@@ -178,7 +183,7 @@ def main() -> None:
 
     # ── Skip RED sources da radar ─────────────────────────────────────────────
     if args.skip_red_sources:
-        radar_path = REPO_ROOT / "data" / "radar" / "radar_summary.json"
+        radar_path = RADAR_SUMMARY_PATH
         if radar_path.exists():
             try:
                 with radar_path.open() as fh:

--- a/scripts/build_catalog_signals.py
+++ b/scripts/build_catalog_signals.py
@@ -16,17 +16,23 @@ from pathlib import Path
 
 import jsonschema
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-SCHEMA_DIR = REPO_ROOT / "schemas"
-DEFAULT_REPORT = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_report.json"
-DEFAULT_RADAR = REPO_ROOT / "data" / "radar" / "radar_summary.json"
-DEFAULT_OUT = REPO_ROOT / "data" / "catalog" / "catalog_signals.json"
-DEFAULT_REPORT_OUT = REPO_ROOT / "data" / "catalog" / "CATALOG_WATCH_REPORT.md"
+from _constants import (
+    CATALOG_INVENTORY_REPORT_PATH,
+    CATALOG_SIGNALS_PATH,
+    CATALOG_WATCH_REPORT_PATH,
+    RADAR_SUMMARY_PATH,
+    SCHEMA_DIR_PATH,
+)
+
+DEFAULT_REPORT = CATALOG_INVENTORY_REPORT_PATH
+DEFAULT_RADAR = RADAR_SUMMARY_PATH
+DEFAULT_OUT = CATALOG_SIGNALS_PATH
+DEFAULT_REPORT_OUT = CATALOG_WATCH_REPORT_PATH
 
 
 def _validate_schema(instance: dict, schema_name: str) -> None:
     """Validate a dict against the JSON schema file in schemas/."""
-    schema_path = SCHEMA_DIR / schema_name
+    schema_path = SCHEMA_DIR_PATH / schema_name
     if not schema_path.exists():
         print(f"⚠️  Schema {schema_name} non trovato — skip validazione")
         return

--- a/scripts/build_catalog_signals.py
+++ b/scripts/build_catalog_signals.py
@@ -15,7 +15,6 @@ import json
 from pathlib import Path
 
 import jsonschema
-
 from _constants import (
     CATALOG_INVENTORY_REPORT_PATH,
     CATALOG_SIGNALS_PATH,

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -37,6 +37,13 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from _constants import (
+    CHECK_PARQUET_PATH,
+    INVENTORY_PARQUET_PATH,
+    RADAR_SUMMARY_PATH,
+    REGISTRY_PATH,
+)
+
 from source_check_analyze import (
     _fallback_infer,
     _finalize_scores,
@@ -60,10 +67,8 @@ from source_check_fetch import (
 
 logger = logging.getLogger(__name__)
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_IN = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "catalog_inventory_latest.parquet"
-DEFAULT_OUT = REPO_ROOT / "data" / "catalog_inventory" / "generated" / "source_check_results.parquet"
-REGISTRY_PATH = REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
+DEFAULT_IN = INVENTORY_PARQUET_PATH
+DEFAULT_OUT = CHECK_PARQUET_PATH
 
 MAX_WORKERS = 16
 _NO_SDMX_YEARS = False  # set via --no-sdmx-years flag
@@ -734,7 +739,7 @@ def main() -> None:
     # Evita di campionare item da fonti che timeoutmano su Actions (IP cloud blocked)
     # e allungano il source-check senza produrre valore.
     if args.skip_red_sources:
-        radar_summary_path = REPO_ROOT / "data" / "radar" / "radar_summary.json"
+        radar_summary_path = RADAR_SUMMARY_PATH
         if radar_summary_path.exists():
             import json
             try:

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -43,7 +43,6 @@ from _constants import (
     RADAR_SUMMARY_PATH,
     REGISTRY_PATH,
 )
-
 from source_check_analyze import (
     _fallback_infer,
     _finalize_scores,

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -6,7 +6,6 @@ from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
-from pathlib import Path
 from typing import Any, Literal
 
 import jsonschema
@@ -15,6 +14,8 @@ from _constants import (
     RADAR_HISTORY_PATH,
     RADAR_SUMMARY_PATH,
     REGISTRY_PATH,
+    SCHEMA_DIR_PATH,
+    STATUS_MD_PATH,
     append_radar_probe,
     load_radar_history,
     load_registry,
@@ -23,12 +24,10 @@ from _constants import (
 )
 from lab_connectors.http import HttpClient, HttpFallbackError
 
-_SCHEMA_DIR = Path(__file__).resolve().parents[1] / "schemas"
-
 
 def _validate_schema(instance: dict, schema_name: str) -> None:
     """Validate a dict against the JSON schema file in schemas/."""
-    schema_path = _SCHEMA_DIR / schema_name
+    schema_path = SCHEMA_DIR_PATH / schema_name
     if not schema_path.exists():
         print(f"⚠️  Schema {schema_name} non trovato — skip validazione")
         return
@@ -40,8 +39,6 @@ def _validate_schema(instance: dict, schema_name: str) -> None:
         raise
 
 
-WORKSPACE_ROOT = Path(__file__).resolve().parents[1]
-STATUS_PATH = WORKSPACE_ROOT / "data" / "radar" / "STATUS.md"
 USER_AGENT = "DataCivicLab-SourceObservatory/1.0"
 TIMEOUT_SECONDS = 10
 
@@ -474,15 +471,15 @@ def main() -> int:
 
     _validate_schema(summary, "radar_summary.schema.json")
 
-    STATUS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    STATUS_PATH.write_text(report, encoding="utf-8")
+    STATUS_MD_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STATUS_MD_PATH.write_text(report, encoding="utf-8")
     RADAR_SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
     RADAR_SUMMARY_PATH.write_text(
         json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
     )
     save_radar_history(history)
     save_registry(REGISTRY_PATH, registry)
-    print(f"Wrote {STATUS_PATH}")
+    print(f"Wrote {STATUS_MD_PATH}")
     print(f"Wrote {RADAR_SUMMARY_PATH}")
     if summary.get("persistent_red"):
         print(f"⚠️  Persistent RED: {summary['persistent_red']} fonti ({', '.join(s['id'] for s in summary['sources'] if s.get('red_streak'))})")

--- a/scripts/sync_datasets_in_use.py
+++ b/scripts/sync_datasets_in_use.py
@@ -9,9 +9,8 @@ import sys
 from pathlib import Path
 from urllib.request import urlopen
 
-from ruamel.yaml import YAML
-
 from _constants import REGISTRY_PATH
+from ruamel.yaml import YAML
 
 DI_CATALOG_URL = (
     "https://raw.githubusercontent.com/dataciviclab/dataset-incubator/"

--- a/scripts/sync_datasets_in_use.py
+++ b/scripts/sync_datasets_in_use.py
@@ -11,12 +11,12 @@ from urllib.request import urlopen
 
 from ruamel.yaml import YAML
 
+from _constants import REGISTRY_PATH
+
 DI_CATALOG_URL = (
     "https://raw.githubusercontent.com/dataciviclab/dataset-incubator/"
     "main/registry/clean_catalog.json"
 )
-ROOT = Path(__file__).resolve().parents[1]
-REGISTRY_PATH = ROOT / "data" / "radar" / "sources_registry.yaml"
 
 
 def fetch_di_catalog() -> list[dict]:


### PR DESCRIPTION
## Sintesi

Unifica in un unico file (`scripts/_constants.py`) tutti i path degli artifact SO, eliminando la duplicazione tra scripts e MCP.

Prima: gli stessi path (source_check_results.parquet, catalog_inventory_latest.parquet, radar_summary.json, ecc.) erano definiti in **6 posti diversi** con nomi e formati differenti. Rischio di desync ogni volta che si sposta un artifact.

Dopo: un unico file fonte canonica. Tutti gli altri importano.

## Cosa cambia

- [x] Modifica script (radar, inventory, source-check, MCP)
- [x] Altro — refactor path constanti

## Checklist

- [x] `pytest tests/` passa — 250/250
- [x] Server MCP si avvia — 12 tool registrati
- [x] `ruff check .` passa
- [x] Perimetro stretto: una PR = un tema (path unificati)

## Cosa è cambiato

### scripts/_constants.py
- Aggiunti `SCHEMA_DIR_PATH`, `CATALOG_WATCH_REPORT_PATH`
- Raggruppati per dominio (radar, inventory, source check, schemas)
- Rimossi alias inutilizzati (`CATALOG_CHECK_PARQUET_PATH`, `CATALOG_INVENTORY_LATEST_PATH`)

### mcp/_artifact.py
- Path caricati da `_constants` via `importlib` anziché ridefiniti

### scripts/bulk_source_check.py
- `DEFAULT_IN`, `DEFAULT_OUT`, `REGISTRY_PATH`, `RADAR_SUMMARY_PATH` → import da `_constants`

### scripts/build_catalog_signals.py
- `DEFAULT_REPORT`, `DEFAULT_RADAR`, `DEFAULT_OUT`, `DEFAULT_REPORT_OUT` → import da `_constants`

### scripts/sync_datasets_in_use.py
- `REGISTRY_PATH` → import da `_constants`

## Verifica

- `pytest tests/ -x --tb=short` → 250 passed
- `python mcp/so_server.py` (import + list_tools) → 12 tool
- Confronto valori path tra vecchie e nuove definizioni identici
- Coverage invariato 58%

## Note per chi revisiona

Refactor meccanico: path spostati in _constants e importati altrove. Zero cambiamento funzionale. I test passano tutti.