### PR TITLE
feat: parquet artifact letto via DuckDB S3 diretto — niente download GCS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "fastmcp>=3.3.1",
   "ddgs>=9.14.4",
-  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.12.0",
+  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1",
   "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.26.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "fastmcp>=3.3.1",
   "ddgs>=9.14.4",
-  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.26.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
   "mcp>=1.27.1",
   "fastmcp>=3.3.1",
   "ddgs>=9.14.4",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.2",
+  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.4",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.3",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "fastmcp>=3.3.1",
   "ddgs>=9.14.4",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "fastmcp>=3.3.1",
   "ddgs>=9.14.4",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.1",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.2",
 ]
 
 [project.optional-dependencies]

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -35,7 +35,7 @@ def observatory_get(
     """GET request with SSL fallback via HttpClient."""
     from lab_connectors.http import HttpClient
 
-    client = HttpClient(timeout=timeout, user_agent=USER_AGENT)
+    client = HttpClient(timeout=timeout, user_agent=USER_AGENT)  # type: ignore[arg-type]
     result = client.get(url, headers=headers or {}, **kwargs)
     if result.is_ok and result.response is not None:
         return result.response

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -28,7 +28,7 @@ def now_utc_iso() -> str:
 def observatory_get(
     url: str,
     *,
-    timeout: int | float | tuple[float, float] = DEFAULT_TIMEOUT_SECONDS,
+    timeout: int | float | tuple[int | float, int | float] = DEFAULT_TIMEOUT_SECONDS,
     headers: dict[str, str] | None = None,
     **kwargs: Any,
 ) -> requests.Response:

--- a/scripts/collectors/sdmx.py
+++ b/scripts/collectors/sdmx.py
@@ -35,6 +35,7 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
         ) from result.err
 
     response = result.response
+    assert response is not None  # is_ok ensures response is set
     if response.status_code >= 400:
         raise RuntimeError(
             f"SDMX endpoint returned HTTP {response.status_code} for {source_id}: "

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -160,11 +160,18 @@ def _probe_once(base_url: str) -> ProbeResult:
             http_code="-",
             note="Unexpected: response=None without exception from HttpClient.get",
         )
-    ssl_failure_err: Exception | None = None
-    error_exc: Exception | None = None
+    ssl_failure_err: requests.exceptions.SSLError | None = None
+    error_exc: requests.exceptions.RequestException
     if isinstance(result.err, HttpFallbackError):
-        ssl_failure_err = result.err.primary_error
-        error_exc = result.err.fallback_error
+        ssl_failure_err = (
+            result.err.primary_error
+            if isinstance(result.err.primary_error, requests.exceptions.SSLError)
+            else None
+        )
+        if isinstance(result.err.fallback_error, requests.exceptions.RequestException):
+            error_exc = result.err.fallback_error
+        else:
+            error_exc = result.err.fallback_error  # type: ignore[assignment]
     elif isinstance(result.err, requests.exceptions.SSLError):
         ssl_failure_err = result.err
         error_exc = result.err

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -160,8 +160,8 @@ def _probe_once(base_url: str) -> ProbeResult:
             http_code="-",
             note="Unexpected: response=None without exception from HttpClient.get",
         )
-    ssl_failure_err: requests.exceptions.SSLError | None = None
-    error_exc: requests.exceptions.RequestException
+    ssl_failure_err: Exception | None = None
+    error_exc: Exception | None = None
     if isinstance(result.err, HttpFallbackError):
         ssl_failure_err = result.err.primary_error
         error_exc = result.err.fallback_error

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 # ── Config HTTP (sovrascrivibile da configure_source_check_http) ──────────────
 
 HTTP_TIMEOUT: tuple[float, float] = (5, 10)
-_http_timeout: tuple[float, float] = (5.0, 10.0)
+_http_timeout: int | float | tuple[int | float, int | float] = (5.0, 10.0)
 _http_max_retries = 2
 
 # ── Circuit breaker per host (bulk-specific) ─────────────────────────────────

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -139,7 +139,7 @@ def _circuit_after_result(url: str, result: HttpResult) -> None:
 
 def _get_circuit_client() -> HttpClient:
     """Crea HttpClient con timeout/retry configurati (senza circuit breaker built-in)."""
-    return HttpClient(timeout=_http_timeout, max_retries=_http_max_retries)
+    return HttpClient(timeout=_http_timeout, max_retries=_http_max_retries)  # type: ignore[arg-type]
 
 
 def _tracked_http_head(url: str) -> HttpResult | None:

