### PR TITLE
refactor(so): Fase 1 ristrutturazione — path constants, sys.path, observatory_get, connection pooling

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 ```
 scripts/
   collectors/          # package: logica di inventory per protocollo
-    base.py            # utility condivise: observatory_get, CollectorResult, strip_query
+    base.py            # utility condivise: CollectorResult, strip_query, USER_AGENT
     ckan.py            # collector CKAN
     sdmx.py            # collector SDMX
     sparql.py          # collector SPARQL
@@ -22,9 +22,10 @@ scripts/
   gha/                         # helper per CI (issue body, publish summary)
 ```
 
-## Regola fondamentale: riusa collectors/base.py
+## Regola fondamentale: usa `HttpClient` per chiamate HTTP
 
-Tutti gli script che fanno chiamate HTTP **devono** usare `observatory_get()` da `collectors/base.py`, non `requests.get()` diretto. Motivo: User-Agent coerente, session management, timeout standard.
+Tutti gli script che fanno chiamate HTTP **devono** usare `HttpClient` da `lab_connectors.http`,
+non `requests.get()` diretto. Motivo: SSL fallback automatico, retry, backoff, User-Agent coerente.
 
 ```python
 # ✗ non fare
@@ -32,13 +33,17 @@ import requests
 r = requests.get(url, timeout=15)
 
 # ✓ fare
-from collectors.base import observatory_get
-r = observatory_get(url, timeout=15)
+from lab_connectors.http import HttpClient
+client = HttpClient(timeout=15, user_agent=USER_AGENT)
+result = client.get(url)
+if result.is_ok:
+    response = result.response
 ```
 
 Per importare `collectors` da uno script in `scripts/`, usa:
 ```python
-from collectors.base import observatory_get
+from lab_connectors.http import HttpClient
+from collectors.base import USER_AGENT
 from collectors.ckan import ckan_get_json
 ```
 
@@ -98,7 +103,7 @@ Il source-check implementa un circuit breaker host-level per evitare di martella
 1. Scrivi `_fetch_X()` e `_parse_X()` — restituiscono sempre il dict shape di `_EMPTY_ENRICH`
 2. Aggiungi un branch in `_enrich()` con la condizione sul protocollo
 3. Aggiungi la costante stringa `ENRICH_X = "x_method"` vicino a `_EMPTY_ENRICH`
-4. Usa `observatory_get()` invece di `requests.get()`
+4. Usa `HttpClient` invece di `requests.get()`
 
 ## Pattern: dict shape degli enricher
 
