### PR TITLE
feat: aggiungi noipa_sparql (MEF NoiPA — personale PA + pensioni) al sources_registry

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -654,6 +654,42 @@ agid:
     PEC, domicili digitali, responsabili transizione digitale, servizi digitali, fatturazione
     elettronica, cloud. Codice_IPA chiave di join con ANAC.'
   datasets_in_use: []
+noipa_sparql:
+  source_kind: catalog
+  protocol: sparql
+  observation_mode: catalog-watch
+  base_url: https://sparql-noipa.mef.gov.it/sparql
+  inventory:
+    timeout: 600
+  last_probed: '2026-05-31'
+  catalog_baseline:
+    captured_at: '2026-05-31'
+    metric: named_graph_count
+    value: 170
+    method: named_graphs
+    query_name: named_graphs
+    reliability: medium
+    note: Baseline via enumerazione named graphs. ~170 grafi: entries-{YYYYMM}
+      personale PA (2019-2026, ~88) + entriesPensioni-{YYYYMM} pensioni PA
+      (2017-oggi, ~80+) + metadata/ontology/tipologiche.
+      Secondo endpoint sparql-pensioni.mef.gov.it (stesso dataset).
+  sparql:
+    endpoint_url: https://sparql-noipa.mef.gov.it/sparql
+    inventory_mode: named_graphs
+    enrich_schema: false
+    timeout_seconds: 300
+    graph_uri_prefix: "https://sparql-noipa.mef.gov.it/"
+    graph_uri_blacklist:
+      - localhost
+      - virtrdf
+      - owl#
+      - "8890"
+  verdict: go
+  note: NoiPA SPARQL — MEF/RGS. Dati mensili personale PA (entries-{YYYYMM},
+    2019-2026) + pensioni PA (entriesPensioni-{YYYYMM}, 2017-oggi).
+    ~490k soggetti/mese. Stesso stack Virtuoso di dati_camera/senato.
+    CC BY (da verificare). Altissimo valore civico.
+  datasets_in_use: []
 mimit_rna:
   source_kind: catalog
   protocol: ckan

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -668,10 +668,10 @@ noipa_sparql:
     method: named_graphs
     query_name: named_graphs
     reliability: medium
-    note: Baseline via enumerazione named graphs. ~170 grafi: entries-{YYYYMM}
+    note: "Baseline via enumerazione named graphs. ~170 grafi: entries-{YYYYMM}
       personale PA (2019-2026, ~88) + entriesPensioni-{YYYYMM} pensioni PA
       (2017-oggi, ~80+) + metadata/ontology/tipologiche.
-      Secondo endpoint sparql-pensioni.mef.gov.it (stesso dataset).
+      Secondo endpoint sparql-pensioni.mef.gov.it (stesso dataset)."
   sparql:
     endpoint_url: https://sparql-noipa.mef.gov.it/sparql
     inventory_mode: named_graphs

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -215,7 +215,8 @@ dati_senato:
   observation_mode: catalog-watch
   base_url: https://dati.senato.it/sparql
   inventory:
-    timeout: 600
+    timeout: 600  # 99 query (1 discovery + 98 enrich) × ~5s × 1.2x = ~600s 
+    timeout_reason: "99 query SPARQL (1 discover + 98 schema enrich × 15 pred). stimate 5s/query su Virtuoso. 99 × 5 × 1.2 = 594s"
   last_probed: '2026-05-31'
   catalog_baseline:
     captured_at: '2026-05-31'
@@ -659,8 +660,6 @@ noipa_sparql:
   protocol: sparql
   observation_mode: catalog-watch
   base_url: https://sparql-noipa.mef.gov.it/sparql
-  inventory:
-    timeout: 600
   last_probed: '2026-05-31'
   catalog_baseline:
     captured_at: '2026-05-31'


### PR DESCRIPTION
## Cosa cambia

Aggiunta della fonte `noipa_sparql` (MEF/RGS — NoiPA) al `sources_registry.yaml`.

### Nuova fonte

```yaml
source_id: noipa_sparql
protocol: sparql
observation_mode: catalog-watch
inventory: named_graphs (~170 grafi)
```

### Dati

**Personale PA** (NoiPA):
- `entries-{YYYYMM}` mensili, 2019-01 → 2026-04 (~88 grafi)
- ~490.000 soggetti/mese
- Dati: ente, qualifica, comparto, stipendio, contributi, assenze, genere, età, residenza

**Pensioni PA**:
- `entriesPensioni-{YYYYMM}` mensili, 2017-01 → oggi (~80+ grafi)
- Secondo endpoint: `sparql-pensioni.mef.gov.it` (stesso dataset)

### Inventory

Stessa modalità di `dati_senato`: `named_graphs` con `graph_uri_prefix`.
Schema enrichment disabilitato per ora (~170 grafi, troppe query).

### Dipendenze

Richiede infrastruttura già mergiata:
- lab-connectors v0.11.0
- toolkit v1.20.0
- SO #306 — inventory_mode: named_graphs

Closes #308.