### PR TITLE
chore: bump toolkit dep to v1.23.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "fastmcp>=3.3.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.11.0",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.20.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.23.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Cosa cambia

- `toolkit` v1.20.0 → **v1.23.0** (dataset_loader, validate config, CKAN/SDMX centralization, backward compat cleanup)

Aggiorna la dipendenza per allinearsi all'ultimo tag del toolkit.