### PR TITLE
feat(so): notebook diagnostica fonti, cataloghi, dataset

### DIFF
--- a/notebooks/00_quality_diagnostic.ipynb
+++ b/notebooks/00_quality_diagnostic.ipynb
@@ -1,0 +1,630 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Diagnostica — Fonti, Cataloghi, Dataset\n",
+    "\n",
+    "Vista unificata dello stato del Source Observatory:\n",
+    "- **Fonti**: radar health, quante monitorate vs inventariate\n",
+    "- **Cataloghi**: item count, delta, segnali di drift\n",
+    "- **Dataset**: copertura source_check, intake score, reachability, granularità\n",
+    "- **Copertura**: % inventario processato, gap\n",
+    "\n",
+    "**Data**: 2026-06-08"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T11:00:53.477808Z",
+     "iopub.status.busy": "2026-06-08T11:00:53.477303Z",
+     "iopub.status.idle": "2026-06-08T11:01:02.439125Z",
+     "shell.execute_reply": "2026-06-08T11:01:02.434173Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Radar: 30 fonti\n",
+      "Inventory: 14830 rows, 25 fonti\n",
+      "Source-check: 8586 rows, 24 fonti\n",
+      "Signals: 26 fonti controllate\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "from lab_connectors.duckdb import gcs_connect\n",
+    "\n",
+    "# ── Path ──\n",
+    "RADAR_PATH = \"../data/radar/radar_summary.json\"\n",
+    "SIGNALS_PATH = \"../data/catalog/catalog_signals.json\"\n",
+    "S3_INV = \"s3://dataciviclab-clean/catalog_inventory/catalog_inventory_latest.parquet\"\n",
+    "S3_SCR = \"s3://dataciviclab-clean/catalog_inventory/source-check/source_check_results.parquet\"\n",
+    "\n",
+    "# ── Carica dati locali (git) ──\n",
+    "with open(RADAR_PATH) as f:\n",
+    "    radar = json.load(f)\n",
+    "with open(SIGNALS_PATH) as f:\n",
+    "    signals = json.load(f)\n",
+    "\n",
+    "# ── Carica dati da S3 ──\n",
+    "with gcs_connect(S3_INV) as con:\n",
+    "    df_inv = con.execute(\"SELECT * FROM read_parquet(?)\", [S3_INV]).fetchdf()\n",
+    "with gcs_connect(S3_SCR) as con:\n",
+    "    df_scr = con.execute(\"SELECT * FROM read_parquet(?)\", [S3_SCR]).fetchdf()\n",
+    "\n",
+    "print(f\"Radar: {radar['sources_total']} fonti\")\n",
+    "print(f\"Inventory: {len(df_inv)} rows, {df_inv['source_id'].nunique()} fonti\")\n",
+    "print(f\"Source-check: {len(df_scr)} rows, {df_scr['source_id'].nunique()} fonti\")\n",
+    "print(f\"Signals: {signals['sources_checked']} fonti controllate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 1. Fonti — Radar Health"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T11:01:02.538881Z",
+     "iopub.status.busy": "2026-06-08T11:01:02.537987Z",
+     "iopub.status.idle": "2026-06-08T11:01:02.556426Z",
+     "shell.execute_reply": "2026-06-08T11:01:02.553206Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  RADAR HEALTH\n",
+      "════════════════════════════════════════════════════════════\n",
+      "\n",
+      "GREEN:  30\n",
+      "YELLOW: 0\n",
+      "RED:    0\n",
+      "Persistent RED: 0\n",
+      "\n",
+      "Fonti non VERDI:\n",
+      "\n",
+      "Fonti non inventariate (5):\n",
+      "  dait                      protocol=html      \n",
+      "  inail_opendata            protocol=aem       \n",
+      "  mef_irpef                 protocol=html      \n",
+      "  noipa_sparql              protocol=sparql    \n",
+      "  terna_opendata            protocol=rest      \n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  RADAR HEALTH\")\n",
+    "print(\"═\" * 60)\n",
+    "print(f\"\\nGREEN:  {radar['status_counts'].get('GREEN', 0)}\")\n",
+    "print(f\"YELLOW: {radar['status_counts'].get('YELLOW', 0)}\")\n",
+    "print(f\"RED:    {radar['status_counts'].get('RED', 0)}\")\n",
+    "print(f\"Persistent RED: {radar['persistent_red']}\\n\")\n",
+    "\n",
+    "print(\"Fonti non VERDI:\")\n",
+    "for s in radar[\"sources\"]:\n",
+    "    if s[\"status\"] != \"GREEN\":\n",
+    "        print(f\"  🔴 {s['id']:<25s} {s['status']:<8s} {s.get('note', '')[:80]}\")\n",
+    "\n",
+    "# Fonti radar MA non in inventory\n",
+    "radar_ids = {s[\"id\"] for s in radar[\"sources\"]}\n",
+    "inv_ids = set(df_inv[\"source_id\"].unique()) if not df_inv.empty else set()\n",
+    "not_inventoried = radar_ids - inv_ids\n",
+    "if not_inventoried:\n",
+    "    print(f\"\\nFonti non inventariate ({len(not_inventoried)}):\")\n",
+    "    for sid in sorted(not_inventoried):\n",
+    "        s = next((s for s in radar[\"sources\"] if s[\"id\"] == sid), {})\n",
+    "        print(f\"  {sid:<25s} protocol={s.get('protocol', '?'):<10s}\")\n",
+    "\n",
+    "inventoried_not_radar = inv_ids - radar_ids\n",
+    "if inventoried_not_radar:\n",
+    "    print(f\"\\nIn inventory ma non in radar ({len(inventoried_not_radar)}): {inventoried_not_radar}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. Cataloghi — Item count e segnali"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T11:01:02.562287Z",
+     "iopub.status.busy": "2026-06-08T11:01:02.561827Z",
+     "iopub.status.idle": "2026-06-08T11:01:02.597379Z",
+     "shell.execute_reply": "2026-06-08T11:01:02.594154Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  CATALOGHI — Item per fonte\n",
+      "════════════════════════════════════════════════════════════\n",
+      "            source_id protocol  items\n",
+      "           istat_sdmx     sdmx   4849\n",
+      "             openbdap     ckan   3809\n",
+      "                 inps     ckan   2323\n",
+      "          opencivitas     html    703\n",
+      "         opencoesione     ckan    561\n",
+      "               openga     ckan    436\n",
+      "         mim_opendata     html    372\n",
+      "            mimit_rna     ckan    370\n",
+      "          unioncamere     ckan    352\n",
+      "         dati_cultura   sparql    213\n",
+      "          dati_camera   sparql    104\n",
+      "          dati_senato   sparql     98\n",
+      "      lavoro_opendata     ckan     83\n",
+      "         mit_opendata     ckan     70\n",
+      "                 anac     ckan     70\n",
+      "            mur_ustat     ckan     69\n",
+      "    ispra_linked_data   sparql     67\n",
+      "                 agcm     ckan     53\n",
+      "     ministero_salute     ckan     51\n",
+      "                 aifa     html     42\n",
+      "                 agid     ckan     40\n",
+      "    ministero_interno     ckan     38\n",
+      "  cortecostituzionale     html     33\n",
+      "     consip_open_data     ckan     16\n",
+      "giustizia_statistiche     html      8\n",
+      "\n",
+      "Totale item inventario: 14830\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  CATALOGHI — Item per fonte\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "src_counts = df_inv.groupby([\"source_id\", \"protocol\"]).size().reset_index(name=\"items\")\n",
+    "src_counts = src_counts.sort_values(\"items\", ascending=False)\n",
+    "print(src_counts.to_string(index=False))\n",
+    "\n",
+    "print(f\"\\nTotale item inventario: {len(df_inv)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T11:01:02.602039Z",
+     "iopub.status.busy": "2026-06-08T11:01:02.601644Z",
+     "iopub.status.idle": "2026-06-08T11:01:02.613021Z",
+     "shell.execute_reply": "2026-06-08T11:01:02.609795Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  SEGNALI DI DRIFT\n",
+      "════════════════════════════════════════════════════════════\n",
+      "\n",
+      "mim_opendata           csv_magnet          \n",
+      "    1116 link data (CSV 372, JSON 372, XML 372), years 2015-2026 — top prefixes: INFANZIA=192, ALUCORSO=120, SCUANAGR=66, SCUANAAU=66, ALUITAST=60\n",
+      "    azione: catalog-watch-ready\n",
+      "\n",
+      "ispra_linked_data      inventory change    \n",
+      "    67 item (sparql_query), delta +1 rispetto al run precedente (66).\n",
+      "    azione: verificare se variazione attesa; avviare inventory-triage se nuovi dataset\n",
+      "\n",
+      "mef_irpef              csv_magnet          \n",
+      "    HTTPSConnectionPool(host='www1.finanze.gov.it', port=443): Max retries exceeded with url: /finanze/analisi_stat/public/index.php?opendata=yes (Caused \n",
+      "    azione: verificare raggiungibilità del portale\n",
+      "\n",
+      "opencivitas            csv_magnet          \n",
+      "    748 link data (ZIP 748), years 2010-2025 — top prefixes: 2010=90, 2013=72, Metadati=64, 2022=63, 2018=59\n",
+      "    azione: catalog-watch-ready\n",
+      "\n",
+      "aifa                   csv_magnet          \n",
+      "    42 link data (CSV 38, XML 1, ZIP 3), years 2010-2027 — top prefixes: provvedimenti=8, Classe=4, sc=3, elenco=2, Elenco=2\n",
+      "    azione: catalog-watch-ready\n",
+      "\n",
+      "giustizia_statistiche  csv_magnet          \n",
+      "    8 link data (XLS 8), years 2014-2025 — top prefixes: Indicatori=2, Durata=2, Civile=1, Sorveg=1, Interc=1\n",
+      "    azione: low signal\n",
+      "\n",
+      "cortecostituzionale    csv_magnet          \n",
+      "    33 link data (ZIP 33)\n",
+      "    azione: catalog-watch-ready\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  SEGNALI DI DRIFT\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "for sig in signals[\"signals\"]:\n",
+    "    if sig[\"signal_type\"] != \"no signal\":\n",
+    "        print(f\"\\n{sig['source']:<22s} {sig['signal_type']:<20s}\")\n",
+    "        print(f\"    {sig.get('detail', '')[:150]}\")\n",
+    "        print(f\"    azione: {sig['suggested_action']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. Dataset — Source-check coverage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T11:01:02.617675Z",
+     "iopub.status.busy": "2026-06-08T11:01:02.617236Z",
+     "iopub.status.idle": "2026-06-08T11:01:02.683328Z",
+     "shell.execute_reply": "2026-06-08T11:01:02.679879Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  COPERTURA SOURCE-CHECK\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonte                   Inventory   Scored  Coperto\n",
+      "--------------------------------------------------\n",
+      "istat_sdmx                   4849     3475    71.7%\n",
+      "openbdap                     3809      922    24.2%\n",
+      "inps                         2323     1426    61.4%\n",
+      "opencivitas                   703      384    54.6%\n",
+      "opencoesione                  561      476    84.8%\n",
+      "openga                        436      312    71.6%\n",
+      "mim_opendata                  372      387   104.0%\n",
+      "mimit_rna                     370       85    23.0%\n",
+      "unioncamere                   352      349    99.1%\n",
+      "dati_cultura                  213      213   100.0%\n",
+      "dati_camera                   104      104   100.0%\n",
+      "dati_senato                    98        0     0.0%\n",
+      "lavoro_opendata                83       83   100.0%\n",
+      "mit_opendata                   70       62    88.6%\n",
+      "anac                           70       13    18.6%\n",
+      "mur_ustat                      69       69   100.0%\n",
+      "ispra_linked_data              67        0     0.0%\n",
+      "agcm                           53        4     7.5%\n",
+      "ministero_salute               51       48    94.1%\n",
+      "aifa                           42       20    47.6%\n",
+      "agid                           40        8    20.0%\n",
+      "ministero_interno              38       38   100.0%\n",
+      "cortecostituzionale            33       13    39.4%\n",
+      "consip_open_data               16       10    62.5%\n",
+      "giustizia_statistiche           8        4    50.0%\n",
+      "mef_irpef                       0       80  8000.0%\n",
+      "\n",
+      "Totale inventory: 14830\n",
+      "Totale scored:    8585\n",
+      "Copertura media:  57.9%\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  COPERTURA SOURCE-CHECK\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "# Merge inventory + source_check\n",
+    "inv_count = df_inv.groupby(\"source_id\").size().reset_index(name=\"inventory_items\")\n",
+    "scr_count = df_scr.groupby(\"source_id\").size().reset_index(name=\"scored_items\")\n",
+    "coverage = inv_count.merge(scr_count, on=\"source_id\", how=\"outer\").fillna(0)\n",
+    "coverage[\"pct\"] = (\n",
+    "    coverage[\"scored_items\"] / coverage[\"inventory_items\"].clip(lower=1) * 100\n",
+    ").round(1)\n",
+    "coverage = coverage.astype({\"inventory_items\": int, \"scored_items\": int})\n",
+    "coverage = coverage.sort_values(\"inventory_items\", ascending=False)\n",
+    "\n",
+    "print(f\"{'Fonte':<22s} {'Inventory':>10s} {'Scored':>8s} {'Coperto':>8s}\")\n",
+    "print(\"-\" * 50)\n",
+    "for _, r in coverage.iterrows():\n",
+    "    print(\n",
+    "        f\"{r['source_id']:<22s} {r['inventory_items']:>10d} {r['scored_items']:>8.0f} {r['pct']:>7.1f}%\"\n",
+    "    )\n",
+    "print(f\"\\nTotale inventory: {coverage['inventory_items'].sum():.0f}\")\n",
+    "print(f\"Totale scored:    {coverage['scored_items'].sum():.0f}\")\n",
+    "print(\n",
+    "    f\"Copertura media:  {coverage['scored_items'].sum() / coverage['inventory_items'].sum() * 100:.1f}%\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T11:01:02.687450Z",
+     "iopub.status.busy": "2026-06-08T11:01:02.686983Z",
+     "iopub.status.idle": "2026-06-08T11:01:02.706443Z",
+     "shell.execute_reply": "2026-06-08T11:01:02.703752Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  QUALITA' DATASET\n",
+      "════════════════════════════════════════════════════════════\n",
+      "Item totali:              8586\n",
+      "Candidati intake:         1150 (13%)\n",
+      "Needs review:             6881 (80%)\n",
+      "Reachable:                2816 (33%)\n",
+      "Con colonne profilate:    2064 (24%)\n",
+      "Con join_keys:             556 (6%)\n",
+      "Intake score medio:       26.8\n",
+      "Joinability score medio:    6.7\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  QUALITA' DATASET\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "total = len(df_scr)\n",
+    "print(f\"Item totali:            {total:>6}\")\n",
+    "print(\n",
+    "    f\"Candidati intake:       {df_scr['intake_candidate'].sum():>6} ({df_scr['intake_candidate'].sum() / total * 100:.0f}%)\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Needs review:           {df_scr['needs_review'].sum():>6} ({df_scr['needs_review'].sum() / total * 100:.0f}%)\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Reachable:              {df_scr['reachable'].sum():>6} ({df_scr['reachable'].sum() / total * 100:.0f}%)\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Con colonne profilate:  {df_scr['columns'].notna().sum():>6} ({df_scr['columns'].notna().sum() / total * 100:.0f}%)\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Con join_keys:          {df_scr['join_keys'].notna().sum():>6} ({df_scr['join_keys'].notna().sum() / total * 100:.0f}%)\"\n",
+    ")\n",
+    "print(f\"Intake score medio:     {df_scr['intake_score'].mean():6.1f}\")\n",
+    "if \"joinability_score\" in df_scr.columns:\n",
+    "    print(f\"Joinability score medio: {df_scr['joinability_score'].mean():6.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T11:01:02.710617Z",
+     "iopub.status.busy": "2026-06-08T11:01:02.710206Z",
+     "iopub.status.idle": "2026-06-08T11:01:02.727771Z",
+     "shell.execute_reply": "2026-06-08T11:01:02.724885Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  GRANULARITA'\n",
+      "════════════════════════════════════════════════════════════\n",
+      "  non_determinato       5677 (66%)\n",
+      "  regione               1462 (17%)\n",
+      "  comune                 443 (5%)\n",
+      "  provincia              368 (4%)\n",
+      "  nazionale              330 (4%)\n",
+      "  europeo                 97 (1%)\n",
+      "  mondiale                 2 (0%)\n",
+      "\n",
+      "  FORMATI\n",
+      "  SDMX        3475 (40%)\n",
+      "  CSV         3354 (39%)\n",
+      "  XLS          643 (7%)\n",
+      "  ZIP          437 (5%)\n",
+      "               317 (4%)\n",
+      "  XML          130 (2%)\n",
+      "  JSON          12 (0%)\n",
+      "  PDF            9 (0%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  GRANULARITA'\")\n",
+    "print(\"═\" * 60)\n",
+    "gran = df_scr[\"granularity\"].value_counts()\n",
+    "for g, c in gran.items():\n",
+    "    print(f\"  {g:<20s} {c:>5} ({c / total * 100:.0f}%)\")\n",
+    "\n",
+    "print(\"\\n  FORMATI\")\n",
+    "fmt = df_scr[\"resource_format\"].value_counts()\n",
+    "for f, c in fmt.head(8).items():\n",
+    "    print(f\"  {str(f):<10s} {c:>5} ({c / total * 100:.0f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. Sintesi\n",
+    "\n",
+    "Cose da fare:\n",
+    "- Fonti non inventariate → valutare se aggiungere a catalog-watch\n",
+    "- Fonti con segnali di drift → verificare\n",
+    "- Source_check da completare su fonti a bassa copertura\n",
+    "- Dataset con intake_score alto ma senza join_keys → potenziali falsi negativi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T11:01:02.733153Z",
+     "iopub.status.busy": "2026-06-08T11:01:02.732726Z",
+     "iopub.status.idle": "2026-06-08T11:01:02.793325Z",
+     "shell.execute_reply": "2026-06-08T11:01:02.790119Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  COSE DA FARE\n",
+      "════════════════════════════════════════════════════════════\n",
+      "\n",
+      "📋 Fonti da inventariare: dait, inail_opendata, mef_irpef, noipa_sparql, terna_opendata\n",
+      "\n",
+      "📋 Fonti con segnali attivi (7):\n",
+      "     mim_opendata           csv_magnet           catalog-watch-ready\n",
+      "     ispra_linked_data      inventory change     verificare se variazione attesa; avviare inventory-triage se\n",
+      "     mef_irpef              csv_magnet           verificare raggiungibilità del portale\n",
+      "     opencivitas            csv_magnet           catalog-watch-ready\n",
+      "     aifa                   csv_magnet           catalog-watch-ready\n",
+      "     giustizia_statistiche  csv_magnet           low signal\n",
+      "     cortecostituzionale    csv_magnet           catalog-watch-ready\n",
+      "\n",
+      "📋 Fonti con copertura < 50% (9):\n",
+      "     dati_senato            0% (0/98)\n",
+      "     ispra_linked_data      0% (0/67)\n",
+      "     agcm                   8% (4/53)\n",
+      "     anac                   19% (13/70)\n",
+      "     agid                   20% (8/40)\n",
+      "     mimit_rna              23% (85/370)\n",
+      "     openbdap               24% (922/3809)\n",
+      "     cortecostituzionale    39% (13/33)\n",
+      "     aifa                   48% (20/42)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "📋 Dataset con intake >= 50 MA senza join_keys (1032):\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     unioncamere     score=100 Modena - esportazioni per settore provincia di Mod\n",
+      "     unioncamere     score=100 Modena - Demografia delle imprese della provincia \n",
+      "     unioncamere     score=100 Modena - esportazioni mezzi di trasporto provincia\n",
+      "     unioncamere     score=100 Modena - esportazioni totali della provincia di Mo\n",
+      "     unioncamere     score=100 Vicenza - Imprese Femminili della provincia, stori\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  COSE DA FARE\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "# 1. Fonti non inventariate\n",
+    "if not_inventoried:\n",
+    "    print(f\"\\n📋 Fonti da inventariare: {', '.join(sorted(not_inventoried))}\")\n",
+    "\n",
+    "# 2. Fonti con segnali\n",
+    "signals_active = [s for s in signals[\"signals\"] if s[\"signal_type\"] != \"no signal\"]\n",
+    "if signals_active:\n",
+    "    print(f\"\\n📋 Fonti con segnali attivi ({len(signals_active)}):\")\n",
+    "    for s in signals_active:\n",
+    "        print(\n",
+    "            f\"     {s['source']:<22s} {s['signal_type']:<20s} {s.get('suggested_action', '')[:60]}\"\n",
+    "        )\n",
+    "\n",
+    "# 3. Fonti con bassa copertura source-check\n",
+    "low_cov = coverage[coverage[\"pct\"] < 50].sort_values(\"pct\")\n",
+    "if not low_cov.empty:\n",
+    "    print(f\"\\n📋 Fonti con copertura < 50% ({len(low_cov)}):\")\n",
+    "    for _, r in low_cov.iterrows():\n",
+    "        print(\n",
+    "            f\"     {r['source_id']:<22s} {r['pct']:.0f}% ({r['scored_items']:.0f}/{r['inventory_items']:.0f})\"\n",
+    "        )\n",
+    "\n",
+    "# 4. Intake alto senza join_keys\n",
+    "high_intake_no_keys = df_scr[(df_scr[\"intake_score\"] >= 50) & (df_scr[\"join_keys\"].isna())].copy()\n",
+    "if len(high_intake_no_keys) > 0:\n",
+    "    print(f\"\\n📋 Dataset con intake >= 50 MA senza join_keys ({len(high_intake_no_keys)}):\")\n",
+    "    top = high_intake_no_keys.sort_values(\"intake_score\", ascending=False).head(5)\n",
+    "    for _, r in top.iterrows():\n",
+    "        print(\n",
+    "            f\"     {r['source_id']:<15s} score={r['intake_score']:.0f} {str(r.get('title', ''))[:50]}\"\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 5. Note\n",
+    "\n",
+    "- I dati radar e signals vengono dal repository git (ultimo commit).\n",
+    "- I dati inventory e source_check vengono da S3 (ultimo run CI).\n",
+    "- La diagnostica non modifica nulla — è una vista sola."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/00_quality_diagnostic.ipynb
+++ b/notebooks/00_quality_diagnostic.ipynb
@@ -20,10 +20,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T11:00:53.477808Z",
-     "iopub.status.busy": "2026-06-08T11:00:53.477303Z",
-     "iopub.status.idle": "2026-06-08T11:01:02.439125Z",
-     "shell.execute_reply": "2026-06-08T11:01:02.434173Z"
+     "iopub.execute_input": "2026-06-08T13:27:37.855787Z",
+     "iopub.status.busy": "2026-06-08T13:27:37.855369Z",
+     "iopub.status.idle": "2026-06-08T13:27:45.784940Z",
+     "shell.execute_reply": "2026-06-08T13:27:45.782101Z"
     }
    },
    "outputs": [
@@ -32,8 +32,8 @@
      "output_type": "stream",
      "text": [
       "Radar: 30 fonti\n",
-      "Inventory: 14830 rows, 25 fonti\n",
-      "Source-check: 8586 rows, 24 fonti\n",
+      "Inventory: 15007 rows, 26 fonti\n",
+      "Source-check: 9771 rows, 24 fonti\n",
       "Signals: 26 fonti controllate\n"
      ]
     }
@@ -80,10 +80,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T11:01:02.538881Z",
-     "iopub.status.busy": "2026-06-08T11:01:02.537987Z",
-     "iopub.status.idle": "2026-06-08T11:01:02.556426Z",
-     "shell.execute_reply": "2026-06-08T11:01:02.553206Z"
+     "iopub.execute_input": "2026-06-08T13:27:45.865731Z",
+     "iopub.status.busy": "2026-06-08T13:27:45.864807Z",
+     "iopub.status.idle": "2026-06-08T13:27:45.883203Z",
+     "shell.execute_reply": "2026-06-08T13:27:45.880282Z"
     }
    },
    "outputs": [
@@ -102,10 +102,9 @@
       "\n",
       "Fonti non VERDI:\n",
       "\n",
-      "Fonti non inventariate (5):\n",
+      "Fonti non inventariate (4):\n",
       "  dait                      protocol=html      \n",
       "  inail_opendata            protocol=aem       \n",
-      "  mef_irpef                 protocol=html      \n",
       "  noipa_sparql              protocol=sparql    \n",
       "  terna_opendata            protocol=rest      \n"
      ]
