### PR TITLE
fix: SO bypass lab-connectors in joinability_scan + _artifact (P1 audit)

### DIFF
--- a/scripts/joinability_scan.py
+++ b/scripts/joinability_scan.py
@@ -19,13 +19,15 @@ import re
 from datetime import date
 from typing import Any
 
-import requests
+from lab_connectors.duckdb import gcs_connect
+from lab_connectors.http import HttpClient
 
 # ── Percorsi ──────────────────────────────────────────────────────────────────
+# I path artifact GCS seguono il path contract canonico (lab-connectors/paths.json).
+# Il parquet viene letto via DuckDB S3 (httpfs) — niente download HTTP.
 
 SOURCE_CHECK_URL = (
-    "https://storage.googleapis.com/dataciviclab-clean/"
-    "catalog_inventory/source-check/source_check_results.parquet"
+    "s3://dataciviclab-clean/catalog_inventory/source-check/source_check_results.parquet"
 )
 
 CATALOG_URL = (
@@ -107,30 +109,28 @@ KEY_PATTERNS: list[tuple[str, str, str]] = [
 
 
 def load_source_check() -> list[dict[str, Any]]:
-    """Scarica e carica source_check_results.parquet come lista di dict."""
-    import io
-
-    import pyarrow.parquet as pq
-
-    print("  Download source_check_results.parquet...", end=" ", flush=True)
-    resp = requests.get(SOURCE_CHECK_URL, timeout=60)
-    resp.raise_for_status()
-    data = io.BytesIO(resp.content)
-    table = pq.read_table(data)
-    df = table.to_pandas()
+    """Legge source_check_results.parquet da GCS via DuckDB S3 diretto."""
+    print("  Lettura source_check_results.parquet via DuckDB S3...", end=" ", flush=True)
+    with gcs_connect(SOURCE_CHECK_URL) as con:
+        df = con.execute(f"SELECT * FROM read_parquet('{SOURCE_CHECK_URL}')").fetchdf()
     print(f"{len(df)} righe, {len(df.columns)} colonne")
     return df.to_dict("records")
 
 
 def load_clean_catalog() -> list[dict[str, Any]]:
-    """Scarica e carica clean_catalog.json come lista di dataset."""
+    """Scarica clean_catalog.json da GitHub via HttpClient."""
     print("  Download clean_catalog.json...", end=" ", flush=True)
-    resp = requests.get(CATALOG_URL, timeout=30)
-    resp.raise_for_status()
-    raw = resp.json()
-    datasets: list[dict] = raw if isinstance(raw, list) else raw.get("datasets", [])
-    print(f"{len(datasets)} dataset")
-    return datasets
+    client = HttpClient(timeout=30)
+    try:
+        result = client.get(CATALOG_URL)
+        if result.is_error:
+            raise RuntimeError(f"Failed to fetch catalog: {result.err}")
+        raw = result.response.json()
+        datasets: list[dict] = raw if isinstance(raw, list) else raw.get("datasets", [])
+        print(f"{len(datasets)} dataset")
+        return datasets
+    finally:
+        client.close()
 
 
 def parse_columns(columns_raw: Any) -> list[str]:

--- a/scripts/joinability_scan.py
+++ b/scripts/joinability_scan.py
@@ -123,7 +123,7 @@ def load_clean_catalog() -> list[dict[str, Any]]:
     client = HttpClient(timeout=30)
     try:
         result = client.get(CATALOG_URL)
-        if result.is_error:
+        if not result.is_ok or result.response is None:
             raise RuntimeError(f"Failed to fetch catalog: {result.err}")
         raw = result.response.json()
         datasets: list[dict] = raw if isinstance(raw, list) else raw.get("datasets", [])

--- a/so_mcp/_artifact.py
+++ b/so_mcp/_artifact.py
@@ -334,7 +334,7 @@ def _download_public_to_temp(uri: str, tmp_path: Path) -> None:
     client = HttpClient(timeout=120)
     try:
         result = client.get(_public_url(uri))
-        if result.is_error:
+        if not result.is_ok or result.response is None:
             raise RuntimeError(f"Failed to download {uri}: {result.err}")
         tmp_path.write_bytes(result.response.content)
     finally:

--- a/so_mcp/_artifact.py
+++ b/so_mcp/_artifact.py
@@ -23,8 +23,8 @@ from pathlib import Path
 from typing import Any
 
 import duckdb
-import requests
 from lab_connectors.gcs.paths import CLEAN_BUCKET
+from lab_connectors.http import HttpClient
 
 # ── Repo root & path setup ────────────────────────────────────────────────────
 # Aggiunge scripts/ a sys.path per importare _constants e altri moduli scripts
@@ -326,12 +326,19 @@ def _probe_s3_parquet(s3_uri: str) -> bool:
 
 
 def _download_public_to_temp(uri: str, tmp_path: Path) -> None:
-    response = requests.get(_public_url(uri), timeout=120, stream=True)
-    response.raise_for_status()
-    with tmp_path.open("wb") as fh:
-        for chunk in response.iter_content(chunk_size=1024 * 1024):
-            if chunk:
-                fh.write(chunk)
+    """Scarica un artifact GCS pubblico su file temporaneo via HttpClient.
+
+    Usato per artifact JSON (es. catalog_inventory_report.json).
+    I parquet usano DuckDB S3 diretto (vedi _resolved_artifact → _ParquetArtifact).
+    """
+    client = HttpClient(timeout=120)
+    try:
+        result = client.get(_public_url(uri))
+        if result.is_error:
+            raise RuntimeError(f"Failed to download {uri}: {result.err}")
+        tmp_path.write_bytes(result.response.content)
+    finally:
+        client.close()
 
 
 def _copy_gcs_to_temp(uri: str, artifact_name: str) -> Path:
@@ -344,7 +351,7 @@ def _copy_gcs_to_temp(uri: str, artifact_name: str) -> Path:
     try:
         try:
             _download_public_to_temp(uri, tmp_path)
-        except requests.RequestException:
+        except Exception:
             subprocess.run(
                 ["gcloud", "storage", "cp", uri, str(tmp_path)],
                 check=True,


### PR DESCRIPTION
## Sintesi

Chiude gli ultimi due bypass P1 dell'audit lab-connectors in source-observatory:
- `joinability_scan.py`: parquet via DuckDB S3 (gcs_connect), catalog JSON via HttpClient
- `_artifact.py`: download artifact JSON via HttpClient invece di `requests.get(stream=True)`

## Contesto collegato

Dopo PR #322 (parquet artifact via DuckDB S3), restavano due bypass:
1. `joinability_scan.py` — script standalone che usava `requests.get()` + pyarrow per il parquet e `requests.get()` per il catalog JSON
2. `_artifact.py` — `_download_public_to_temp()` usava `requests.get(stream=True)` per JSON artifact GCS

## Cosa cambia

- [ ] Nuova fonte o modifica registro (sources_registry.yaml)
- [ ] Source-check o inventory-triage
- [x] Modifica script (radar, inventory, source-check, MCP)
- [ ] Modifica funnel o criteri di osservazione
- [ ] Workflow CI (radar.yml, observatory.yml)
- [x] Skills o MCP tools
- [ ] Documentazione
- [ ] Altro

## Checklist

### Se modifichi script o MCP

- [x] `pytest tests/` passa — 362/362
- [x] `ruff check .` passa
- [x] `ruff format` passa
- [ ] Comando manuale verificato (es. `python scripts/joinability_scan.py`)

## Verifica

```bash
pytest tests/ -v
```
362/362 passano. I test esistenti di `joinability_scan.py` testano solo la logica pura (detect_keys, cross_reference, compute_joinability_score) — le funzioni I/O non hanno test, ma il cambiamento è meccanico: `requests.get()` → `HttpClient.get()` / `gcs_connect()`.

- [x] Perimetro stretto: una PR = bypass lab-connectors
- [ ] Issue collegata o motivazione dell'assenza

## Note per chi revisiona

- `joinability_scan.load_source_check()`: non scarica più il parquet via HTTP + pyarrow. Usa `gcs_connect()` (DuckDB + httpfs) che legge `s3://dataciviclab-clean/...` direttamente. Stessa semantica: restituisce `list[dict]`.
- `joinability_scan.load_clean_catalog()`: `HttpClient` con timeout 30s, retry e SSL fallback inclusi.
- `_artifact._download_public_to_temp()`: non usa più `stream=True` (non necessario per JSON < 10MB). `HttpClient` con timeout 120s.
- `_artifact._copy_gcs_to_temp()`: `except requests.RequestException` → `except Exception` (requests non più importato).
