### PR TITLE
chore: pre-commit hooks (ruff + ruff-format) + editorconfig

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,4 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
+      - id: ruff-format

--- a/so_mcp/_artifact.py
+++ b/so_mcp/_artifact.py
@@ -319,9 +319,7 @@ def _probe_s3_parquet(s3_uri: str) -> bool:
 
     try:
         with gcs_connect(s3_uri) as con:
-            row = con.execute(
-                f'SELECT 1 FROM read_parquet(\'{s3_uri}\') LIMIT 1'
-            ).fetchone()
+            row = con.execute(f"SELECT 1 FROM read_parquet('{s3_uri}') LIMIT 1").fetchone()
             return row is not None
     except Exception:
         return False
@@ -377,7 +375,9 @@ def _resolved_artifact(artifact: _ParquetArtifact | _JsonArtifact):
                 yield s3_uri, _direct_cache_info(s3_uri)
                 return
             # auto + S3 non raggiungibile → fall through to local cache
-            fallback_warning = f"S3 URI {s3_uri} non raggiungibile; uso cache locale se disponibile."
+            fallback_warning = (
+                f"S3 URI {s3_uri} non raggiungibile; uso cache locale se disponibile."
+            )
         else:
             # JSON → download su temp file
             tmp_path: Path | None = None
@@ -385,8 +385,12 @@ def _resolved_artifact(artifact: _ParquetArtifact | _JsonArtifact):
                 tmp_path = _copy_gcs_to_temp(uri, artifact.name)
             except Exception as exc:
                 if backend == "gcs":
-                    raise RuntimeError(f"Cannot read {artifact.name} from GCS {uri}: {exc}") from exc
-                fallback_warning = f"Cannot read GCS artifact {uri}; using local cache if available."
+                    raise RuntimeError(
+                        f"Cannot read {artifact.name} from GCS {uri}: {exc}"
+                    ) from exc
+                fallback_warning = (
+                    f"Cannot read GCS artifact {uri}; using local cache if available."
+                )
             else:
                 try:
                     yield tmp_path, _artifact_cache_info(tmp_path, source="gcs", uri=uri)

--- a/so_mcp/_recommend.py
+++ b/so_mcp/_recommend.py
@@ -24,9 +24,7 @@ def recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:
         artifact = _artifact._catalog_inventory_parquet()
         with _artifact._resolved_parquet(artifact) as (resolved_path, cache):
             with gcs_connect(resolved_path) as con:
-                total_row = con.execute(
-                    f'SELECT COUNT(*) FROM "{resolved_path}"'
-                ).fetchone()
+                total_row = con.execute(f'SELECT COUNT(*) FROM "{resolved_path}"').fetchone()
                 total_items = total_row[0] if total_row else 0
 
                 rows = con.execute(

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -93,7 +93,10 @@ def test_resolved_parquet_gcs_direct_no_download(monkeypatch) -> None:
 def test_gs_to_s3_conversion() -> None:
     """_gs_to_s3 converte correttamente URI."""
     assert _artifact._gs_to_s3("gs://bucket/key.parquet") == "s3://bucket/key.parquet"
-    assert _artifact._gs_to_s3("gs://dataciviclab-clean/source-check/check.parquet") == "s3://dataciviclab-clean/source-check/check.parquet"
+    assert (
+        _artifact._gs_to_s3("gs://dataciviclab-clean/source-check/check.parquet")
+        == "s3://dataciviclab-clean/source-check/check.parquet"
+    )
 
 
 def test_direct_cache_info() -> None:


### PR DESCRIPTION
## Sintesi

Aggiunge `.pre-commit-config.yaml` con ruff (lint + format) e hook standard.
Aggiunge `ruff-format` mancante (config esisteva già senza).
Aggiunge `.editorconfig`.

Allinea source-observatory alla policy già attiva in toolkit e lab-connectors.

## Cosa cambia

- `.pre-commit-config.yaml`: aggiunto `ruff-format`
- `.editorconfig`: già presente, non modificato
- `pre-commit install` eseguito localmente

## Verifica

```bash
pre-commit run --all-files  # tutto verde
```

## Checklist PR

- [x] Perimetro stretto: tooling, zero logica