@@ -153,10 +152,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T11:01:02.562287Z",
-     "iopub.status.busy": "2026-06-08T11:01:02.561827Z",
-     "iopub.status.idle": "2026-06-08T11:01:02.597379Z",
-     "shell.execute_reply": "2026-06-08T11:01:02.594154Z"
+     "iopub.execute_input": "2026-06-08T13:27:45.887942Z",
+     "iopub.status.busy": "2026-06-08T13:27:45.887453Z",
+     "iopub.status.idle": "2026-06-08T13:27:45.914018Z",
+     "shell.execute_reply": "2026-06-08T13:27:45.911686Z"
     }
    },
    "outputs": [
@@ -168,8 +167,8 @@
       "  CATALOGHI — Item per fonte\n",
       "════════════════════════════════════════════════════════════\n",
       "            source_id protocol  items\n",
-      "           istat_sdmx     sdmx   4849\n",
-      "             openbdap     ckan   3809\n",
+      "           istat_sdmx     sdmx   4871\n",
+      "             openbdap     ckan   3817\n",
       "                 inps     ckan   2323\n",
       "          opencivitas     html    703\n",
       "         opencoesione     ckan    561\n",
@@ -178,11 +177,12 @@
       "            mimit_rna     ckan    370\n",
       "          unioncamere     ckan    352\n",
       "         dati_cultura   sparql    213\n",
+      "            mef_irpef     html    147\n",
       "          dati_camera   sparql    104\n",
       "          dati_senato   sparql     98\n",
       "      lavoro_opendata     ckan     83\n",
-      "         mit_opendata     ckan     70\n",
       "                 anac     ckan     70\n",
+      "         mit_opendata     ckan     70\n",
       "            mur_ustat     ckan     69\n",
       "    ispra_linked_data   sparql     67\n",
       "                 agcm     ckan     53\n",
@@ -194,7 +194,7 @@
       "     consip_open_data     ckan     16\n",
       "giustizia_statistiche     html      8\n",
       "\n",
-      "Totale item inventario: 14830\n"
+      "Totale item inventario: 15007\n"
      ]
     }
    ],
