### PR TITLE
refactor: update lab-connectors@v0.12.0, toolkit@v1.26.0, org-level action, audit CLI

### DIFF
--- a/.github/scripts/audit_test_markers.py
+++ b/.github/scripts/audit_test_markers.py
@@ -1,211 +1,27 @@
 #!/usr/bin/env python3
-"""Audit test markers — cross-repo.
+"""Backward-compatibility shim — delegates to ``lab_connectors.testing.audit_markers``.
 
-Usage:
-    python3 _local/scripts/audit_test_markers.py tests/            # audit entire dir
-    python3 _local/scripts/audit_test_markers.py tests/ --diff     # only unmarked (exit 1 if any)
-    python3 _local/scripts/audit_test_markers.py tests/ --json     # machine-readable
-    python3 _local/scripts/audit_test_markers.py tests/ --files f1.py f2.py  # specific files
+If ``lab-connectors`` is not installed, prints a clear error and exits.
 
-Exit code:
-    0 = all tests have markers (or --diff not set)
-    1 = at least one test without marker (only with --diff)
+New code should use ``audit-test-markers`` CLI command directly
+(installed via ``pip install lab-connectors``).
 """
 
-from __future__ import annotations
-
-import argparse
-import ast
-import json
-import re
 import sys
-from pathlib import Path
 
-MARKERS = {"contract", "policy", "regression", "adapter", "pure_unit", "smoke"}
-_MARKER_RE = re.compile(r"mark\.(\w+)")
-
-
-class TestCollector(ast.NodeVisitor):
-    """Collect test functions and their markers via AST.
-
-    Detects markers from:
-    - @pytest.mark.xxx decorators on test functions/methods
-    - Module-level ``pytestmark = pytest.mark.xxx`` (applied to all tests in file)
-    """
-
-    def __init__(self) -> None:
-        """Initialize collector with empty results and no module-level markers."""
-        self.results: list[dict] = []
-        self._module_markers: set[str] = set()
-
-    def visit_Module(self, node: ast.Module) -> None:
-        """Collect module-level pytestmark, then scan test functions/classes."""
-        # Collect module-level pytestmark first
-        for stmt in ast.iter_child_nodes(node):
-            if isinstance(stmt, ast.Assign):
-                for target in stmt.targets:
-                    if isinstance(target, ast.Name) and target.id == "pytestmark":
-                        marker = self._get_marker_name(stmt.value)
-                        if marker:
-                            self._module_markers.add(marker)
-                    # Also handle list: pytestmark = [pytest.mark.contract, pytest.mark.smoke]
-                    elif isinstance(target, ast.Name) and target.id == "pytestmark":
-                        if isinstance(stmt.value, ast.List):
-                            for elt in stmt.value.elts:
-                                m = self._get_marker_name(elt)
-                                if m:
-                                    self._module_markers.add(m)
-
-        for stmt in ast.iter_child_nodes(node):
-            if isinstance(stmt, ast.FunctionDef) and stmt.name.startswith("test_"):
-                self._visit_test_function(stmt)
-            elif isinstance(stmt, ast.ClassDef):
-                for child in ast.iter_child_nodes(stmt):
-                    if isinstance(child, ast.FunctionDef) and child.name.startswith("test_"):
-                        self._visit_test_function(child)
-        self.generic_visit(node)
-
-    def _visit_test_function(self, node: ast.FunctionDef) -> None:
-        """Extract markers from a single test function (decorator + module-level)."""
-        markers: set[str] = set()
-        # Inherit module-level markers
-        markers.update(self._module_markers)
-        # Add per-function decorator markers
-        for decorator in reversed(node.decorator_list):
-            marker = self._get_marker_name(decorator)
-            if marker:
-                markers.add(marker)
-        self.results.append(
-            {
-                "test": node.name,
-                "markers": sorted(markers & MARKERS),
-                "missing": sorted(MARKERS - markers),
-                "unmarked": not bool(markers & MARKERS),
-            }
-        )
-
-    def _get_marker_name(self, node: ast.expr) -> str | None:
-        """Extract Lab marker name from a decorator via ast.unparse + regex."""
-        try:
-            src = ast.unparse(node)
-            m = _MARKER_RE.search(src)
-            if m and m.group(1) in MARKERS:
-                return m.group(1)
-        except Exception:
-            pass
-        return None
-
-
-def collect_tests(tests_dir: Path, file_filter: list[str] | None = None) -> list[dict]:
-    """Collect all test functions from test_*.py files in directory (recursive)."""
-    results = []
-    pattern = "test_*.py"
-    for fpath in sorted(tests_dir.glob(pattern)):
-        if fpath.name == "conftest.py":
-            continue
-        if file_filter and fpath.name not in file_filter:
-            continue
-        # Also look in subdirectories
-        if not fpath.is_file():
-            continue
-        try:
-            tree = ast.parse(fpath.read_text(), filename=fpath.name)
-        except SyntaxError:
-            continue
-        visitor = TestCollector()
-        visitor.visit(tree)
-        for r in visitor.results:
-            r["file"] = fpath.name
-            results.append(r)
-
-    # Also scan subdirectories (e.g. tests/http/ in lab-connectors)
-    for subdir in sorted(tests_dir.iterdir()):
-        if not subdir.is_dir() or subdir.name.startswith("__") or subdir.name == "__pycache__":
-            continue
-        for fpath in sorted(subdir.glob("test_*.py")):
-            if file_filter and fpath.name not in file_filter:
-                continue
-            try:
-                tree = ast.parse(fpath.read_text(), filename=fpath.name)
-            except SyntaxError:
-                continue
-            visitor = TestCollector()
-            visitor.visit(tree)
-            for r in visitor.results:
-                r["file"] = str(Path(subdir.name) / fpath.name)
-                results.append(r)
-
-    return results
-
-
-def main() -> None:
-    """Parse CLI args, run audit, print results."""
-    parser = argparse.ArgumentParser(
-        description="Audit test markers in any repo's test directory."
+try:
+    from lab_connectors.testing.audit_markers import main
+except ImportError:
+    print(
+        "ERROR: lab-connectors not installed.\n"
+        "\n"
+        "This script requires lab-connectors to be installed:\n"
+        "  pip install lab-connectors\n"
+        "\n"
+        "Or use the audit-test-markers CLI directly after installation.",
+        file=sys.stderr,
     )
-    parser.add_argument("tests_dir", type=str, help="Path to tests/ directory")
-    parser.add_argument(
-        "--diff",
-        action="store_true",
-        help="Exit 1 if any test is unmarked (for CI gate)",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Machine-readable JSON output",
-    )
-    parser.add_argument(
-        "--files",
-        nargs="*",
-        default=None,
-        help="Check only specific test files (for PR diff checks)",
-    )
-    args = parser.parse_args()
-
-    tests_path = Path(args.tests_dir)
-    if not tests_path.is_dir():
-        print(f"ERROR: directory not found: {tests_path}", file=sys.stderr)
-        sys.exit(2)
-
-    results = collect_tests(tests_path, args.files)
-    unmarked = [r for r in results if r["unmarked"]]
-    marked = [r for r in results if not r["unmarked"]]
-
-    if args.json:
-        print(
-            json.dumps(
-                {
-                    "total": len(results),
-                    "marked": len(marked),
-                    "unmarked": len(unmarked),
-                    "tests": results,
-                },
-                indent=2,
-            )
-        )
-    else:
-        print("=== Test Marker Audit ===")
-        print(f"Tests: {len(results)} | Marked: {len(marked)} | Unmarked: {len(unmarked)}")
-        print()
-        if unmarked:
-            print(f"--- UNMARKED TESTS ({len(unmarked)}) ---")
-            for r in unmarked:
-                print(f"  {r['file']}::{r['test']}")
-            print()
-            print("Suggested markers (pick one per test):")
-            print("  @pytest.mark.contract  — public interface, artifact format, CLI output")
-            print("  @pytest.mark.policy    — Lab rule not derivable from source code")
-            print("  @pytest.mark.regression — documented bug fix (link issue/PR)")
-            print("  @pytest.mark.adapter   — external service adapter logic")
-            print("  @pytest.mark.pure_unit  — pure logic, zero side effects")
-            print("  @pytest.mark.smoke     — golden path end-to-end")
-            print()
-        if not unmarked:
-            print("All tests have markers. OK")
-
-    if args.diff and unmarked:
-        sys.exit(1)
-
+    sys.exit(2)
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v6
+
       - name: Python setup
         uses: dataciviclab/.github/actions/python-setup@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Python setup
+        uses: dataciviclab/.github/actions/python-setup@main
         with:
-          python-version: "3.12"
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+          extra-requirements: requirements-dev.txt
 
       - name: Lint with ruff
         run: ruff check scripts/ tests/ so_mcp/

--- a/.github/workflows/observatory.yml
+++ b/.github/workflows/observatory.yml
@@ -28,18 +28,8 @@ jobs:
         shell: bash
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install runtime dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+      - name: Python setup
+        uses: dataciviclab/.github/actions/python-setup@main
 
       # ── GCS Auth ──────────────────────────────────────────────────────────
       - name: Authenticate to Google Cloud

--- a/.github/workflows/observatory.yml
+++ b/.github/workflows/observatory.yml
@@ -28,6 +28,8 @@ jobs:
         shell: bash
 
     steps:
+      - uses: actions/checkout@v6
+
       - name: Python setup
         uses: dataciviclab/.github/actions/python-setup@main
 

--- a/.github/workflows/radar.yml
+++ b/.github/workflows/radar.yml
@@ -21,6 +21,8 @@ jobs:
         shell: bash
 
     steps:
+      - uses: actions/checkout@v6
+
       - name: Python setup
         uses: dataciviclab/.github/actions/python-setup@main
 

--- a/.github/workflows/radar.yml
+++ b/.github/workflows/radar.yml
@@ -21,18 +21,8 @@ jobs:
         shell: bash
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install runtime dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+      - name: Python setup
+        uses: dataciviclab/.github/actions/python-setup@main
 
       - name: Run radar check
         run: |

--- a/.github/workflows/test-audit.yml
+++ b/.github/workflows/test-audit.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "tests/**/test_*.py"
       - "scripts/collectors/test_*.py"
+      - ".github/workflows/test-audit.yml"
 
 jobs:
   audit-markers:
@@ -14,9 +15,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
+      - uses: dataciviclab/.github/actions/python-setup@main
+
+      - name: Verify audit-test-markers CLI
+        run: audit-test-markers --help
 
       - name: Audit test markers in tests/
         run: |
@@ -26,7 +28,7 @@ jobs:
             exit 0
           fi
           files=$(echo "$changed" | xargs -n1 basename | tr '\n' ' ')
-          python .github/scripts/audit_test_markers.py tests/ --diff --files $files
+          audit-test-markers tests/ --diff --files $files
 
       - name: Audit test markers in scripts/collectors/
         run: |
@@ -36,4 +38,4 @@ jobs:
             exit 0
           fi
           files=$(echo "$changed" | xargs -n1 basename | tr '\n' ' ')
-          python .github/scripts/audit_test_markers.py scripts/collectors/ --diff --files $files
+          audit-test-markers scripts/collectors/ --diff --files $files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
   "mcp>=1.27.1",
   "fastmcp>=3.3.1",
   "ddgs>=9.14.4",
-  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.11.0",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.23.0",
+  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.12.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.26.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Sintesi

Allinea source-observatory alla nuova infrastruttura condivisa: lab-connectors v0.12.0, toolkit v1.26.0, org-level action, audit-test-markers CLI.

## Cosa cambia

- [ ] Dipendenze o CI

## Impatto

- [x] Nessun impatto su interfacce pubbliche

## Dettaglio

- Aggiorna lab-connectors: v0.11.0 → v0.12.0
- Aggiorna toolkit: v1.23.0 → v1.26.0
- ci.yml, observatory.yml, radar.yml: switch da setup manuale a `dataciviclab/.github/actions/python-setup@main` (cache pip incluso)
- test-audit.yml: usa `audit-test-markers` CLI + preflight + org action
- Sostituisce `.github/scripts/audit_test_markers.py` con shim backward-compat

## Verifica

```
ruff check .  → All checks passed
```

## Note

Dipende da: `dataciviclab/toolkit` v1.26.0, `dataciviclab/lab-connectors` v0.12.0, `dataciviclab/.github` action su main.
