### PR TITLE
test: test pure functions html collector + sostituisce _is_sdmx_url con toolkit

### DIFF
--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -22,6 +22,7 @@ from _constants import (
     validate_schema,
 )
 from lab_connectors.http import HttpClient, HttpFallbackError
+from toolkit.scout.http import is_sdmx_url
 
 USER_AGENT = "DataCivicLab-SourceObservatory/1.0"
 TIMEOUT_SECONDS = 10
@@ -70,12 +71,6 @@ def validate_ckan_action_response(
         return "YELLOW", "CKAN API payload missing expected keys"
 
     return status, None
-
-
-def _is_sdmx_url(url: str) -> bool:
-    """Detect SDMX endpoint by URL pattern."""
-    sdmx_markers = ("/rest/", "/SDMXWS/", "/sdmx/")
-    return any(marker in url for marker in sdmx_markers)
 
 
 def _make_error_result(
@@ -189,7 +184,7 @@ def _probe_once(base_url: str) -> ProbeResult:
 
 def probe_url(base_url: str) -> ProbeResult:
     """Probe URL with retry/backoff for SDMX endpoints known to be intermittent."""
-    if not _is_sdmx_url(base_url):
+    if not is_sdmx_url(base_url):
         result = _probe_once(base_url)
         # Retry once with shorter timeout on transient failures (timeout / connection error)
         if result.http_code == "-" and result.status == "YELLOW":

--- a/tests/test_html_collector_pure.py
+++ b/tests/test_html_collector_pure.py
@@ -1,10 +1,13 @@
 """Test delle funzioni pure di collectors.html (nessun HTTP)."""
 
+import pytest
 from collectors.html import (
     _extract_page_meta,
     _extract_prefix,
     _extract_years,
 )
+
+pytestmark = pytest.mark.pure_unit
 
 # ─── _extract_page_meta ───────────────────────────────────────────────────────
 

--- a/tests/test_html_collector_pure.py
+++ b/tests/test_html_collector_pure.py
@@ -1,0 +1,101 @@
+"""Test delle funzioni pure di collectors.html (nessun HTTP)."""
+
+from collectors.html import (
+    _extract_page_meta,
+    _extract_prefix,
+    _extract_years,
+)
+
+# ─── _extract_page_meta ───────────────────────────────────────────────────────
+
+
+def test_extract_page_meta_normal_title():
+    """Estrae title da <title> semplice."""
+    html = "<html><head><title>My Portal</title></head><body></body></html>"
+    meta = _extract_page_meta(html)
+    assert meta.get("title") == "My Portal"
+
+
+def test_extract_page_meta_open_data_prefix():
+    """Rimuove prefisso 'Open Data - ' dal title."""
+    html = "<html><head><title>Open Data - My Portal</title></head><body></body></html>"
+    meta = _extract_page_meta(html)
+    assert meta.get("title") == "My Portal"
+
+
+def test_extract_page_meta_with_description():
+    """Estrae description da <meta name='description'>."""
+    html = (
+        '<html><head><title>Title</title>'
+        '<meta name="description" content="A portal description here.">'
+        '</head><body></body></html>'
+    )
+    meta = _extract_page_meta(html)
+    assert meta.get("title") == "Title"
+    assert meta.get("description") == "A portal description here."
+
+
+def test_extract_page_meta_no_title():
+    """HTML senza <title> → dict vuoto."""
+    html = "<html><head></head><body>content</body></html>"
+    meta = _extract_page_meta(html)
+    assert meta == {}
+
+
+def test_extract_page_meta_empty_html():
+    """Stringa vuota → dict vuoto."""
+    meta = _extract_page_meta("")
+    assert meta == {}
+
+
+# ─── _extract_prefix ──────────────────────────────────────────────────────────
+
+
+def test_extract_prefix_underscore():
+    """Filename con underscore → prima parte."""
+    assert _extract_prefix("FRM_FARMA_5_20260427") == "FRM"
+
+
+def test_extract_prefix_uppercase_run():
+    """Filename senza underscore → regex match (max 8 char)."""
+    assert _extract_prefix("SCUANAGRAFESTAT202526") == "SCUANAGR"
+
+
+def test_extract_prefix_short_no_underscore():
+    """Filename corto (2-8 char) senza underscore → match regex."""
+    assert _extract_prefix("abc") == "abc"
+
+
+def test_extract_prefix_single_char():
+    """Filename singolo carattere → fallback filename[:6]."""
+    assert _extract_prefix("a") == "a"
+
+
+def test_extract_prefix_underscore_first():
+    """Underscore come primo segmento."""
+    assert _extract_prefix("_hidden_file") == ""
+
+
+# ─── _extract_years ───────────────────────────────────────────────────────────
+
+
+def test_extract_years_single():
+    """Filename con un anno."""
+    assert _extract_years("dati_2024.csv") == [2024]
+
+
+def test_extract_years_multiple():
+    """Filename con anni multipli."""
+    result = _extract_years("report_2023_2025_final.csv")
+    assert 2023 in result
+    assert 2025 in result
+
+
+def test_extract_years_none():
+    """Filename senza anni."""
+    assert _extract_years("noyears.csv") == []
+
+
+def test_extract_years_four_digit_pattern():
+    """Match 20xx anche per anni futuri (es. 2026)."""
+    assert _extract_years("FRM_FARMA_5_20260427.csv") == [2026]


### PR DESCRIPTION
## Cosa

Due micro-interventi.

### 1. Test per funzioni pure dell'HTML collector

Nuovo file `tests/test_html_collector_pure.py` con 11 test per:
- `_extract_page_meta()` — title, Open Data prefix, description, HTML vuoto
- `_extract_prefix()` — underscore, uppercase, singolo carattere, segmento vuoto
- `_extract_years()` — singolo, multipli, assenti, pattern 20xx

Tutte funzioni pure (no HTTP), test rapido e deterministico.

### 2. Sostituisce `_is_sdmx_url` con `is_sdmx_url` di toolkit

`radar_check.py` aveva una versione locale di `_is_sdmx_url` con 3 pattern. Rimpiazzata con `is_sdmx_url` da `toolkit.scout.http` che ha 4 pattern più completi.

### Perché

- Le pure functions dell'HTML collector non avevano test diretti (solo indiretti via scan functions)
- Unificare la detection SDMX con toolkit (evita duplicazione)
- **+103 righe di test, -7 righe di codice, 0 regressioni**

### Diff
```
 2 files changed, 103 insertions(+), 7 deletions(-)
 create mode 100644 tests/test_html_collector_pure.py
```