### PR TITLE
Fix: probe radar usa HEAD invece di GET per ridurre falsi positivi SSL

### DIFF
--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -134,12 +134,18 @@ def _build_probe_result(
 
 
 def _probe_once(base_url: str) -> ProbeResult:
-    """Single probe attempt (no retry). Uses lab_connectors HttpClient with SSL fallback."""
+    """Single probe attempt (no retry). Uses lab_connectors HttpClient with SSL fallback.
+
+    Uses HEAD instead of GET per root-cause analysis: the radar only needs
+    status_code + headers (content-type, final_url). HEAD avoids downloading
+    the full body (es. 652KB homepage di dati.salute.gov.it) and reduces the
+    chance of SSLError/ConnectionError in CI environments where the server CA
+    (TI Trust Technologies) is not in the truststore.
+    """
     client = HttpClient(timeout=TIMEOUT_SECONDS, user_agent=USER_AGENT)
-    result = client.get(
+    result = client.head(
         base_url,
         allow_redirects=True,
-        stream=True,
     )
     # ssl_fallback_used=True → primary SSL failed, fallback succeeded → GREEN
     # ssl_fallback_used=False → both failed


### PR DESCRIPTION
## Sintesi

Il probe radar (`_probe_once`) usava `client.get()` con `stream=True` per verificare la raggiungibilità delle fonti. Per le fonti HTML come `dati.salute.gov.it`, questo causava:
- Download completo della homepage (652KB) — inutile, il radar guarda solo status_code + headers
- SSLError + ConnectionError in CI (GitHub Actions) perché il CA "TI Trust Technologies" non è nel truststore del runner

## Cosa cambia

`client.get()` → `client.head()`. HEAD restituisce solo headers, senza body. Stesso `HttpClient` con SSL fallback automatico.

## Verifica

- `pytest tests/test_radar_check.py` — 13/13 pass
- Test manuale: `_probe_once('https://www.dati.salute.gov.it/')` → GREEN 200
- `FakeHttpClient.head()` già presente in `lab_connectors.testing`

## Note

Fix minimo, non rompe contratti. `HttpClient.head()` ha stessa interfaccia SSL fallback di `get()`.