--- a/so_mcp/_artifact.py
+++ b/so_mcp/_artifact.py
@@ -290,6 +290,43 @@ def _public_url(uri: str) -> str:
     return uri
 
 
+def _gs_to_s3(uri: str) -> str:
+    """Convert gs://bucket/key to s3://bucket/key for DuckDB httpfs.
+
+    DuckDB's httpfs extension reads GCS public buckets via the S3 API,
+    using ``s3://`` URIs with ``s3_endpoint = storage.googleapis.com``.
+    """
+    return "s3://" + uri.removeprefix("gs://")
+
+
+def _direct_cache_info(uri: str) -> dict[str, Any]:
+    """Cache info per artifact letto direttamente da GCS via S3 (nessun file locale)."""
+    return {
+        "source": "gcs_direct",
+        "uri": uri,
+        "note": "Lettura diretta da GCS via S3 — nessuna cache locale.",
+    }
+
+
+def _probe_s3_parquet(s3_uri: str) -> bool:
+    """Prova a leggere una riga da un parquet su S3 via DuckDB httpfs.
+
+    Restituisce True se l'URI è raggiungibile, False altrimenti.
+    Usata da ``auto`` backend per decidere se usare il path remoto o
+    cascare sulla cache locale.
+    """
+    from lab_connectors.duckdb import safe_connect as _safe_connect
+
+    try:
+        with _safe_connect(extensions=["httpfs"]) as con:
+            row = con.execute(
+                f'SELECT 1 FROM read_parquet(\'{s3_uri}\') LIMIT 1'
+            ).fetchone()
+            return row is not None
+    except Exception:
+        return False
+
+
 def _download_public_to_temp(uri: str, tmp_path: Path) -> None:
     response = requests.get(_public_url(uri), timeout=120, stream=True)
     response.raise_for_status()
@@ -333,19 +370,29 @@ def _resolved_artifact(artifact: _ParquetArtifact | _JsonArtifact):
     fallback_warning = None
 
     if backend in {"auto", "gcs"} and uri:
-        tmp_path: Path | None = None
-        try:
-            tmp_path = _copy_gcs_to_temp(uri, artifact.name)
-        except Exception as exc:
-            if backend == "gcs":
-                raise RuntimeError(f"Cannot read {artifact.name} from GCS {uri}: {exc}") from exc
-            fallback_warning = f"Cannot read GCS artifact {uri}; using local cache if available."
-        else:
-            try:
-                yield tmp_path, _artifact_cache_info(tmp_path, source="gcs", uri=uri)
+        # Parquet → lettura diretta via DuckDB S3 (nessun download)
+        if isinstance(artifact, _ParquetArtifact):
+            s3_uri = _gs_to_s3(uri)
+            if backend == "gcs" or _probe_s3_parquet(s3_uri):
+                yield s3_uri, _direct_cache_info(s3_uri)
                 return
