### PR TITLE
feat: so_source_overview tool aggregato (radar + inventory + signals)

### DIFF
--- a/so_mcp/so_server.py
+++ b/so_mcp/so_server.py
@@ -177,5 +177,30 @@ def so_list_source_items(
     return guard_timed(list_source_items, "so_list_source_items", source_id, limit, offset, query)
 
 
+@mcp.tool(
+    description=(
+        "Overview completo di una fonte: stato radar, stato inventory, "
+        "delta item count, signals recenti. Compone so_radar_summary + "
+        "so_inventory_status + so_inventory_diff + so_catalog_signals "
+        "in una singola chiamata."
+    ),
+    structured_output=True,
+)
+def so_source_overview(source_id: str) -> dict[str, Any]:
+    """Overview completo di una fonte in un giro solo."""
+
+    def _exec() -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "source_id": source_id,
+            "radar": radar_summary(source_id),
+            "inventory_status": inventory_status(source_id),
+            "inventory_diff": inventory_diff(source_id),
+            "signals": query_signals(source_id, limit=5),
+        }
+        return result
+
+    return guard_timed(_exec, "so_source_overview")
+
+
 if __name__ == "__main__":
     mcp.run()

--- a/tests/test_so_server_wrapper.py
+++ b/tests/test_so_server_wrapper.py
@@ -1,4 +1,4 @@
-"""Smoke test: verify so_server.py registers 13 MCP tools via create_mcp_server."""
+"""Smoke test: verify so_server.py registers 14 MCP tools via create_mcp_server."""
 
 from __future__ import annotations
 
@@ -8,8 +8,8 @@ import pytest
 import so_server  # noqa: E402  # conftest aggiunge so_mcp/ a sys.path
 
 
-def test_mcp_server_registers_13_tools() -> None:
-    """Verify all 13 tools are registered on the mcp server object."""
+def test_mcp_server_registers_14_tools() -> None:
+    """Verify all 14 tools are registered on the mcp server object."""
     tools = asyncio.run(so_server.mcp.list_tools())
     tool_names = sorted(t.name for t in tools)
 
@@ -28,6 +28,7 @@ def test_mcp_server_registers_13_tools() -> None:
             "so_radar_summary",
             "so_recommend_sources",
             "so_registry_query",
+            "so_source_overview",
         ]
     )
 


### PR DESCRIPTION
## Sintesi

Aggiunge `so_source_overview(source_id)` — tool MCP aggregato che compone 4 chiamate in una:

- `radar_summary(source_id)` — stato health (GREEN/YELLOW/RED)
- `inventory_status(source_id)` — build status inventory
- `inventory_diff(source_id)` — delta item count vs baseline
- `query_signals(source_id, limit=5)` — segnali recenti

## Perché

L'agente AI che vuole capire lo stato di una fonte oggi faceva 4 chiamate MCP separate. Ora ne basta una.

## Checklist

- [x] `pytest tests/ -q` passa (47 test MCP)
- [x] `ruff check so_mcp/` passa
- [x] Prova reale: `so_source_overview('istat_sdmx')` funziona

## Verifica

```
so_source_overview('istat_sdmx')
  → radar: YELLOW (Timeout)
  → inventory_status: OK
  → inventory_diff: delta=0
  → signals: 1 segnale
```