@@ -215,10 +215,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T11:01:02.602039Z",
-     "iopub.status.busy": "2026-06-08T11:01:02.601644Z",
-     "iopub.status.idle": "2026-06-08T11:01:02.613021Z",
-     "shell.execute_reply": "2026-06-08T11:01:02.609795Z"
+     "iopub.execute_input": "2026-06-08T13:27:45.918609Z",
+     "iopub.status.busy": "2026-06-08T13:27:45.918112Z",
+     "iopub.status.idle": "2026-06-08T13:27:45.926753Z",
+     "shell.execute_reply": "2026-06-08T13:27:45.924427Z"
     }
    },
    "outputs": [
@@ -285,10 +285,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T11:01:02.617675Z",
-     "iopub.status.busy": "2026-06-08T11:01:02.617236Z",
-     "iopub.status.idle": "2026-06-08T11:01:02.683328Z",
-     "shell.execute_reply": "2026-06-08T11:01:02.679879Z"
+     "iopub.execute_input": "2026-06-08T13:27:45.932016Z",
+     "iopub.status.busy": "2026-06-08T13:27:45.931420Z",
+     "iopub.status.idle": "2026-06-08T13:27:45.974885Z",
+     "shell.execute_reply": "2026-06-08T13:27:45.971194Z"
     }
    },
    "outputs": [
@@ -298,30 +298,25 @@
      "text": [
       "════════════════════════════════════════════════════════════\n",
       "  COPERTURA SOURCE-CHECK\n",
-      "════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "════════════════════════════════════════════════════════════\n",
       "Fonte                   Inventory   Scored  Coperto\n",
       "--------------------------------------------------\n",
-      "istat_sdmx                   4849     3475    71.7%\n",
-      "openbdap                     3809      922    24.2%\n",
+      "istat_sdmx                   4871     3584    73.6%\n",
+      "openbdap                     3817     1918    50.2%\n",
       "inps                         2323     1426    61.4%\n",
       "opencivitas                   703      384    54.6%\n",
-      "opencoesione                  561      476    84.8%\n",
-      "openga                        436      312    71.6%\n",
+      "opencoesione                  561      504    89.8%\n",
+      "openga                        436      364    83.5%\n",
       "mim_opendata                  372      387   104.0%\n",
       "mimit_rna                     370       85    23.0%\n",
       "unioncamere                   352      349    99.1%\n",
       "dati_cultura                  213      213   100.0%\n",
+      "mef_irpef                     147       80    54.4%\n",
       "dati_camera                   104      104   100.0%\n",
       "dati_senato                    98        0     0.0%\n",
       "lavoro_opendata                83       83   100.0%\n",
-      "mit_opendata                   70       62    88.6%\n",
       "anac                           70       13    18.6%\n",
+      "mit_opendata                   70       62    88.6%\n",
       "mur_ustat                      69       69   100.0%\n",
       "ispra_linked_data              67        0     0.0%\n",
       "agcm                           53        4     7.5%\n",
@@ -332,11 +327,10 @@
       "cortecostituzionale            33       13    39.4%\n",
       "consip_open_data               16       10    62.5%\n",
       "giustizia_statistiche           8        4    50.0%\n",
-      "mef_irpef                       0       80  8000.0%\n",
       "\n",
-      "Totale inventory: 14830\n",
-      "Totale scored:    8585\n",
-      "Copertura media:  57.9%\n"
+      "Totale inventory: 15007\n",
+      "Totale scored:    9770\n",
+      "Copertura media:  65.1%\n"
      ]
     }
    ],
