### PR TITLE
fix(mcp): entry point standard + rimuove fastmcp (mai usato)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
   "pyarrow>=24.0.0",
   "jsonschema>=4.26.0",
   "mcp>=1.27.1",
-  "fastmcp>=3.3.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.4",
   "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.27.3",
@@ -48,6 +47,9 @@ dev = [
   "types-pyyaml",
   "pandas-stubs",
 ]
+
+[project.scripts]
+source-observatory-mcp = "so_mcp.so_server:main"
 
 [project.urls]
 Repository = "https://github.com/dataciviclab/source-observatory"

--- a/so_mcp/_discovery.py
+++ b/so_mcp/_discovery.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 from typing import Any
 
-import _artifact
 from lab_connectors.duckdb import gcs_connect
+
+from . import _artifact
 
 
 def list_source_items(

--- a/so_mcp/_find_url.py
+++ b/so_mcp/_find_url.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-import _artifact
 from lab_connectors.duckdb import gcs_connect
+
+from . import _artifact
 
 
 def find_by_url(url: str) -> dict[str, Any]:

--- a/so_mcp/_inventory.py
+++ b/so_mcp/_inventory.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 import json
 from typing import Any
 
-import _artifact
 from lab_connectors.duckdb import gcs_connect
+
+from . import _artifact
 
 
 def query_inventory(

--- a/so_mcp/_radar.py
+++ b/so_mcp/_radar.py
@@ -6,7 +6,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any
 
-import _artifact
+from . import _artifact
 
 
 def radar_summary(source_id: str | None = None) -> dict[str, Any]:

--- a/so_mcp/_recommend.py
+++ b/so_mcp/_recommend.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-import _artifact
 from lab_connectors.duckdb import gcs_connect
+
+from . import _artifact
 
 
 def recommend_sources(keyword: str, limit: int = 10) -> dict[str, Any]:

--- a/so_mcp/_registry.py
+++ b/so_mcp/_registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import _artifact
+from . import _artifact
 
 
 def registry_query(

--- a/so_mcp/_sdmx.py
+++ b/so_mcp/_sdmx.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import re
 from typing import Any
 
-import _artifact
 from lab_connectors.duckdb import gcs_connect
+
+from . import _artifact
 
 
 def _score_dataflow(text: str, keywords: list[str]) -> int:

--- a/so_mcp/_signals.py
+++ b/so_mcp/_signals.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-import _artifact
+from . import _artifact
 
 
 def query_signals(source_id: str | None = None, limit: int | None = None) -> dict[str, Any]:

--- a/so_mcp/so_server.py
+++ b/so_mcp/so_server.py
@@ -12,20 +12,21 @@ from __future__ import annotations
 
 from typing import Any
 
-from _discovery import list_source_items
-from _find_url import find_by_url
-from _inventory import (
+from lab_connectors.mcp import create_mcp_server, guard_timed
+
+from ._discovery import list_source_items
+from ._find_url import find_by_url
+from ._inventory import (
     catalog_inventory_search,
     inventory_diff,
     inventory_status,
     query_inventory,
 )
-from _radar import radar_history, radar_status_md, radar_summary
-from _recommend import recommend_sources
-from _registry import registry_query
-from _sdmx import discover_sdmx
-from _signals import query_signals
-from lab_connectors.mcp import create_mcp_server, guard_timed
+from ._radar import radar_history, radar_status_md, radar_summary
+from ._recommend import recommend_sources
+from ._registry import registry_query
+from ._sdmx import discover_sdmx
+from ._signals import query_signals
 
 mcp = create_mcp_server(
     name="source-observatory",

--- a/so_mcp/so_server.py
+++ b/so_mcp/so_server.py
@@ -202,5 +202,10 @@ def so_source_overview(source_id: str) -> dict[str, Any]:
     return guard_timed(_exec, "so_source_overview")
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Entry point per l'MCP server."""
     mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,10 +15,12 @@ from typing import Any
 import pytest
 
 # Aggiungi percorsi di import prima di qualsiasi test
-_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
-_SO_MCP_DIR = Path(__file__).resolve().parent.parent / "so_mcp"
+# REPO_ROOT serve per importare so_mcp come package (from so_mcp._discovery import ...)
+# SCRIPTS_DIR serve per importare _constants da scripts/ (non è un package)
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
 
-for _p in (_SCRIPTS_DIR, _SO_MCP_DIR):
+for _p in (_REPO_ROOT, _SCRIPTS_DIR):
     if str(_p) not in sys.path:
         sys.path.insert(0, str(_p))
 

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -2,24 +2,25 @@ from __future__ import annotations
 
 import json
 
-import _artifact
 import duckdb  # noqa: E402
 import pandas as pd  # must be before duckdb
 import pytest
-from _discovery import list_source_items
-from _find_url import find_by_url
-from _inventory import (
+
+from so_mcp import _artifact
+from so_mcp._discovery import list_source_items
+from so_mcp._find_url import find_by_url
+from so_mcp._inventory import (
     _source_radar_context,
     catalog_inventory_search,
     inventory_diff,
     inventory_status,
     query_inventory,
 )
-from _radar import radar_history, radar_status_md, radar_summary
-from _recommend import recommend_sources
-from _registry import registry_query
-from _sdmx import discover_sdmx
-from _signals import query_signals
+from so_mcp._radar import radar_history, radar_status_md, radar_summary
+from so_mcp._recommend import recommend_sources
+from so_mcp._registry import registry_query
+from so_mcp._sdmx import discover_sdmx
+from so_mcp._signals import query_signals
 
 pytestmark = pytest.mark.contract
 

--- a/tests/test_so_server_wrapper.py
+++ b/tests/test_so_server_wrapper.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-import so_server  # noqa: E402  # conftest aggiunge so_mcp/ a sys.path
+
+from so_mcp import so_server
 
 
 def test_mcp_server_registers_14_tools() -> None:


### PR DESCRIPTION
## Sintesi

Standardizza l'entry point del server MCP e rimuove dipendenza inutilizzata.

**Problema reale**: SO non ha entry point CLI registrato in `pyproject.toml` (usa path diretto) e ha `fastmcp` in dipendenze ma mai importato.

**Contratto riusato**: pattern `[project.scripts]` già in uso in `agent-context-builder`.

## Cosa cambia

- [ ] Modifica script (radar, inventory, source-check, MCP)
- [ ] Skills o MCP tools

### Dettaglio

1. **`pyproject.toml`**: aggiunto `[project.scripts]` → `source-observatory-mcp = "so_mcp.so_server:main"`; rimosso `fastmcp>=3.3.1` (mai importato nel codice)
2. **`so_mcp/so_server.py`**: aggiunta funzione `main()` per entry point CLI

## Checklist

### Se modifichi script o MCP

- [x] `ruff check .` passa
- [x] pre-commit hooks superati

## Verifica

```bash
# L'entry point è testabile con:
source-observatory-mcp
```

## Note per chi revisiona

`fastmcp>=3.3.1` era in `pyproject.toml` da inizio progetto ma mai importato in nessun file Python — lo conferma GitHub Code Search.
