### PR TITLE
feat: aggiungi dati.senato.it al sources_registry

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -209,6 +209,48 @@ dati_camera:
   datasets_in_use:
     - camera_deputati_legislature
     - camera_votazioni_sparql
+dati_senato:
+  source_kind: catalog
+  protocol: sparql
+  observation_mode: catalog-watch
+  base_url: https://dati.senato.it/sparql
+  inventory:
+    timeout: 600
+  last_probed: '2026-05-31'
+  catalog_baseline:
+    captured_at: '2026-05-31'
+    metric: named_graph_count
+    value: 98
+    method: named_graphs
+    query_name: named_graphs
+    reliability: medium
+    note: Baseline via enumerazione named graphs SPARQL. ~98 grafi organizzati 
+      per categoria (composizione, ddl, votazioni, emendamenti, ecc.) e 
+      legislatura (01-19). Fonte non ha DCAT catalog.
+  sparql:
+    endpoint_url: https://dati.senato.it/sparql
+    inventory_mode: named_graphs
+    enrich_schema: true
+    schema_predicate_limit: 15
+    timeout_seconds: 300
+    graph_uri_prefix: "http://dati.senato.it/"
+    graph_uri_blacklist:
+      - localhost
+      - virtrdf
+      - owl#
+      - rules.skos
+      - virtrdf-label
+      - "8890"
+      - b3sifp
+      - b3sonto
+      - facets
+      - teseo
+  verdict: go
+  note: Portale Open Data Senato. SPARQL endpoint Virtuoso (GET). Inventory via 
+    enumerazione named graphs (~98 grafi categoria/legislatura). Download CSV/JSON 
+    via POST form autenticato (non crawlabile). CC BY 3.0. Speculare a 
+    dati_camera ma senza DCAT catalog.
+  datasets_in_use: []
 dati_cultura:
   source_kind: catalog
   protocol: sparql


### PR DESCRIPTION
## Cosa cambia

Aggiunta della fonte `dati_senato` (Portale Open Data del Senato) al `sources_registry.yaml`.

### Nuova fonte

```yaml
source_id: dati_senato
protocol: sparql
observation_mode: catalog-watch
inventory: named_graphs (98 grafi)
```

### Dati

- **SPARQL endpoint**: https://dati.senato.it/sparql (Virtuoso, GET)
- **Catalogo**: ~98 named graphs organizzati per categoria × legislatura
- **Categorie**: composizione, ddl, votazioni, emendamenti, documenti, procedure, sedute, sindisp
- **Legislature**: I (1948) → XIX (2026)
- **Licenza**: CC BY 3.0
- **Speculare a**: `dati_camera` ma senza DCAT catalog

### Inventory

La fonte non ha un catalogo DCAT (a differenza di `dati_camera`). L'inventory usa la modalità `named_graphs`:
- Enumera i named graphs dell'endpoint come proxy di catalogo
- Filtro `graph_uri_prefix` + `graph_uri_blacklist` per escludere grafi interni
- Schema enrichment opzionale (`enrich_schema: true`) — predicati con conteggio soggetti

### Dipendenze

Richiede l'infrastruttura già mergiata:
- lab-connectors v0.11.0 — `http/sparql.py` (POST+GET fallback)
- toolkit v1.20.0 — SPARQL GET fallback in `SparqlSource`
- SO #306 — `inventory_mode: named_graphs` in `collectors/sparql.py`

### Note

Il Senato endpoint è attualmente rate-limited (YELLOW). L'inventory si popolerà al prossimo run CI quando il rate limit si resetta.

Closes #305.