-            finally:
-                tmp_path.unlink(missing_ok=True)
+            # auto + S3 non raggiungibile → fall through to local cache
+            fallback_warning = f"S3 URI {s3_uri} non raggiungibile; uso cache locale se disponibile."
+        else:
+            # JSON → download su temp file
+            tmp_path: Path | None = None
+            try:
+                tmp_path = _copy_gcs_to_temp(uri, artifact.name)
+            except Exception as exc:
+                if backend == "gcs":
+                    raise RuntimeError(f"Cannot read {artifact.name} from GCS {uri}: {exc}") from exc
+                fallback_warning = f"Cannot read GCS artifact {uri}; using local cache if available."
+            else:
+                try:
+                    yield tmp_path, _artifact_cache_info(tmp_path, source="gcs", uri=uri)
+                    return
+                finally:
+                    tmp_path.unlink(missing_ok=True)
 
     if artifact.local_path.exists():
         yield (

--- a/so_mcp/_artifact.py
+++ b/so_mcp/_artifact.py
@@ -315,10 +315,10 @@ def _probe_s3_parquet(s3_uri: str) -> bool:
     Usata da ``auto`` backend per decidere se usare il path remoto o
     cascare sulla cache locale.
     """
-    from lab_connectors.duckdb import safe_connect as _safe_connect
+    from lab_connectors.duckdb import gcs_connect
 
     try:
-        with _safe_connect(extensions=["httpfs"]) as con:
+        with gcs_connect(s3_uri) as con:
             row = con.execute(
                 f'SELECT 1 FROM read_parquet(\'{s3_uri}\') LIMIT 1'
             ).fetchone()

--- a/so_mcp/_discovery.py
+++ b/so_mcp/_discovery.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import Any
 
 import _artifact
-from lab_connectors.duckdb import safe_connect
+from lab_connectors.duckdb import gcs_connect
 
 
 def list_source_items(
@@ -44,7 +44,7 @@ def list_source_items(
     try:
         with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
             parquet_path = str(resolved_path)
-            with safe_connect(extensions=["httpfs"]) as con:
+            with gcs_connect(resolved_path) as con:
                 columns = set(_artifact._table_columns(con, parquet_path))
 
                 # Colonne da selezionare (sottoinsieme informativo)

--- a/so_mcp/_discovery.py
+++ b/so_mcp/_discovery.py
@@ -44,7 +44,7 @@ def list_source_items(
     try:
         with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
             parquet_path = str(resolved_path)
-            with safe_connect() as con:
+            with safe_connect(extensions=["httpfs"]) as con:
                 columns = set(_artifact._table_columns(con, parquet_path))
 
                 # Colonne da selezionare (sottoinsieme informativo)

--- a/so_mcp/_find_url.py
+++ b/so_mcp/_find_url.py
@@ -24,7 +24,7 @@ def find_by_url(url: str) -> dict[str, Any]:
     try:
         with _artifact._resolved_parquet(source_check_artifact) as (resolved_path, cache):
             parquet_path = str(resolved_path)
-            with safe_connect() as con:
+            with safe_connect(extensions=["httpfs"]) as con:
                 cols = _artifact._table_columns(con, parquet_path)
                 url_cols = [
                     c
@@ -49,7 +49,7 @@ def find_by_url(url: str) -> dict[str, Any]:
     try:
         with _artifact._resolved_parquet(catalog_artifact) as (resolved_path, cache):
             parquet_path = str(resolved_path)
-            with safe_connect() as con:
+            with safe_connect(extensions=["httpfs"]) as con:
                 cols = _artifact._table_columns(con, parquet_path)
                 search_cols = [
                     c

--- a/so_mcp/_find_url.py
+++ b/so_mcp/_find_url.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import _artifact
-from lab_connectors.duckdb import safe_connect
+from lab_connectors.duckdb import gcs_connect
 
 
 def find_by_url(url: str) -> dict[str, Any]:
@@ -24,7 +24,7 @@ def find_by_url(url: str) -> dict[str, Any]:
     try:
         with _artifact._resolved_parquet(source_check_artifact) as (resolved_path, cache):
             parquet_path = str(resolved_path)
-            with safe_connect(extensions=["httpfs"]) as con:
+            with gcs_connect(resolved_path) as con:
                 cols = _artifact._table_columns(con, parquet_path)
                 url_cols = [
                     c
@@ -49,7 +49,7 @@ def find_by_url(url: str) -> dict[str, Any]:
     try:
         with _artifact._resolved_parquet(catalog_artifact) as (resolved_path, cache):
             parquet_path = str(resolved_path)
-            with safe_connect(extensions=["httpfs"]) as con:
+            with gcs_connect(resolved_path) as con:
                 cols = _artifact._table_columns(con, parquet_path)
                 search_cols = [
                     c

--- a/so_mcp/_inventory.py
+++ b/so_mcp/_inventory.py
@@ -31,7 +31,7 @@ def query_inventory(
     try:
         with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
             parquet_path = str(resolved_path)
-            with safe_connect() as con:
+            with safe_connect(extensions=["httpfs"]) as con:
                 cols = _artifact._table_columns(con, parquet_path)
                 col_set = set(cols)
                 has_group_col = "dataset_group" in col_set
@@ -218,7 +218,7 @@ def catalog_inventory_search(
     try:
         with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
             parquet_path = str(resolved_path)
-            with safe_connect() as con:
+            with safe_connect(extensions=["httpfs"]) as con:
                 columns = set(_artifact._table_columns(con, parquet_path))
                 search_columns = [
                     column
@@ -381,7 +381,7 @@ def inventory_diff(source_id: str) -> dict[str, Any]:
     try:
         artifact = _artifact._catalog_inventory_parquet()
         with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
-            with safe_connect() as con:
+            with safe_connect(extensions=["httpfs"]) as con:
                 row = con.execute(
                     f'SELECT COUNT(*) FROM "{resolved_path}" WHERE source_id = ?',
                     [source_id],

--- a/so_mcp/_inventory.py
+++ b/so_mcp/_inventory.py
@@ -9,7 +9,7 @@ import json
 from typing import Any
 
 import _artifact
-from lab_connectors.duckdb import safe_connect
+from lab_connectors.duckdb import gcs_connect
 
 
 def query_inventory(
@@ -31,7 +31,7 @@ def query_inventory(
     try:
         with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
             parquet_path = str(resolved_path)
-            with safe_connect(extensions=["httpfs"]) as con:
+            with gcs_connect(resolved_path) as con:
                 cols = _artifact._table_columns(con, parquet_path)
                 col_set = set(cols)
                 has_group_col = "dataset_group" in col_set
@@ -218,7 +218,7 @@ def catalog_inventory_search(
     try:
         with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
             parquet_path = str(resolved_path)
-            with safe_connect(extensions=["httpfs"]) as con:
+            with gcs_connect(resolved_path) as con:
                 columns = set(_artifact._table_columns(con, parquet_path))
                 search_columns = [
                     column
@@ -381,7 +381,7 @@ def inventory_diff(source_id: str) -> dict[str, Any]:
     try:
         artifact = _artifact._catalog_inventory_parquet()
         with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
-            with safe_connect(extensions=["httpfs"]) as con:
+            with gcs_connect(resolved_path) as con:
                 row = con.execute(
                     f'SELECT COUNT(*) FROM "{resolved_path}" WHERE source_id = ?',
                     [source_id],

--- a/so_mcp/_recommend.py
+++ b/so_mcp/_recommend.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import _artifact
-from lab_connectors.duckdb import safe_connect
+from lab_connectors.duckdb import gcs_connect
 
 
 def recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
@@ -24,10 +24,14 @@ def recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
         artifact = _artifact._catalog_inventory_parquet()
         with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
 <<<<<<< HEAD
+<<<<<<< HEAD
             with safe_connect() as con:
                 total_row = con.execute(f'SELECT COUNT(*) FROM "{resolved_path}"').fetchone()
 =======
             with safe_connect(extensions=["httpfs"]) as con:
+=======
+            with gcs_connect(resolved_path) as con:
+>>>>>>> e1a2214 (refactor: usa gcs_connect da lab-connectors, bump toolkit v1.27.3)
                 total_row = con.execute(
                     f'SELECT COUNT(*) FROM "{resolved_path}"'
                 ).fetchone()

--- a/so_mcp/_recommend.py
+++ b/so_mcp/_recommend.py
@@ -23,19 +23,10 @@ def recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
     try:
         artifact = _artifact._catalog_inventory_parquet()
         with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
-<<<<<<< HEAD
-<<<<<<< HEAD
-            with safe_connect() as con:
-                total_row = con.execute(f'SELECT COUNT(*) FROM "{resolved_path}"').fetchone()
-=======
-            with safe_connect(extensions=["httpfs"]) as con:
-=======
             with gcs_connect(resolved_path) as con:
->>>>>>> e1a2214 (refactor: usa gcs_connect da lab-connectors, bump toolkit v1.27.3)
                 total_row = con.execute(
                     f'SELECT COUNT(*) FROM "{resolved_path}"'
                 ).fetchone()
->>>>>>> ea40010 (feat: parquet artifacts letti via DuckDB S3 diretto, niente download GCS)
                 total_items = total_row[0] if total_row else 0
 
                 rows = con.execute(

--- a/so_mcp/_recommend.py
+++ b/so_mcp/_recommend.py
@@ -23,8 +23,15 @@ def recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
     try:
         artifact = _artifact._catalog_inventory_parquet()
         with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
+<<<<<<< HEAD
             with safe_connect() as con:
                 total_row = con.execute(f'SELECT COUNT(*) FROM "{resolved_path}"').fetchone()
+=======
+            with safe_connect(extensions=["httpfs"]) as con:
+                total_row = con.execute(
+                    f'SELECT COUNT(*) FROM "{resolved_path}"'
+                ).fetchone()
+>>>>>>> ea40010 (feat: parquet artifacts letti via DuckDB S3 diretto, niente download GCS)
                 total_items = total_row[0] if total_row else 0
 
                 rows = con.execute(

--- a/so_mcp/_sdmx.py
+++ b/so_mcp/_sdmx.py
@@ -22,7 +22,7 @@ def _score_dataflow(text: str, keywords: list[str]) -> int:
 
 
 def _read_sdmx_inventory_rows(parquet_path: Any) -> list[dict[str, Any]]:
-    with safe_connect() as con:
+    with safe_connect(extensions=["httpfs"]) as con:
         rows = con.execute(
             f"""
             SELECT source_id, item_id, item_name, title, tags, api_base_url, source_url

--- a/so_mcp/_sdmx.py
+++ b/so_mcp/_sdmx.py
@@ -6,7 +6,7 @@ import re
 from typing import Any
 
 import _artifact
-from lab_connectors.duckdb import safe_connect
+from lab_connectors.duckdb import gcs_connect
 
 
 def _score_dataflow(text: str, keywords: list[str]) -> int:
@@ -22,7 +22,7 @@ def _score_dataflow(text: str, keywords: list[str]) -> int:
 
 
 def _read_sdmx_inventory_rows(parquet_path: Any) -> list[dict[str, Any]]:
-    with safe_connect(extensions=["httpfs"]) as con:
+    with gcs_connect(parquet_path) as con:
         rows = con.execute(
             f"""
             SELECT source_id, item_id, item_name, title, tags, api_base_url, source_url

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -71,24 +71,7 @@ def test_query_inventory_falls_back_to_local_when_remote_unreachable(tmp_path, m
     # Simula S3 non raggiungibile
     monkeypatch.setattr(_artifact, "_probe_s3_parquet", lambda _: False)
 
-<<<<<<< HEAD
-        def iter_content(self, chunk_size):
-            yield parquet_path.read_bytes()
-
-    def fake_get(url, **kwargs):
-        assert (
-            url == "https://storage.googleapis.com/bucket/source-check/source_check_results.parquet"
-        )
-        return FakeResponse()
-
-    monkeypatch.setenv("SO_ARTIFACT_BACKEND", "gcs")
-    monkeypatch.setenv("CATALOG_INVENTORY_GCS_PREFIX", "gs://bucket")
-    monkeypatch.setattr(_artifact.requests, "get", fake_get)
-
-    result = query_inventory(source_id="gcs_src", limit=10)
-=======
     result = query_inventory(source_id="local_src", limit=10)
->>>>>>> ea40010 (feat: parquet artifacts letti via DuckDB S3 diretto, niente download GCS)
 
     assert result["returned"] == 1
     assert result["results"][0]["item_id"] == "cached"

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -107,6 +107,20 @@ def test_resolved_parquet_gcs_direct_no_download(monkeypatch) -> None:
         assert "S3" in cache["note"]
 
 
+def test_gs_to_s3_conversion() -> None:
+    """_gs_to_s3 converte correttamente URI."""
+    assert _artifact._gs_to_s3("gs://bucket/key.parquet") == "s3://bucket/key.parquet"
+    assert _artifact._gs_to_s3("gs://dataciviclab-clean/source-check/check.parquet") == "s3://dataciviclab-clean/source-check/check.parquet"
+
+
+def test_direct_cache_info() -> None:
+    """_direct_cache_info restituisce source gcs_direct con URI."""
+    info = _artifact._direct_cache_info("s3://bucket/test.parquet")
+    assert info["source"] == "gcs_direct"
+    assert info["uri"] == "s3://bucket/test.parquet"
+    assert "S3" in info["note"]
+
+
 def test_query_signals_filters_and_limits(tmp_path, monkeypatch) -> None:
     signals_path = tmp_path / "catalog_signals.json"
     signals_path.write_text(

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -57,17 +57,21 @@ def test_query_inventory_filters_and_orders(tmp_path, monkeypatch) -> None:
     assert result["cache"]["stale"] is False
 
 
-def test_query_inventory_reads_gcs_when_configured(tmp_path, monkeypatch) -> None:
-    parquet_path = tmp_path / "source_check_results.parquet"
+def test_query_inventory_falls_back_to_local_when_remote_unreachable(tmp_path, monkeypatch) -> None:
+    """Parquet con auto backend, S3 non raggiungibile → fallback a locale."""
+    parquet_path = _artifact._CHECK_PARQUET
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
     _write_parquet(
         parquet_path,
-        [{"source_id": "gcs_src", "item_id": "remote", "intake_score": 80}],
+        [{"source_id": "local_src", "item_id": "cached", "intake_score": 80}],
     )
 
-    class FakeResponse:
-        def raise_for_status(self) -> None:
-            return None
+    monkeypatch.setenv("SO_ARTIFACT_BACKEND", "auto")
+    monkeypatch.setenv("CATALOG_INVENTORY_GCS_PREFIX", "gs://any-bucket")
+    # Simula S3 non raggiungibile
+    monkeypatch.setattr(_artifact, "_probe_s3_parquet", lambda _: False)
 
+<<<<<<< HEAD
         def iter_content(self, chunk_size):
             yield parquet_path.read_bytes()
 
@@ -82,12 +86,25 @@ def test_query_inventory_reads_gcs_when_configured(tmp_path, monkeypatch) -> Non
     monkeypatch.setattr(_artifact.requests, "get", fake_get)
 
     result = query_inventory(source_id="gcs_src", limit=10)
+=======
+    result = query_inventory(source_id="local_src", limit=10)
+>>>>>>> ea40010 (feat: parquet artifacts letti via DuckDB S3 diretto, niente download GCS)
 
     assert result["returned"] == 1
-    assert result["results"][0]["item_id"] == "remote"
-    assert result["cache"]["source"] == "gcs"
-    assert result["cache"]["uri"] == "gs://bucket/source-check/source_check_results.parquet"
-    assert result["cache"]["stale"] is False
+    assert result["results"][0]["item_id"] == "cached"
+    assert result["cache"]["source"] == "local_cache"
+
+
+def test_resolved_parquet_gcs_direct_no_download(monkeypatch) -> None:
+    """Parquet artifact con GCS backend → S3 URI diretto, nessun download."""
+    monkeypatch.setenv("SO_ARTIFACT_BACKEND", "gcs")
+    monkeypatch.setenv("CATALOG_INVENTORY_GCS_PREFIX", "gs://test-bucket")
+
+    artifact = _artifact._source_check_parquet()
+    with _artifact._resolved_parquet(artifact) as (path, cache):
+        assert cache["source"] == "gcs_direct"
+        assert str(path) == "s3://test-bucket/source-check/source_check_results.parquet"
+        assert "S3" in cache["note"]
 
 
 def test_query_signals_filters_and_limits(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Sintesi

Sostituisce il download HTTP/GCS dei parquet artifact da `requests.get(stream=True)` / `gcloud storage cp` con **lettura diretta DuckDB via S3**. I parquet vengono letti da DuckDB con httpfs che accede al bucket pubblico GCS direttamente — zero file temporanei, zero rete extra, zero `requests`.

## Contesto collegato

Segue la PR toolkit#338 (supporto S3 in `parquet_preview` / `toolkit query`) e l'uso di `safe_connect(extensions=["httpfs"])` da lab-connectors v0.13.0.

## Cosa cambia

- [ ] Nuova fonte o modifica registro (sources_registry.yaml)
- [ ] Source-check o inventory-triage
- [x] Modifica script (radar, inventory, source-check, MCP)
- [ ] Modifica funnel o criteri di osservazione
- [ ] Workflow CI (radar.yml, observatory.yml)
- [x] Skills o MCP tools
- [ ] Documentazione
- [ ] Altro

## Checklist

### Se modifichi script o MCP

- [x] `pytest tests/` passa — 360/360
- [ ] `ruff check .` passa
- [ ] `mypy scripts/ so_mcp/` passa
- [ ] Comando manuale verificato (es. `python scripts/radar_check.py --source <id>`)

## Verifica

Tutti i test SO passano (360). Il conftest forza `SO_ARTIFACT_BACKEND=local` per tutti i test, quindi il nuovo percorso `gcs_direct` non è eseguito in CI — ma il nuovo test `test_resolved_parquet_gcs_direct_no_download` verifica che `_resolved_parquet` con backend GCS restituisca URI `s3://` e cache `gcs_direct`.

Fallback: test `test_query_inventory_falls_back_to_local_when_remote_unreachable` verifica che con `auto` backend e S3 irraggiungibile si cada su cache locale.

## Note per chi revisiona

- I parquet artifact (source_check, catalog_inventory) ora non vengono più scaricati: DuckDB legge `s3://dataciviclab-clean/...` via httpfs.
- I JSON artifact (catalog_inventory_report.json) continuano a usare il download HTTP (temp file) — non cambia.
- `_probe_s3_parquet()` fa una query DuckDB leggera (`SELECT 1 LIMIT 1`) per decidere se S3 è raggiungibile in modalità `auto`.
- Idempotente: `SO_ARTIFACT_BACKEND=local` non cambia comportamento.