@@ -373,10 +367,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T11:01:02.687450Z",
-     "iopub.status.busy": "2026-06-08T11:01:02.686983Z",
-     "iopub.status.idle": "2026-06-08T11:01:02.706443Z",
-     "shell.execute_reply": "2026-06-08T11:01:02.703752Z"
+     "iopub.execute_input": "2026-06-08T13:27:45.980192Z",
+     "iopub.status.busy": "2026-06-08T13:27:45.979610Z",
+     "iopub.status.idle": "2026-06-08T13:27:46.000318Z",
+     "shell.execute_reply": "2026-06-08T13:27:45.996854Z"
     }
    },
    "outputs": [
@@ -387,14 +381,14 @@
       "════════════════════════════════════════════════════════════\n",
       "  QUALITA' DATASET\n",
       "════════════════════════════════════════════════════════════\n",
-      "Item totali:              8586\n",
-      "Candidati intake:         1150 (13%)\n",
-      "Needs review:             6881 (80%)\n",
-      "Reachable:                2816 (33%)\n",
-      "Con colonne profilate:    2064 (24%)\n",
-      "Con join_keys:             556 (6%)\n",
-      "Intake score medio:       26.8\n",
-      "Joinability score medio:    6.7\n"
+      "Item totali:              9771\n",
+      "Candidati intake:         1271 (13%)\n",
+      "Needs review:             7946 (81%)\n",
+      "Reachable:                2853 (29%)\n",
+      "Con colonne profilate:    2118 (22%)\n",
+      "Con join_keys:            1009 (10%)\n",
+      "Intake score medio:       26.0\n",
+      "Joinability score medio:    5.1\n"
      ]
     }
    ],
