### PR TITLE
chore: allinea profile_excel — _profile_excel → profile_excel (toolkit #300)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ mcp>=1.27.1
 fastmcp>=3.3.1
 # Path contract GCS — vedere lab-connectors/gcs/paths.py
 lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.0
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.10.1
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ jsonschema>=4.26.0,<5.0
 mcp>=1.27.1
 fastmcp>=3.3.1
 # Path contract GCS — vedere lab-connectors/gcs/paths.py
-lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.0
+lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.1
 dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.18.0

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -498,10 +498,10 @@ def _fetch_data_preview(
                                     break
 
             elif fmt in ("xlsx", "xls"):
-                from toolkit.profile.raw import _profile_excel
+                from toolkit.profile.raw import profile_excel
 
                 read_cfg_excel = {"header": True, "skip": skip_suggested}
-                excel_result = _profile_excel(tmp_path, read_cfg_excel)
+                excel_result = profile_excel(tmp_path, read_cfg_excel)
                 excel_cols = excel_result.get("columns_raw", [])
                 if excel_cols:
                     columns = excel_cols


### PR DESCRIPTION
Toolkit PR #300 ha reso pubblico `_profile_excel` → `profile_excel`. Aggiorna l'import in `source_check_fetch.py` + bump dipendenza toolkit da v1.10.1 → v1.18.0.