### PR TITLE
refactor: unifica logica SPARQL SO su lab-connectors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ dependencies = [
   "jsonschema>=4.26.0",
   "mcp>=1.27.1",
   "fastmcp>=3.3.1",
-  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.1",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.18.0",
+  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.11.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.20.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ jsonschema>=4.26.0,<5.0
 mcp>=1.27.1
 fastmcp>=3.3.1
 # Path contract GCS — vedere lab-connectors/gcs/paths.py
-lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.1
-dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.18.0
+lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.11.0
+dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.20.0

--- a/scripts/collectors/sparql.py
+++ b/scripts/collectors/sparql.py
@@ -4,7 +4,11 @@ from typing import Any
 
 from lab_connectors.http.sparql import (
     discover_graphs as discover_named_graphs,
+)
+from lab_connectors.http.sparql import (
     execute_sparql,
+)
+from lab_connectors.http.sparql import (
     infer_schema as infer_graph_schema,
 )
 

--- a/scripts/collectors/sparql.py
+++ b/scripts/collectors/sparql.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from lab_connectors.http.sparql import (
+    discover_graphs as discover_named_graphs,
+    execute_sparql,
+    infer_schema as infer_graph_schema,
+)
+
 from .base import (
     CollectorResult,
     append_unique,
@@ -181,24 +187,119 @@ def _query_supports_offset(source_cfg: dict[str, Any], query_name: str) -> bool:
 def _execute_sparql_query(
     endpoint: str, query_text: str, timeout: int,
 ) -> list[dict[str, Any]]:
-    """Execute a single SPARQL query and return bindings."""
-    response = observatory_get(
-        endpoint,
-        params={"query": query_text, "format": "application/sparql-results+json"},
-        headers={"Accept": "application/sparql-results+json"},
+    """Execute a single SPARQL query and return bindings.
+
+    Delega a lab_connectors.http.sparql.execute_sparql
+    (POST + GET fallback).
+    """
+    try:
+        return execute_sparql(endpoint, query_text, timeout=timeout)
+    except RuntimeError as e:
+        raise ValueError(str(e)) from e
+
+
+def _collect_named_graphs(
+    source_id: str, source_cfg: dict[str, Any], captured_at: str,
+) -> CollectorResult:
+    """Enumerate all named graphs as proxy inventory items.
+
+    Use when the endpoint has no DCAT catalog but organizes data in named graphs
+    (e.g., Senato: composizione/13, ddl/19, votazioni/17, ...).
+    Activated via sparql.inventory_mode: named_graphs in sources_registry.yaml.
+    """
+    sparql_cfg = source_cfg.get("sparql") or {}
+    endpoint = sparql_cfg.get("endpoint_url") or source_cfg["base_url"]
+    timeout = int(sparql_cfg.get("timeout_seconds", 60))
+    graph_uri_prefix = sparql_cfg.get("graph_uri_prefix", "")
+    graph_uri_blacklist = [str(b) for b in sparql_cfg.get("graph_uri_blacklist", [
+        "localhost", "virtrdf", "owl#", "rules.skos", "virtrdf-label",
+    ])]
+    enrich_schema = sparql_cfg.get("enrich_schema", False)
+    schema_predicate_limit = int(sparql_cfg.get("schema_predicate_limit", 20))
+
+    # Discover named graphs via lab-connectors
+    graph_uris = discover_named_graphs(
+        endpoint=endpoint,
         timeout=timeout,
+        prefix=graph_uri_prefix,
+        blacklist=graph_uri_blacklist,
     )
-    response.raise_for_status()
-    payload = response.json()
-    bindings = ((payload.get("results") or {}).get("bindings")) or []
-    if not isinstance(bindings, list):
-        raise ValueError("Unexpected SPARQL payload: bindings is not a list")
-    return bindings
+
+    rows: list[dict[str, Any]] = []
+    for idx, graph_uri in enumerate(graph_uris, start=1):
+        uri_path = graph_uri.replace(graph_uri_prefix, "").rstrip("/")
+        title = uri_path.replace("_", " ").replace("/", " \u2014 Legislatura ")
+        if title:
+            title = title[0].upper() + title[1:]
+
+        tags = None
+        notes_excerpt = f"Named graph: {uri_path}"
+        if enrich_schema:
+            try:
+                schema = infer_graph_schema(
+                    endpoint=endpoint,
+                    graph_uri=graph_uri,
+                    timeout=timeout,
+                    limit=schema_predicate_limit,
+                )
+                if schema:
+                    pred_strings = [
+                        f"{p['compact_name']}({p['count']})" for p in schema
+                    ]
+                    tags = ", ".join(pred_strings)
+                    notes_excerpt = (
+                        f"Named graph: {uri_path} | "
+                        f"Predicati ({len(schema)}): {tags}"
+                    )
+            except Exception:
+                pass
+
+        rows.append({
+            "captured_at": captured_at,
+            "source_id": source_id,
+            "source_kind": source_cfg.get("source_kind"),
+            "protocol": "sparql",
+            "inventory_method": "named_graphs",
+            "item_kind": "dataset",
+            "item_id": graph_uri,
+            "item_name": compact_uri_name(graph_uri),
+            "title": title,
+            "organization": None,
+            "tags": tags,
+            "notes_excerpt": notes_excerpt,
+            "source_url": endpoint,
+            "ordinal": idx,
+            "issued": None,
+            "modified": None,
+            "landing_page": None,
+            "distribution_url": None,
+            "distribution_count": None,
+            "format": None,
+            "theme": None,
+        })
+
+    if not rows:
+        raise ValueError(
+            f"Named graph enumeration returned no rows for {source_id}"
+        )
+
+    return CollectorResult(
+        rows=rows,
+        summary={
+            "type": "named_graphs",
+            "message": "Inventory via enumerazione named graphs SPARQL.",
+            "graphs": len(rows),
+        },
+    )
 
 
 def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> CollectorResult:
     sparql_cfg = source_cfg.get("sparql") or {}
     endpoint = sparql_cfg.get("endpoint_url") or source_cfg["base_url"]
+    inventory_mode = sparql_cfg.get("inventory_mode", "dcat")
+
+    if inventory_mode == "named_graphs":
+        return _collect_named_graphs(source_id, source_cfg, captured_at)
     limit = int(sparql_cfg.get("limit", 5000))
     max_pages = int(sparql_cfg.get("max_pages", 50))
     timeout = int(sparql_cfg.get("timeout_seconds", 60))

--- a/scripts/collectors/sparql.py
+++ b/scripts/collectors/sparql.py
@@ -12,7 +12,6 @@ from .base import (
     CollectorResult,
     append_unique,
     compact_uri_name,
-    observatory_get,
     parse_int,
     sparql_binding_value,
 )

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -369,14 +369,12 @@ def test_collect_sparql_inventory_groups_distribution_bindings(monkeypatch) -> N
         }
     }
 
-    def fake_get(url, **kwargs):
-        assert url == "https://example.test/sparql"
-        assert kwargs["headers"]["Accept"] == "application/sparql-results+json"
-        assert kwargs["params"]["format"] == "application/sparql-results+json"
-        assert "LIMIT 10" in kwargs["params"]["query"]
-        return fake_response(200, json_data=payload, headers={"content-type": "application/sparql-results+json"})
+    def fake_execute(endpoint, query, timeout=60):
+        assert endpoint == "https://example.test/sparql"
+        assert "LIMIT 10" in query
+        return payload["results"]["bindings"]
 
-    monkeypatch.setattr(collectors.sparql, "observatory_get", fake_get)
+    monkeypatch.setattr(collectors.sparql, "execute_sparql", fake_execute)
 
     rows, warning = build_catalog_inventory.collect_sparql_inventory(
         "demo_sparql", source_cfg, "2026-04-11T12:00:00+00:00"

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -713,3 +713,55 @@ class TestContentTypeProbe:
         bf = result.summary.get("by_format", {})
         assert "CSV" in bf, f"by_format non contiene CSV dopo probe: {bf}"
         assert "ZIP" not in bf, f"by_format contiene ancora ZIP pre-probe: {bf}"
+
+
+def test_collect_named_graphs_inventory(monkeypatch):
+    """_collect_named_graphs con discover/infer mockati."""
+    source_cfg = {
+        "source_kind": "catalog",
+        "protocol": "sparql",
+        "base_url": "https://example.test/sparql",
+        "sparql": {
+            "endpoint_url": "https://example.test/sparql",
+            "inventory_mode": "named_graphs",
+            "graph_uri_prefix": "http://dati.test.it/",
+            "graph_uri_blacklist": ["localhost"],
+            "enrich_schema": True,
+            "schema_predicate_limit": 5,
+            "timeout_seconds": 30,
+        },
+    }
+
+    fake_graphs = [
+        "http://dati.test.it/composizione/19",
+        "http://dati.test.it/ddl/19",
+        "http://localhost/internal",
+    ]
+    fake_schema = [
+        {"pred": "http://ex.org/name", "compact_name": "name", "count": 100},
+        {"pred": "http://ex.org/age", "compact_name": "age", "count": 50},
+    ]
+
+    def mock_discover(endpoint, **kw):
+        assert endpoint == "https://example.test/sparql"
+        return [g for g in fake_graphs if "localhost" not in g]
+
+    def mock_infer(endpoint, graph_uri, **kw):
+        assert endpoint == "https://example.test/sparql"
+        return fake_schema
+
+    monkeypatch.setattr(collectors.sparql, "discover_named_graphs", mock_discover)
+    monkeypatch.setattr(collectors.sparql, "infer_graph_schema", mock_infer)
+
+    result = collectors.sparql._collect_named_graphs(
+        "dati_test", source_cfg, "2026-05-31T12:00:00+00:00",
+    )
+
+    assert len(result.rows) == 2
+    assert result.rows[0]["item_id"] == "http://dati.test.it/composizione/19"
+    assert result.rows[0]["title"] == "Composizione \u2014 Legislatura 19"
+    assert result.rows[1]["item_id"] == "http://dati.test.it/ddl/19"
+    assert result.rows[1]["title"] == "Ddl \u2014 Legislatura 19"
+    assert result.rows[0]["tags"] is not None
+    assert "name(100)" in result.rows[0]["tags"]
+    assert result.summary["graphs"] == 2


### PR DESCRIPTION
## Cosa cambia

Unificazione della logica SPARQL HTTP su `lab_connectors.http.sparql` (PR lab-connectors#36).

### collectors/sparql.py

- **`_execute_sparql_query()`**: delega a `lab_connectors.http.sparql.execute_sparql()`
  - POST + GET fallback (prima era GET-only via `observatory_get`)
  - Stessa strategia di toolkit/plugins/sparql.py
- **`_collect_named_graphs()`**: nuova funzione per inventory su endpoint SPARQL
  senza DCAT catalog (es. Senato). Usa `discover_graphs` + `infer_schema` da
  lab-connectors
- **`collect()`**: supporta `inventory_mode: named_graphs` routing
- **Rimossa**: duplicazione HTTP SPARQL (prima 3 implementazioni, ora 1 in
  lab-connectors)

### tests/test_build_catalog_inventory.py

- Mock su `execute_sparql` invece di `observatory_get` (API cambiata)
- 315/315 test SO passati 🟢

### Dipendenze

Richiede:
- `lab-connectors` #36 — modulo http/sparql.py
- `toolkit` #311 — refactor plugins/scout su lab-connectors

### Perimetro

Nessuna modifica a `sources_registry.yaml`. Le nuove funzionalità
(`named_graphs` mode, schema enrichment) sono pronte ma non ancora attivate
— richiedono un successivo aggiornamento del registry per fonti come
`dati.senato.it`.