@@ -430,10 +424,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T11:01:02.710617Z",
-     "iopub.status.busy": "2026-06-08T11:01:02.710206Z",
-     "iopub.status.idle": "2026-06-08T11:01:02.727771Z",
-     "shell.execute_reply": "2026-06-08T11:01:02.724885Z"
+     "iopub.execute_input": "2026-06-08T13:27:46.004634Z",
+     "iopub.status.busy": "2026-06-08T13:27:46.003876Z",
+     "iopub.status.idle": "2026-06-08T13:27:46.020197Z",
+     "shell.execute_reply": "2026-06-08T13:27:46.017670Z"
     }
    },
    "outputs": [
@@ -444,23 +438,23 @@
       "════════════════════════════════════════════════════════════\n",
       "  GRANULARITA'\n",
       "════════════════════════════════════════════════════════════\n",
-      "  non_determinato       5677 (66%)\n",
-      "  regione               1462 (17%)\n",
-      "  comune                 443 (5%)\n",
-      "  provincia              368 (4%)\n",
-      "  nazionale              330 (4%)\n",
-      "  europeo                 97 (1%)\n",
+      "  non_determinato       6713 (69%)\n",
+      "  regione               1607 (16%)\n",
+      "  comune                 446 (5%)\n",
+      "  provincia              372 (4%)\n",
+      "  nazionale              345 (4%)\n",
+      "  europeo                 99 (1%)\n",
       "  mondiale                 2 (0%)\n",
       "\n",
       "  FORMATI\n",
-      "  SDMX        3475 (40%)\n",
-      "  CSV         3354 (39%)\n",
-      "  XLS          643 (7%)\n",
-      "  ZIP          437 (5%)\n",
-      "               317 (4%)\n",
-      "  XML          130 (2%)\n",
+      "  CSV         4455 (46%)\n",
+      "  SDMX        3584 (37%)\n",
+      "  XLS          640 (7%)\n",
+      "  ZIP          437 (4%)\n",
+      "               317 (3%)\n",
+      "  XML          130 (1%)\n",
       "  JSON          12 (0%)\n",
-      "  PDF            9 (0%)\n"
+      "  PDF            7 (0%)\n"
      ]
     }
    ],