@@ -122,9 +127,9 @@ Ogni enricher restituisce esattamente queste chiavi (valore `None` se non dispon
 
 ## Utility da collectors/base.py
 
-### Funzioni HTTP
-- `observatory_get(url, *, timeout=60, headers=None, **kwargs)` — GET con User-Agent coerente
-- `get_observatory_session()` → `requests.Session` con header predefiniti
+### Costanti
+- `USER_AGENT` — User-Agent standard per chiamate HTTP
+- `DEFAULT_TIMEOUT_SECONDS` — timeout predefinito
 
 ### Tipi
 - `CollectorResult(rows, warning=None, summary=None)` — risultato di una collezione

--- a/scripts/_constants.py
+++ b/scripts/_constants.py
@@ -1,4 +1,12 @@
-"""Costanti condivise tra gli script di source-observatory."""
+"""Costanti condivise tra gli script di source-observatory.
+
+Le costanti di path sono importate da ``so_mcp._paths`` (unica fonte).
+Le utility (validate_schema, stale_reason, load/save) rimangono qui.
+
+``so_mcp`` e' un package installato — import diretto, nessun sys.path hack.
+"""
+
+from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
@@ -6,30 +14,17 @@ from pathlib import Path
 
 import jsonschema
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-
-# ── Registry ──────────────────────────────────────────────────────────────────
-REGISTRY_PATH = REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
-
-# ── Radar (scripts/radar_check.py → so_mcp/_radar.py) ────────────────────────
-RADAR_SUMMARY_PATH = REPO_ROOT / "data" / "radar" / "radar_summary.json"
-RADAR_HISTORY_PATH = REPO_ROOT / "data" / "radar" / "radar_history.json"
-STATUS_MD_PATH = REPO_ROOT / "data" / "radar" / "STATUS.md"
-
-# ── Catalog inventory (scripts/build_catalog_inventory.py → so_mcp/_inventory.py) ─
-CATALOG_INVENTORY_DIR_PATH = REPO_ROOT / "data" / "catalog_inventory" / "generated"
-INVENTORY_PARQUET_PATH = CATALOG_INVENTORY_DIR_PATH / "catalog_inventory_latest.parquet"
-CATALOG_INVENTORY_REPORT_PATH = CATALOG_INVENTORY_DIR_PATH / "catalog_inventory_report.json"
-CATALOG_WATCH_REPORT_PATH = REPO_ROOT / "data" / "catalog" / "CATALOG_WATCH_REPORT.md"
-
-# ── Source check (scripts/bulk_source_check.py → so_mcp/_signals.py) ─────────
-CHECK_PARQUET_PATH = (
-    REPO_ROOT / "data" / "catalog_inventory" / "generated" / "source_check_results.parquet"
+from so_mcp._paths import (
+    RADAR_HISTORY_PATH,
+    REGISTRY_PATH,
 )
-CATALOG_SIGNALS_PATH = REPO_ROOT / "data" / "catalog" / "catalog_signals.json"
 
-# ── Schemas (scripts/build_catalog_signals.py) ────────────────────────────────
-SCHEMA_DIR_PATH = REPO_ROOT / "schemas"
+# Repo root per path non esportati da so_mcp._paths (solo script).
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# ── Paths non esportati da so_mcp._paths (solo script) ─────────────────────
+CATALOG_WATCH_REPORT_PATH = _REPO_ROOT / "data" / "catalog" / "CATALOG_WATCH_REPORT.md"
+SCHEMA_DIR_PATH = _REPO_ROOT / "schemas"
 
 
 def validate_schema(instance: dict, schema_name: str) -> None:

--- a/scripts/_constants.py
+++ b/scripts/_constants.py
@@ -15,8 +15,31 @@ from pathlib import Path
 import jsonschema
 
 from so_mcp._paths import (
-    RADAR_HISTORY_PATH,
-    REGISTRY_PATH,
+    CATALOG_INVENTORY_DIR_PATH as CATALOG_INVENTORY_DIR_PATH,  # noqa: F401 — re‑export per scripts
+)
+from so_mcp._paths import (
+    CATALOG_INVENTORY_REPORT_PATH as CATALOG_INVENTORY_REPORT_PATH,  # noqa: F401
+)
+from so_mcp._paths import (
+    CATALOG_SIGNALS_PATH as CATALOG_SIGNALS_PATH,  # noqa: F401
+)
+from so_mcp._paths import (
+    CHECK_PARQUET_PATH as CHECK_PARQUET_PATH,  # noqa: F401
+)
+from so_mcp._paths import (
+    INVENTORY_PARQUET_PATH as INVENTORY_PARQUET_PATH,  # noqa: F401
+)
+from so_mcp._paths import (
+    RADAR_HISTORY_PATH as RADAR_HISTORY_PATH,  # noqa: F401
+)
+from so_mcp._paths import (
+    RADAR_SUMMARY_PATH as RADAR_SUMMARY_PATH,  # noqa: F401
+)
+from so_mcp._paths import (
+    REGISTRY_PATH as REGISTRY_PATH,  # noqa: F401
+)
+from so_mcp._paths import (
+    STATUS_MD_PATH as STATUS_MD_PATH,  # noqa: F401
 )
 
 # Repo root per path non esportati da so_mcp._paths (solo script).

--- a/scripts/collectors/base.py
+++ b/scripts/collectors/base.py
@@ -5,8 +5,6 @@ from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
-import requests
-
 USER_AGENT = "DataCivicLab-SourceObservatory/1.0"
 DEFAULT_TIMEOUT_SECONDS = 60
 
@@ -23,23 +21,6 @@ class CollectorResult:
 
 def now_utc_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-
-
-def observatory_get(
-    url: str,
-    *,
-    timeout: int | float | tuple[int | float, int | float] = DEFAULT_TIMEOUT_SECONDS,
-    headers: dict[str, str] | None = None,
-    **kwargs: Any,
-) -> requests.Response:
-    """GET request with SSL fallback via HttpClient."""
-    from lab_connectors.http import HttpClient
-
-    client = HttpClient(timeout=timeout, user_agent=USER_AGENT)  # type: ignore[arg-type]
-    result = client.get(url, headers=headers or {}, **kwargs)
-    if result.is_ok and result.response is not None:
-        return result.response
-    raise result.err if result.err else RuntimeError(f"GET failed for {url}")
 
 
 def strip_query(url: str) -> str:

--- a/scripts/collectors/ckan.py
+++ b/scripts/collectors/ckan.py
@@ -646,9 +646,9 @@ def _ckan_standard_path(
 
     time.sleep(1.0)
     try:
-        current_rows, current_warning = current_list_fn(
-            source_id, source_cfg, captured_at, client=client
-        )
+        # current_list ha timeout 15s proprio — non passare il client condiviso
+        # (creato con timeout 60s) per non alterare il comportamento di retry
+        current_rows, current_warning = current_list_fn(source_id, source_cfg, captured_at)
         enriched_by_id = {row["item_id"]: row for row in current_rows}
         fallback_merged_rows: list[dict[str, Any]] = []
         missing_metadata = 0

--- a/scripts/collectors/ckan.py
+++ b/scripts/collectors/ckan.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import requests
 
-from .base import CollectorResult, inventory_cfg, observatory_get, strip_query
+from .base import USER_AGENT, CollectorResult, inventory_cfg, strip_query
 
 CKAN_ACTION_NAMES = {
     "package_list",
@@ -59,9 +59,15 @@ def ckan_action_endpoint(base_url: str, action: str) -> str:
 
 
 def ckan_get_json(url: str, **kwargs: Any) -> dict[str, Any]:
+    from lab_connectors.http import HttpClient
+
     timeout = kwargs.pop("timeout", 60)
     headers = kwargs.pop("headers", None)
-    response = observatory_get(url, timeout=timeout, headers=headers, **kwargs)
+    client = HttpClient(timeout=timeout, user_agent=USER_AGENT)
+    result = client.get(url, headers=headers or {}, **kwargs)
+    if not result.is_ok or result.response is None:
+        raise result.err if result.err else RuntimeError(f"GET failed for {url}")
+    response = result.response
     response.raise_for_status()
     content_type = (response.headers.get("content-type") or "").lower()
     if "json" not in content_type:

--- a/scripts/collectors/ckan.py
+++ b/scripts/collectors/ckan.py
@@ -59,11 +59,24 @@ def ckan_action_endpoint(base_url: str, action: str) -> str:
 
 
 def ckan_get_json(url: str, **kwargs: Any) -> dict[str, Any]:
+    """GET JSON da un'API CKAN.
+
+    Args:
+        url: Endpoint URL (es. ``/api/3/action/package_show``).
+        client: Opzionale, ``HttpClient`` riusabile per connection pooling.
+            Se non fornito, ne crea uno nuovo (comportamento legacy).
+        **kwargs: Passati a ``HttpClient.get()``; ``timeout`` e ``headers``
+            vengono estratti prima di passarli.
+    """
     from lab_connectors.http import HttpClient
 
+    client: HttpClient | None = kwargs.pop("client", None)
     timeout = kwargs.pop("timeout", 60)
     headers = kwargs.pop("headers", None)
-    client = HttpClient(timeout=timeout, user_agent=USER_AGENT)
+
+    if client is None:
+        client = HttpClient(timeout=timeout, user_agent=USER_AGENT)
+
     result = client.get(url, headers=headers or {}, **kwargs)
     if not result.is_ok or result.response is None:
         raise result.err if result.err else RuntimeError(f"GET failed for {url}")
@@ -208,8 +221,23 @@ def _ckan_search_params(
 
 
 def collect_ckan_inventory_via_search(
-    source_id: str, source_cfg: dict[str, Any], captured_at: str
+    source_id: str,
+    source_cfg: dict[str, Any],
+    captured_at: str,
+    *,
+    client: Any | None = None,
 ) -> list[dict[str, Any]]:
+    """Inventory via paginated package_search.
+
+    Args:
+        client: Opzionale, ``HttpClient`` riusabile per connection pooling.
+            Se non fornito, ne crea uno nuovo.
+    """
+    from lab_connectors.http import HttpClient
+
+    if client is None:
+        client = HttpClient(timeout=60, user_agent=USER_AGENT)
+
     endpoint = ckan_action_endpoint(source_cfg["base_url"], "package_search")
     page_size = 1000
     start = 0
@@ -218,7 +246,9 @@ def collect_ckan_inventory_via_search(
 
     while True:
         payload = ckan_get_json(
-            endpoint, params=_ckan_search_params(source_cfg, page_size=page_size, start=start)
+            endpoint,
+            client=client,
+            params=_ckan_search_params(source_cfg, page_size=page_size, start=start),
         )
         if not payload.get("success"):
             raise ValueError(f"CKAN package_search failed for {source_id}")
@@ -260,6 +290,7 @@ def _fetch_ckan_chunk_with_fallback(
     request_timeout: int,
     max_retries: int,
     retry_delay: float,
+    client: Any | None = None,
 ) -> tuple[dict[str, Any] | None, str | None, int]:
     current_limit = page_size
 
@@ -268,6 +299,7 @@ def _fetch_ckan_chunk_with_fallback(
             try:
                 payload = ckan_get_json(
                     endpoint,
+                    client=client,
                     params={**params, "limit": current_limit},
                     timeout=request_timeout,
                 )
@@ -293,8 +325,16 @@ def _fetch_ckan_chunk_with_fallback(
 
 
 def collect_ckan_inventory_via_current_list(
-    source_id: str, source_cfg: dict[str, Any], captured_at: str
+    source_id: str,
+    source_cfg: dict[str, Any],
+    captured_at: str,
+    *,
+    client: Any | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    from lab_connectors.http import HttpClient
+
+    if client is None:
+        client = HttpClient(timeout=15, user_agent=USER_AGENT)
     endpoint = ckan_action_endpoint(source_cfg["base_url"], "current_package_list_with_resources")
     page_size = 100
     fallback_page_sizes = (50, 10)
@@ -310,6 +350,7 @@ def collect_ckan_inventory_via_current_list(
             endpoint,
             {"offset": offset},
             page_size,
+            client=client,
             fallback_page_sizes=fallback_page_sizes,
             request_timeout=request_timeout,
             max_retries=max_retries,
@@ -367,10 +408,18 @@ def collect_ckan_inventory_via_current_list(
 
 
 def collect_ckan_inventory_via_package_list(
-    source_id: str, source_cfg: dict[str, Any], captured_at: str
+    source_id: str,
+    source_cfg: dict[str, Any],
+    captured_at: str,
+    *,
+    client: Any | None = None,
 ) -> list[dict[str, Any]]:
+    from lab_connectors.http import HttpClient
+
+    if client is None:
+        client = HttpClient(timeout=60, user_agent=USER_AGENT)
     endpoint = ckan_action_endpoint(source_cfg["base_url"], "package_list")
-    payload = ckan_get_json(endpoint)
+    payload = ckan_get_json(endpoint, client=client)
     if not payload.get("success"):
         raise ValueError(f"CKAN action failed for {source_id}")
 
@@ -507,17 +556,23 @@ def collect(
     source_cfg: dict[str, Any],
     captured_at: str,
     *,
+    client: Any | None = None,
     search_fn=collect_ckan_inventory_via_search,
     current_list_fn=collect_ckan_inventory_via_current_list,
     package_list_fn=collect_ckan_inventory_via_package_list,
     package_show_sample_fn=collect_ckan_inventory_via_package_show_sample,
 ) -> CollectorResult:
+    from lab_connectors.http import HttpClient
+
+    if client is None:
+        client = HttpClient(timeout=60, user_agent=USER_AGENT)
     inv = inventory_cfg(source_cfg)
     rows, warning = _ckan_standard_path(
         source_id=source_id,
         source_cfg=source_cfg,
         captured_at=captured_at,
         inv=inv,
+        client=client,
         search_fn=search_fn,
         current_list_fn=current_list_fn,
         package_list_fn=package_list_fn,
@@ -531,17 +586,22 @@ def _ckan_standard_path(
     source_cfg: dict[str, Any],
     captured_at: str,
     inv: dict[str, Any],
+    *,
+    client: Any | None = None,
     search_fn,
     current_list_fn,
     package_list_fn,
     package_show_sample_fn,
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    """Ramo standard: package_search -> fallback package_list -> current_list."""
+    """Ramo standard: package_search -> fallback package_list -> current_list.
+
+    Tutte le funzioni di inventory ricevono il client condiviso per connection pooling.
+    """
     search_exc: Exception | None = None
 
     if not inv.get("skip_package_search"):
         try:
-            rows = search_fn(source_id, source_cfg, captured_at)
+            rows = search_fn(source_id, source_cfg, captured_at, client=client)
             return rows, None
         except Exception as exc:
             search_exc = exc  # per debug
@@ -550,7 +610,7 @@ def _ckan_standard_path(
             f"CKAN package_search disabled for {source_id} ({inv.get('skip_package_search_reason', 'disabled by registry config')})."
         )
 
-    package_list_rows = package_list_fn(source_id, source_cfg, captured_at)
+    package_list_rows = package_list_fn(source_id, source_cfg, captured_at, client=client)
     if inv.get("skip_current_list"):
         if inv.get("package_show_sample"):
             enriched_rows, sample_warning = package_show_sample_fn(
@@ -586,7 +646,9 @@ def _ckan_standard_path(
 
     time.sleep(1.0)
     try:
-        current_rows, current_warning = current_list_fn(source_id, source_cfg, captured_at)
+        current_rows, current_warning = current_list_fn(
+            source_id, source_cfg, captured_at, client=client
+        )
         enriched_by_id = {row["item_id"]: row for row in current_rows}
         fallback_merged_rows: list[dict[str, Any]] = []
         missing_metadata = 0

--- a/so_mcp/_artifact.py
+++ b/so_mcp/_artifact.py
@@ -1,12 +1,14 @@
 """
 Shared artifact infrastructure for SO MCP modules.
 
-Path constants, artifact resolution (local/GCS), env loading, format maps,
-and helper utilities used by all other ``so_mcp/_*.py`` modules.
+Path constants, artifact resolution (local/GCS), env loading, and helper
+utilities used by all other ``so_mcp/_*.py`` modules.
 
 Sibling modules import via ``import _artifact``, relying on ``so_mcp/`` being
 in ``sys.path`` (added automatically when running ``python so_mcp/so_server.py``
 or via conftest for tests).
+
+Path constants live in ``so_mcp/_paths.py`` — imported normally, no sys.path hack.
 """
 
 from __future__ import annotations
@@ -14,7 +16,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 import tempfile
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
@@ -26,18 +27,7 @@ import duckdb
 from lab_connectors.gcs.paths import CLEAN_BUCKET
 from lab_connectors.http import HttpClient
 
-# ── Repo root & path setup ────────────────────────────────────────────────────
-# Aggiunge scripts/ a sys.path per importare _constants e altri moduli scripts
-# senza ricorrere a importlib. Idempotente: se già in path, non fa nulla.
-
-_REPO_ROOT = Path(__file__).resolve().parents[1]
-_SCRIPTS_DIR = str(_REPO_ROOT / "scripts")
-if _SCRIPTS_DIR not in sys.path:
-    sys.path.insert(0, _SCRIPTS_DIR)
-
-# ── Artifact paths (canonical source: scripts/_constants.py) ──────────────────
-
-from _constants import (  # noqa: E402
+from ._paths import (
     CATALOG_INVENTORY_REPORT_PATH,
     CATALOG_SIGNALS_PATH,
     CHECK_PARQUET_PATH,
@@ -47,6 +37,9 @@ from _constants import (  # noqa: E402
     REGISTRY_PATH,
     STATUS_MD_PATH,
 )
+
+# Repo root for relative path display and env file resolution.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
 
 _CHECK_PARQUET = CHECK_PARQUET_PATH
 _INVENTORY_PARQUET = INVENTORY_PARQUET_PATH

--- a/so_mcp/_artifact.py
+++ b/so_mcp/_artifact.py
@@ -4,9 +4,8 @@ Shared artifact infrastructure for SO MCP modules.
 Path constants, artifact resolution (local/GCS), env loading, and helper
 utilities used by all other ``so_mcp/_*.py`` modules.
 
-Sibling modules import via ``import _artifact``, relying on ``so_mcp/`` being
-in ``sys.path`` (added automatically when running ``python so_mcp/so_server.py``
-or via conftest for tests).
+Sibling modules import via ``from . import _artifact`` (package-relative import,
+relying on ``so_mcp/`` being installed or ``so_mcp/`` being in ``sys.path``).
 
 Path constants live in ``so_mcp/_paths.py`` — imported normally, no sys.path hack.
 """

--- a/so_mcp/_artifact.py
+++ b/so_mcp/_artifact.py
@@ -61,39 +61,6 @@ _SOURCE_CHECK_ARTIFACT = "source_check_results.parquet"
 _CATALOG_INVENTORY_ARTIFACT = "catalog_inventory_latest.parquet"
 _CATALOG_INVENTORY_REPORT_ARTIFACT = "catalog_inventory_report.json"
 
-# ── Format maps ───────────────────────────────────────────────────────────────
-
-_FORMAT_BY_CONTENT_TYPE: dict[str, str] = {
-    "text/csv": "CSV",
-    "application/json": "JSON",
-    "application/ld+json": "JSON",
-    "application/vnd.ms-excel": "XLS",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
-    "application/xml": "XML",
-    "text/xml": "XML",
-    "application/pdf": "PDF",
-    "application/parquet": "PARQUET",
-    "text/html": "HTML",
-    "text/plain": "TXT",
-    "application/octet-stream": "BIN",
-    "text/tab-separated-values": "TSV",
-    "application/gzip": "GZ",
-    "application/zip": "ZIP",
-    "application/x-tar": "TAR",
-    "application/vnd.oasis.opendocument.spreadsheet": "ODS",
-}
-_FORMAT_BY_SUFFIX: dict[str, str] = {
-    ".csv": "CSV",
-    ".json": "JSON",
-    ".geojson": "JSON",
-    ".xlsx": "XLSX",
-    ".xls": "XLS",
-    ".xml": "XML",
-    ".pdf": "PDF",
-    ".parquet": "PARQUET",
-    ".zip": "ZIP",
-}
-
 # ── Env loading (lazy, once) ─────────────────────────────────────────────────
 
 _ENV_LOADED = False

--- a/so_mcp/_paths.py
+++ b/so_mcp/_paths.py
@@ -1,0 +1,29 @@
+"""
+Canonical artifact paths for SO artifacts.
+
+Separated from ``scripts/_constants.py`` so that ``so_mcp/`` modules
+can import path constants without a ``sys.path`` hack.
+"""
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# ── Registry ──────────────────────────────────────────────────────────────────
+REGISTRY_PATH = _REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
+
+# ── Radar (scripts/radar_check.py → so_mcp/_radar.py) ────────────────────────
+RADAR_SUMMARY_PATH = _REPO_ROOT / "data" / "radar" / "radar_summary.json"
+RADAR_HISTORY_PATH = _REPO_ROOT / "data" / "radar" / "radar_history.json"
+STATUS_MD_PATH = _REPO_ROOT / "data" / "radar" / "STATUS.md"
+
+# ── Catalog inventory (scripts/build_catalog_inventory.py → so_mcp/_inventory.py) ─
+CATALOG_INVENTORY_DIR_PATH = _REPO_ROOT / "data" / "catalog_inventory" / "generated"
+INVENTORY_PARQUET_PATH = CATALOG_INVENTORY_DIR_PATH / "catalog_inventory_latest.parquet"
+CATALOG_INVENTORY_REPORT_PATH = CATALOG_INVENTORY_DIR_PATH / "catalog_inventory_report.json"
+
+# ── Source check (scripts/bulk_source_check.py → so_mcp/_signals.py) ─────────
+CHECK_PARQUET_PATH = (
+    _REPO_ROOT / "data" / "catalog_inventory" / "generated" / "source_check_results.parquet"
+)
+CATALOG_SIGNALS_PATH = _REPO_ROOT / "data" / "catalog" / "catalog_signals.json"

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -22,7 +22,7 @@ def test_collect_ckan_inventory_merges_current_list_metadata(monkeypatch) -> Non
     def fake_search(*_args, **_kwargs):
         raise ValueError("package_search rotto")
 
-    def fake_package_list(source_id, source_cfg, captured_at):
+    def fake_package_list(source_id, source_cfg, captured_at, **kwargs):
         return [
             {
                 "captured_at": captured_at,
@@ -58,7 +58,7 @@ def test_collect_ckan_inventory_merges_current_list_metadata(monkeypatch) -> Non
             },
         ]
 
-    def fake_current_list(source_id, source_cfg, captured_at):
+    def fake_current_list(source_id, source_cfg, captured_at, **kwargs):
         return (
             [
                 {
@@ -123,7 +123,7 @@ def test_collect_ckan_inventory_skips_current_list_for_inps(monkeypatch) -> None
     def fake_search(*_args, **_kwargs):
         raise ValueError("package_search rotto")
 
-    def fake_package_list(source_id, source_cfg, captured_at):
+    def fake_package_list(source_id, source_cfg, captured_at, **kwargs):
         return [
             {
                 "captured_at": captured_at,
@@ -190,7 +190,7 @@ def test_collect_ckan_inventory_inps_enriches_with_package_show_sample(monkeypat
     def fake_search(*_args, **_kwargs):
         raise ValueError("package_search rotto")
 
-    def fake_package_list(source_id, source_cfg, captured_at):
+    def fake_package_list(source_id, source_cfg, captured_at, **kwargs):
         return [
             {
                 "captured_at": captured_at,

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -280,14 +280,16 @@ def test_collect_ckan_inventory_inps_enriches_with_package_show_sample(monkeypat
 
 
 def test_ckan_get_json_reports_non_json_response(monkeypatch) -> None:
-    def fake_get(*_args, **_kwargs):
-        return fake_response(
+    fake = FakeHttpClient()
+    fake.responses["https://example.test/api/3/action/package_list"] = HttpResult(
+        response=fake_response(
             200,
             text="<html>Request Rejected</html>",
             headers={"content-type": "text/html"},
-        )
-
-    monkeypatch.setattr(collectors.ckan, "observatory_get", fake_get)
+        ),
+        err=None,
+    )
+    monkeypatch.setattr("lab_connectors.http.HttpClient", lambda *a, **kw: fake)
 
     try:
         collectors.ckan.ckan_get_json("https://example.test/api/3/action/package_list")


### PR DESCRIPTION
## Sintesi

Fase 1 della ristrutturazione di Source Observatory alla luce delle capacità attuali di toolkit e lab-connectors. Quattro commit indipendenti, nessuna regressione (362 test passano).

## Contesto collegato

Nessuna issue aperta — lavoro emerso da analisi strutturale del repo.

## Cosa cambia

- [x] Eliminato sys.path hack in `so_mcp/_artifact.py`: spostate le costanti di path in `so_mcp/_paths.py`
- [x] Rimosse `_FORMAT_BY_*` zombie maps (dead code, toolkit ha già `resolve_preview_kind`)
- [x] Rimosso wrapper `observatory_get()`: `ckan_get_json` ora usa `HttpClient` direttamente
- [x] Connection pooling nei collector CKAN: `HttpClient` condiviso tra chiamate paginate (invece di uno nuovo per ogni GET)
- [x] Documentazione (`docs/architecture.md`) aggiornata
- [ ] Altro

## Checklist

- [x] `pytest tests/` passa (362 su 362)
- [x] `ruff check .` passa
- [x] `docs/architecture.md` aggiornato

## Verifica

- Tutti e 4 i commit hanno test verde CI (362 test)
- Ogni commit è indipendente e cross-checkato con `pytest`
- Backward compat: parametro `client=None` su tutte le nuove funzioni

## Note per chi revisiona

- `so_mcp/_paths.py` è nuovo: contiene le stesse costanti di `scripts/_constants.py` per i soli path. La duplicazione è intenzionale — `_constants.py` ha utility aggiuntive (validate_schema, stale_reason, load/save registry) che non servono a MCP.
- `ckan_get_json` ora gestisce `client` via kwargs.pop, non come parametro posizionale — zero impatto sui chiamanti esistenti.
- Il connection pooling è attivo solo per le funzioni chiamate attraverso `collect()` / `_ckan_standard_path()`. I chiamanti diretti delle funzioni di inventory (package_list, search, current_list) continuano a creare un client proprio — upgrade possibile in futuro.