### PR TITLE
chore: raise coverage threshold 55% → 60%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,6 @@ jobs:
 
 
       - name: Run tests
-        run: pytest -v --cov-fail-under=55
+        run: pytest -v --cov-fail-under=60
 
 


### PR DESCRIPTION
## Cosa cambia

- Coverage threshold CI da 55% a 60%
- Coverage reale: 61.77% (3,369 stmts, 1,288 missed)

### Verifica
- `pytest --cov-fail-under=60` → ✅ 61.77%