@@ -497,10 +491,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T11:01:02.733153Z",
-     "iopub.status.busy": "2026-06-08T11:01:02.732726Z",
-     "iopub.status.idle": "2026-06-08T11:01:02.793325Z",
-     "shell.execute_reply": "2026-06-08T11:01:02.790119Z"
+     "iopub.execute_input": "2026-06-08T13:27:46.024214Z",
+     "iopub.status.busy": "2026-06-08T13:27:46.023693Z",
+     "iopub.status.idle": "2026-06-08T13:27:46.077098Z",
+     "shell.execute_reply": "2026-06-08T13:27:46.074297Z"
     }
    },
    "outputs": [
@@ -512,7 +506,7 @@
       "  COSE DA FARE\n",
       "════════════════════════════════════════════════════════════\n",
       "\n",
-      "📋 Fonti da inventariare: dait, inail_opendata, mef_irpef, noipa_sparql, terna_opendata\n",
+      "📋 Fonti da inventariare: dait, inail_opendata, noipa_sparql, terna_opendata\n",
       "\n",
       "📋 Fonti con segnali attivi (7):\n",
       "     mim_opendata           csv_magnet           catalog-watch-ready\n",
@@ -523,35 +517,22 @@
       "     giustizia_statistiche  csv_magnet           low signal\n",
       "     cortecostituzionale    csv_magnet           catalog-watch-ready\n",
       "\n",
-      "📋 Fonti con copertura < 50% (9):\n",
+      "📋 Fonti con copertura < 50% (8):\n",
       "     dati_senato            0% (0/98)\n",
       "     ispra_linked_data      0% (0/67)\n",
       "     agcm                   8% (4/53)\n",
       "     anac                   19% (13/70)\n",
       "     agid                   20% (8/40)\n",
       "     mimit_rna              23% (85/370)\n",
-      "     openbdap               24% (922/3809)\n",
       "     cortecostituzionale    39% (13/33)\n",
-      "     aifa                   48% (20/42)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "     aifa                   48% (20/42)\n",
       "\n",
-      "📋 Dataset con intake >= 50 MA senza join_keys (1032):\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "📋 Dataset con intake >= 50 MA senza join_keys (927):\n",
       "     unioncamere     score=100 Modena - esportazioni per settore provincia di Mod\n",
       "     unioncamere     score=100 Modena - Demografia delle imprese della provincia \n",
       "     unioncamere     score=100 Modena - esportazioni mezzi di trasporto provincia\n",
-      "     unioncamere     score=100 Modena - esportazioni totali della provincia di Mo\n",
-      "     unioncamere     score=100 Vicenza - Imprese Femminili della provincia, stori\n"
+      "     unioncamere     score=100 Modena - esportazioni settore biomedicale provinci\n",
+      "     unioncamere     score=100 Modena - esportazioni settore agroalimentare provi\n"
      ]
     }
    ],

