### PR TITLE
Aggiungi MCP tool so_list_source_items per discovery item per fonte

### DIFF
--- a/so_mcp/_discovery.py
+++ b/so_mcp/_discovery.py
@@ -1,0 +1,134 @@
+"""
+Discovery: elenca gli item di una fonte dal catalog_inventory_latest.parquet.
+
+``list_source_items(source_id)`` restituisce la lista degli item (dataset,
+dataflow, risorsa) enumerati dall'ultimo build inventory per quella fonte,
+con paginazione e filtro testuale opzionale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import _artifact
+from lab_connectors.duckdb import safe_connect
+
+
+def list_source_items(
+    source_id: str,
+    limit: int = 50,
+    offset: int = 0,
+    query: str | None = None,
+) -> dict[str, Any]:
+    """Elenca gli item di una fonte dal catalog_inventory_latest.parquet.
+
+    Args:
+        source_id: Identificativo della fonte (es. ``inps``, ``istat_sdmx``).
+        limit: Numero massimo di item da restituire (default 50, max 500).
+        offset: Offset per la paginazione (default 0).
+        query: Filtro testuale opzionale — cerca in item_id, item_name,
+               title, tags e organization.
+
+    Returns:
+        Dict con ``source_id``, ``filters``, ``results`` (lista di item),
+        ``returned``, ``has_more``, ``artifact`` e ``cache``.
+    """
+    if not source_id or not str(source_id).strip():
+        return {"error": "invalid_params", "message": "source_id is required"}
+
+    safe_limit = max(1, min(int(limit or 50), 500))
+    safe_offset = max(0, int(offset or 0))
+    clean_query = (query or "").strip().lower() if query else None
+
+    artifact = _artifact._catalog_inventory_parquet()
+    try:
+        with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
+            parquet_path = str(resolved_path)
+            with safe_connect() as con:
+                columns = set(_artifact._table_columns(con, parquet_path))
+
+                # Colonne da selezionare (sottoinsieme informativo)
+                select_columns = [
+                    "source_id",
+                    "protocol",
+                    "item_id",
+                    "item_name",
+                    "title",
+                    "organization",
+                    "tags",
+                    "landing_page",
+                    "distribution_url",
+                    "format",
+                    "source_status",
+                    "inventory_method",
+                    "item_kind",
+                    "api_base_url",
+                    "captured_at",
+                ]
+                select_sql = ", ".join(
+                    _artifact._select_expr(col, columns) for col in select_columns
+                )
+
+                where_parts = ["source_id = ?"]
+                params: list[Any] = [source_id]
+
+                if clean_query:
+                    search_columns = [
+                        col
+                        for col in ("item_id", "item_name", "title", "tags", "organization")
+                        if col in columns
+                    ]
+                    if search_columns:
+                        like = f"%{clean_query}%"
+                        search_clause = "(" + " OR ".join(
+                            f"lower(coalesce(cast({col} as varchar), '')) LIKE ?"
+                            for col in search_columns
+                        ) + ")"
+                        where_parts.append(search_clause)
+                        params.extend([like] * len(search_columns))
+
+                where = " AND ".join(where_parts)
+
+                # Count totale (per has_more)
+                count_row = con.execute(
+                    f'SELECT COUNT(*) FROM "{parquet_path}" WHERE {where}',
+                    params,
+                ).fetchone()
+                total_count = count_row[0] if count_row else 0
+
+                sql = f"""
+                    SELECT {select_sql}
+                    FROM "{parquet_path}"
+                    WHERE {where}
+                    ORDER BY title NULLS LAST, item_id
+                    LIMIT {safe_limit} OFFSET {safe_offset}
+                """
+                rows = con.execute(sql, params).fetchall()
+                result_cols = [desc[0] for desc in con.description]
+
+    except FileNotFoundError:
+        return _artifact._parquet_not_found(artifact)
+
+    returned = len(rows)
+    result: dict[str, Any] = {
+        "artifact": _artifact._display_path(_artifact._INVENTORY_PARQUET),
+        "cache": cache,
+        "gcs_uri": artifact.gcs_uri(),
+        "source_id": source_id,
+        "filters": {
+            "limit": safe_limit,
+            "offset": safe_offset,
+            "query": clean_query,
+        },
+        "total_count": total_count,
+        "results": [dict(zip(result_cols, row)) for row in rows],
+        "returned": returned,
+        "has_more": (safe_offset + returned) < total_count,
+    }
+    if not rows:
+        result["source_status"] = _artifact._inventory_source_status(source_id)
+        result["note"] = (
+            "Nessun item trovato. Verifica che source_id sia corretto "
+            "e che l'inventory sia stato buildato di recente."
+        )
+    return result

--- a/so_mcp/so_server.py
+++ b/so_mcp/so_server.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from _discovery import list_source_items
 from _find_url import find_by_url
 from _inventory import (
     catalog_inventory_search,
@@ -151,6 +152,22 @@ def so_recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
 )
 def so_inventory_diff(source_id: str) -> dict[str, Any]:
     return guard_timed(inventory_diff, "so_inventory_diff", source_id)
+
+
+@mcp.tool(
+    description="Elenca gli item (dataset, dataflow, risorsa) di una fonte "
+    "dal catalog_inventory_latest.parquet. "
+    "Accetta source_id (richiesto), limit, offset e query testuale opzionale "
+    "su item_id, item_name, title, tags e organization.",
+    structured_output=True,
+)
+def so_list_source_items(
+    source_id: str,
+    limit: int = 50,
+    offset: int = 0,
+    query: str | None = None,
+) -> dict[str, Any]:
+    return guard_timed(list_source_items, "so_list_source_items", source_id, limit, offset, query)
 
 
 if __name__ == "__main__":

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -6,6 +6,7 @@ import _artifact
 import duckdb  # noqa: E402
 import pandas as pd  # must be before duckdb
 import pytest
+from _discovery import list_source_items
 from _find_url import find_by_url
 from _inventory import (
     _source_radar_context,
@@ -855,3 +856,244 @@ def test_query_inventory_grouped_aggregates(tmp_path, monkeypatch) -> None:
     assert results[1]["dataset_group"] == "s1/gruppo-b"
     assert results[1]["item_count"] == 1
     assert results[1]["best_score"] == 50
+
+
+# ─── Discovery: list_source_items ───────────────────────────────────────────────
+
+
+def test_list_source_items_filters_by_source(tmp_path, monkeypatch) -> None:
+    """list_source_items con source_id restituisce solo gli item di quella fonte."""
+    inventory_path = tmp_path / "catalog_inventory_latest.parquet"
+    _write_parquet(
+        inventory_path,
+        [
+            {
+                "source_id": "inps",
+                "protocol": "ckan",
+                "item_id": "544",
+                "item_name": "pensioni",
+                "title": "Pensioni INPS",
+                "organization": "INPS",
+                "tags": "pensioni",
+                "landing_page": "",
+                "distribution_url": "",
+                "format": "csv",
+                "source_status": "",
+                "inventory_method": "package_list",
+                "item_kind": "dataset",
+                "api_base_url": "https://example.test/api",
+                "captured_at": "2026-04-30",
+            },
+            {
+                "source_id": "openbdap",
+                "protocol": "ckan",
+                "item_id": "b",
+                "item_name": "conti",
+                "title": "Conto economico",
+                "organization": "MEF",
+                "tags": "",
+                "landing_page": "",
+                "distribution_url": "",
+                "format": "csv",
+                "source_status": "",
+                "inventory_method": "package_search",
+                "item_kind": "dataset",
+                "api_base_url": "https://example.test/api",
+                "captured_at": "2026-04-30",
+            },
+            {
+                "source_id": "inps",
+                "protocol": "ckan",
+                "item_id": "999",
+                "item_name": "contributi",
+                "title": "Contributi INPS",
+                "organization": "INPS",
+                "tags": "contributi",
+                "landing_page": "",
+                "distribution_url": "",
+                "format": "csv",
+                "source_status": "",
+                "inventory_method": "package_list",
+                "item_kind": "dataset",
+                "api_base_url": "https://example.test/api",
+                "captured_at": "2026-04-30",
+            },
+        ],
+    )
+    monkeypatch.setattr(_artifact, "_INVENTORY_PARQUET", inventory_path)
+
+    result = list_source_items("inps")
+
+    assert result["source_id"] == "inps"
+    assert result["returned"] == 2
+    assert result["total_count"] == 2
+    assert result["has_more"] is False
+    assert result["filters"]["limit"] == 50
+    assert result["filters"]["offset"] == 0
+    assert all(r["source_id"] == "inps" for r in result["results"])
+    item_ids = {r["item_id"] for r in result["results"]}
+    assert item_ids == {"544", "999"}
+
+
+def test_list_source_items_respects_limit_and_offset(tmp_path, monkeypatch) -> None:
+    """limit e offset controllano la paginazione."""
+    inventory_path = tmp_path / "catalog_inventory_latest.parquet"
+    rows = [
+        {
+            "source_id": "inps",
+            "protocol": "ckan",
+            "item_id": f"item_{i}",
+            "item_name": f"item_{i}",
+            "title": f"Item {i:03d}",
+            "organization": "INPS",
+            "tags": "",
+            "landing_page": "",
+            "distribution_url": "",
+            "format": "csv",
+            "source_status": "",
+            "inventory_method": "package_list",
+            "item_kind": "dataset",
+            "api_base_url": "https://example.test/api",
+            "captured_at": "2026-04-30",
+        }
+        for i in range(10)
+    ]
+    _write_parquet(inventory_path, rows)
+    monkeypatch.setattr(_artifact, "_INVENTORY_PARQUET", inventory_path)
+
+    # Prima pagina: 3 item
+    page1 = list_source_items("inps", limit=3, offset=0)
+    assert page1["returned"] == 3
+    assert page1["has_more"] is True
+    assert page1["total_count"] == 10
+
+    # Seconda pagina: altri 3
+    page2 = list_source_items("inps", limit=3, offset=3)
+    assert page2["returned"] == 3
+    assert page2["has_more"] is True
+    assert page2["results"][0]["item_id"] != page1["results"][0]["item_id"]
+
+    # Ultima pagina: 4 item rimasti
+    page3 = list_source_items("inps", limit=5, offset=6)
+    assert page3["returned"] == 4
+    assert page3["has_more"] is False
+
+
+def test_list_source_items_text_query_filter(tmp_path, monkeypatch) -> None:
+    """query testuale filtra per item_id, item_name, title, tags, organization."""
+    inventory_path = tmp_path / "catalog_inventory_latest.parquet"
+    _write_parquet(
+        inventory_path,
+        [
+            {
+                "source_id": "inps",
+                "protocol": "ckan",
+                "item_id": "pens-2024",
+                "item_name": "pensioni-2024",
+                "title": "Pensioni erogate nel 2024",
+                "organization": "INPS",
+                "tags": "pensioni,previdenza",
+                "landing_page": "",
+                "distribution_url": "",
+                "format": "csv",
+                "source_status": "",
+                "inventory_method": "package_list",
+                "item_kind": "dataset",
+                "api_base_url": "https://example.test/api",
+                "captured_at": "2026-04-30",
+            },
+            {
+                "source_id": "inps",
+                "protocol": "ckan",
+                "item_id": "contr-2024",
+                "item_name": "contributi-2024",
+                "title": "Contributi versati",
+                "organization": "INPS",
+                "tags": "contributi",
+                "landing_page": "",
+                "distribution_url": "",
+                "format": "csv",
+                "source_status": "",
+                "inventory_method": "package_list",
+                "item_kind": "dataset",
+                "api_base_url": "https://example.test/api",
+                "captured_at": "2026-04-30",
+            },
+        ],
+    )
+    monkeypatch.setattr(_artifact, "_INVENTORY_PARQUET", inventory_path)
+
+    # Match su title
+    result = list_source_items("inps", query="pensioni")
+    assert result["returned"] == 1
+    assert result["results"][0]["item_id"] == "pens-2024"
+
+    # Match su tags
+    result2 = list_source_items("inps", query="contributi")
+    assert result2["returned"] == 1
+    assert result2["results"][0]["item_id"] == "contr-2024"
+
+    # Match su item_name
+    result3 = list_source_items("inps", query="pensioni-2024")
+    assert result3["returned"] == 1
+
+    # Nessun match
+    result4 = list_source_items("inps", query="inesistente")
+    assert result4["returned"] == 0
+    assert result4["total_count"] == 0
+
+
+def test_list_source_items_empty_source_id() -> None:
+    """source_id vuoto restituisce errore."""
+    result = list_source_items("")
+    assert result["error"] == "invalid_params"
+
+
+def test_list_source_items_unknown_source(tmp_path, monkeypatch) -> None:
+    """source_id non presente nell'inventory restituisce 0 risultati."""
+    inventory_path = tmp_path / "catalog_inventory_latest.parquet"
+    _write_parquet(
+        inventory_path,
+        [
+            {
+                "source_id": "inps",
+                "protocol": "ckan",
+                "item_id": "1",
+                "item_name": "test",
+                "title": "Test",
+                "organization": "",
+                "tags": "",
+                "landing_page": "",
+                "distribution_url": "",
+                "format": "csv",
+                "source_status": "",
+                "inventory_method": "package_list",
+                "item_kind": "dataset",
+                "api_base_url": "https://example.test/api",
+                "captured_at": "2026-04-30",
+            },
+        ],
+    )
+    # Write a report so source_status works
+    report_path = tmp_path / "catalog_inventory_report.json"
+    report_path.write_text(
+        json.dumps({"sources": {"unknown_source": {"status": "error", "error": "HTTP 500"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(_artifact, "_INVENTORY_PARQUET", inventory_path)
+    monkeypatch.setattr(_artifact, "_INVENTORY_REPORT", report_path)
+
+    result = list_source_items("unknown_source")
+    assert result["returned"] == 0
+    assert result["total_count"] == 0
+    assert result["source_status"] is not None
+    assert "note" in result
+
+
+def test_list_source_items_parquet_not_found(tmp_path, monkeypatch) -> None:
+    """Parquet non trovato restituisce artifact_not_found."""
+    monkeypatch.setattr(
+        _artifact, "_INVENTORY_PARQUET", tmp_path / "nonexistent.parquet"
+    )
+    result = list_source_items("inps")
+    assert result["error"] == "artifact_not_found"

--- a/tests/test_so_server_wrapper.py
+++ b/tests/test_so_server_wrapper.py
@@ -1,4 +1,4 @@
-"""Smoke test: verify so_server.py registers 12 MCP tools via create_mcp_server."""
+"""Smoke test: verify so_server.py registers 13 MCP tools via create_mcp_server."""
 from __future__ import annotations
 
 import asyncio
@@ -7,8 +7,8 @@ import pytest
 import so_server  # noqa: E402  # conftest aggiunge so_mcp/ a sys.path
 
 
-def test_mcp_server_registers_12_tools() -> None:
-    """Verify all 12 tools are registered on the mcp server object."""
+def test_mcp_server_registers_13_tools() -> None:
+    """Verify all 13 tools are registered on the mcp server object."""
     tools = asyncio.run(so_server.mcp.list_tools())
     tool_names = sorted(t.name for t in tools)
 
@@ -20,6 +20,7 @@ def test_mcp_server_registers_12_tools() -> None:
         "so_inventory_diff",
         "so_inventory_query",
         "so_inventory_status",
+        "so_list_source_items",
         "so_radar_history",
         "so_radar_status_md",
         "so_radar_summary",


### PR DESCRIPTION
## Sintesi

Aggiunge il tool MCP `so_list_source_items` che elenca gli item (dataset, dataflow, risorsa) di una singola fonte dal `catalog_inventory_latest.parquet`. Colma il gap del discovery layer SO: prima esisteva solo `so_catalog_inventory_search` (ricerca testuale cross-fonte) e `so_discover_sdmx` (solo ISTAT, con scoring tematico).

## Contesto collegato

Primo passo delle raccomandazioni emerse dall'analisi comparativa con `italian_our_world_data` — che ha un discovery layer unificato (`list_indicators()`, `list_sources()`) che a SO manca completamente.

## Cosa cambia

- [x] Skills o MCP tools

## Checklist

### Se modifichi script o MCP

- [x] `pytest tests/` passa (44/44, 0 regressioni)
- [x] `ruff check .` passa
- [x] `mypy so_mcp/` passa
- [x] Comando manuale verificato con dati reali (parquet locale con 19 fonti, ~13K item)

## Verifica

Testato con dati reali del parquet locale:

```python
# Elenca 5 item di anac
list_source_items("anac", limit=5)
# → total_count=70, returned=5, has_more=True

# Filtro testuale su istat_sdmx
list_source_items("istat_sdmx", query="prezzi", limit=5)
# → total_count=13, 5 dataflow sui prezzi

# Paginazione
list_source_items("istat_sdmx", limit=3, offset=0)  # pagina 1
list_source_items("istat_sdmx", limit=3, offset=3)  # pagina 2
# → item_ids non si sovrappongono, has_more coerente
```

- [x] Perimetro stretto: solo `_discovery.py` + wiring MCP + test
- [x] 6 test contract, coverage 100% su `_discovery.py`

## Note per chi revisiona

- Il tool riusa `catalog_inventory_latest.parquet` (artifact esistente) — nessuna chiamata API live
- Stesso pattern di `_inventory.py` (DuckDB + `_artifact` + `safe_connect` + `guard_timed`)
- `so_discover_sdmx` potrebbe in futuro essere rifattorizzato per usare `_discovery.py` internamente (non in questa PR)