### PR TITLE
feat(so): aggiunge agcm — rating di legalità da dati.gov.it

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -717,6 +717,7 @@ ministero_salute:
     Complementare a dati_salute (csv_magnet) per il catalogo completo del portale
     diretto.'
   datasets_in_use: []
+
 agcm:
   source_kind: catalog
   protocol: ckan

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -717,3 +717,29 @@ ministero_salute:
     Complementare a dati_salute (csv_magnet) per il catalogo completo del portale
     diretto.'
   datasets_in_use: []
+agcm:
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
+  inventory:
+    fq: organization:agcm
+    timeout: 180
+    skip_current_list: true
+    skip_current_list_reason: "package_search con fq=organization:agcm
+      restituisce 53 dataset (rating legalita', concentrazioni).
+      current_list non necessario."
+  last_probed: '2026-06-04'
+  catalog_baseline:
+    captured_at: '2026-06-04'
+    metric: package_count
+    value: 53
+    method: package_search
+    reliability: high
+    note: Conteggio via package_search con fq=organization:agcm su dati.gov.it.
+      53 dataset (rating di legalità, operazioni di concentrazione).
+  verdict: go
+  note: "Fonte via dati.gov.it (AGCM). 53 dataset su concorrenza e mercato:
+    rating di legalita' (elenchi settimanali imprese con rating),
+    operazioni di concentrazione 2021-2025.\n"
+  datasets_in_use: []


### PR DESCRIPTION
## Cosa
Aggiunge `agcm` al registry — CKAN su dati.gov.it, organizzazione `agcm`.

## Modifiche
- `sources_registry.yaml`: 26 righe, nuova fonte agcm

## Checklist
- [x] `sources_registry.yaml` — nuova fonte con `verdict: go`, `protocol: ckan`, `observation_mode: catalog-watch`
- [x] `catalog_baseline` — package_count 53 via `package_search`
- [x] Radiod handled by `radar_check.py` via `catalog-watch` (inventory via CKAN)

## Issue
Closes #316

## Verifica
- [x] YAML valido
- [x] CKAN risponde: `fq=organization:agcm` → 53 dataset