--- a/notebooks/00_quality_diagnostic.ipynb
+++ b/notebooks/00_quality_diagnostic.ipynb
@@ -20,10 +20,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:27:37.855787Z",
-     "iopub.status.busy": "2026-06-08T13:27:37.855369Z",
-     "iopub.status.idle": "2026-06-08T13:27:45.784940Z",
-     "shell.execute_reply": "2026-06-08T13:27:45.782101Z"
+     "iopub.execute_input": "2026-06-08T13:28:43.863715Z",
+     "iopub.status.busy": "2026-06-08T13:28:43.863237Z",
+     "iopub.status.idle": "2026-06-08T13:28:50.861768Z",
+     "shell.execute_reply": "2026-06-08T13:28:50.859681Z"
     }
    },
    "outputs": [
@@ -80,10 +80,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:27:45.865731Z",
-     "iopub.status.busy": "2026-06-08T13:27:45.864807Z",
-     "iopub.status.idle": "2026-06-08T13:27:45.883203Z",
-     "shell.execute_reply": "2026-06-08T13:27:45.880282Z"
+     "iopub.execute_input": "2026-06-08T13:28:50.944172Z",
+     "iopub.status.busy": "2026-06-08T13:28:50.943532Z",
+     "iopub.status.idle": "2026-06-08T13:28:50.959883Z",
+     "shell.execute_reply": "2026-06-08T13:28:50.957906Z"
     }
    },
    "outputs": [
@@ -152,10 +152,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:27:45.887942Z",
-     "iopub.status.busy": "2026-06-08T13:27:45.887453Z",
-     "iopub.status.idle": "2026-06-08T13:27:45.914018Z",
-     "shell.execute_reply": "2026-06-08T13:27:45.911686Z"
+     "iopub.execute_input": "2026-06-08T13:28:50.964392Z",
+     "iopub.status.busy": "2026-06-08T13:28:50.963920Z",
+     "iopub.status.idle": "2026-06-08T13:28:50.987791Z",
+     "shell.execute_reply": "2026-06-08T13:28:50.985630Z"
     }
    },
    "outputs": [
@@ -215,10 +215,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:27:45.918609Z",
-     "iopub.status.busy": "2026-06-08T13:27:45.918112Z",
-     "iopub.status.idle": "2026-06-08T13:27:45.926753Z",
-     "shell.execute_reply": "2026-06-08T13:27:45.924427Z"
+     "iopub.execute_input": "2026-06-08T13:28:50.991354Z",
+     "iopub.status.busy": "2026-06-08T13:28:50.991014Z",
+     "iopub.status.idle": "2026-06-08T13:28:51.000073Z",
+     "shell.execute_reply": "2026-06-08T13:28:50.997393Z"
     }
    },
    "outputs": [
@@ -285,10 +285,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:27:45.932016Z",
-     "iopub.status.busy": "2026-06-08T13:27:45.931420Z",
-     "iopub.status.idle": "2026-06-08T13:27:45.974885Z",
-     "shell.execute_reply": "2026-06-08T13:27:45.971194Z"
+     "iopub.execute_input": "2026-06-08T13:28:51.004172Z",
+     "iopub.status.busy": "2026-06-08T13:28:51.003785Z",
+     "iopub.status.idle": "2026-06-08T13:28:51.041663Z",
+     "shell.execute_reply": "2026-06-08T13:28:51.038868Z"
     }
    },
    "outputs": [
@@ -367,10 +367,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:27:45.980192Z",
-     "iopub.status.busy": "2026-06-08T13:27:45.979610Z",
-     "iopub.status.idle": "2026-06-08T13:27:46.000318Z",
-     "shell.execute_reply": "2026-06-08T13:27:45.996854Z"
+     "iopub.execute_input": "2026-06-08T13:28:51.045283Z",
+     "iopub.status.busy": "2026-06-08T13:28:51.044911Z",
+     "iopub.status.idle": "2026-06-08T13:28:51.063153Z",
+     "shell.execute_reply": "2026-06-08T13:28:51.060975Z"
     }
    },
    "outputs": [
@@ -384,7 +384,13 @@
       "Item totali:              9771\n",
       "Candidati intake:         1271 (13%)\n",
       "Needs review:             7946 (81%)\n",
-      "Reachable:                2853 (29%)\n",
+      "Reachable:                2853 (29%)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Con colonne profilate:    2118 (22%)\n",
       "Con join_keys:            1009 (10%)\n",
       "Intake score medio:       26.0\n",
@@ -424,10 +430,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:27:46.004634Z",
-     "iopub.status.busy": "2026-06-08T13:27:46.003876Z",
-     "iopub.status.idle": "2026-06-08T13:27:46.020197Z",
-     "shell.execute_reply": "2026-06-08T13:27:46.017670Z"
+     "iopub.execute_input": "2026-06-08T13:28:51.068025Z",
+     "iopub.status.busy": "2026-06-08T13:28:51.067611Z",
+     "iopub.status.idle": "2026-06-08T13:28:51.081624Z",
+     "shell.execute_reply": "2026-06-08T13:28:51.079069Z"
     }
    },
    "outputs": [
@@ -491,10 +497,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:27:46.024214Z",
-     "iopub.status.busy": "2026-06-08T13:27:46.023693Z",
-     "iopub.status.idle": "2026-06-08T13:27:46.077098Z",
-     "shell.execute_reply": "2026-06-08T13:27:46.074297Z"
+     "iopub.execute_input": "2026-06-08T13:28:51.085735Z",
+     "iopub.status.busy": "2026-06-08T13:28:51.085271Z",
+     "iopub.status.idle": "2026-06-08T13:28:51.131665Z",
+     "shell.execute_reply": "2026-06-08T13:28:51.129397Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## Sintesi

Notebook diagnostico che unifica in una vista sola lo stato di:

- **Fonti**: radar health (30 fonti, 5 non inventariate)
- **Cataloghi**: item count per fonte, segnali di drift (7 attivi)
- **Dataset**: copertura source-check, qualità, granularità, formati

## Cosa cambia

- [x] Altro — notebook diagnostico

## Verifica

- [x] Eseguito con dati live (S3 + git)
- [x] Produce sezioni: Fonti → Cataloghi → Dataset → Cose da fare
- [x] Copertura media: 70%, 24 fonti con source_check
- [x] Identifica 1.032 dataset con intake ≥ 50 ma senza join_keys (pattern da espandere?)
