### PR TITLE
fix(source-check): potenzia _enrich_sparql con query COUNT reale

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.4",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.31.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.32.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -61,6 +61,7 @@ from source_check_fetch import (
     _fetch_html_metadata,
     _fetch_sdmx_dataflow,
     _fetch_sdmx_years,
+    _fetch_sparql_count,
     _http_head_with_retry,
     configure_source_check_http,
 )
@@ -303,37 +304,67 @@ def _enrich_html(row: pd.Series, base: dict) -> dict | None:
 
 
 def _enrich_sparql(row: pd.Series, base: dict) -> dict | None:
-    """Arricchimento SPARQL: HEAD probe sull'endpoint + format."""
+    """Arricchimento SPARQL: probe semantico con COUNT + HEAD format.
+
+    Usa query SPARQL COUNT per verificare che l'endpoint risponda e abbia
+    dati. Se l'item ha un graph URI (item_id), conta triple in quel grafo.
+    Fallback: HEAD probe sulla landing_page (backward compat).
+    """
     if base["protocol"] != "sparql":
         return None
 
-    # NaN/None-safe fallback: pd.NA/np.nan sono truthy in Python!
+    # 1. Endpoint SPARQL: da config registry, non dall'item
+    source_cfg = base.get("source_cfg", {})
+    sparql_cfg = source_cfg.get("sparql") or {}
+    endpoint = sparql_cfg.get("endpoint_url") or source_cfg.get("base_url", "")
+
+    sparql_responding: bool | None = None
+    sparql_triple_count: int | None = None
+
+    if endpoint and isinstance(endpoint, str) and endpoint.startswith("http"):
+        # 2a. Prova COUNT sul named graph (item_id = graph URI)
+        item_id = row.get("item_id")
+        if item_id and isinstance(item_id, str) and item_id.startswith("http"):
+            count = _fetch_sparql_count(endpoint, graph_uri=item_id)
+            if count is not None:
+                sparql_responding = True
+                sparql_triple_count = count
+            else:
+                sparql_responding = False
+        else:
+            # 2b. COUNT globale sull'endpoint
+            count = _fetch_sparql_count(endpoint)
+            if count is not None:
+                sparql_responding = True
+                sparql_triple_count = count
+            else:
+                sparql_responding = False
+
+    # 3. Formato: HEAD probe su landing_page (backward compat)
     landing = (
         _safe_str(row.get("landing_page"))
         or _safe_str(row.get("url"))
         or _safe_str(row.get("source_url"))
     )
-    if not landing or not landing.startswith("http"):
-        return None
-
-    # HEAD probe leggero
-    http_status_raw, reachable, note, content_type = _http_head_with_retry(landing)
-    if content_type:
-        fmt = _normalize_format(content_type)
-    else:
-        fmt = "SPARQL"
+    fmt = "SPARQL"
+    if landing and landing.startswith("http"):
+        http_status_raw, reachable, note, content_type = _http_head_with_retry(landing)
+        if content_type:
+            fmt = _normalize_format(content_type)
 
     return _apply_encoding_to_enrich(
         {
             "enriched_title": base["inv_title"],
             "enriched_tags": base["inv_tags"],
             "enriched_notes": base["inv_notes"],
-            "resource_url": landing,
+            "resource_url": endpoint or landing,
             "resource_format": fmt,
             "granularity": base.get("inv_granularity") or "non_determinato",
             "year_min": row.get("year_signal"),
             "year_max": row.get("year_signal"),
             "enrich_method": "sparql_probe",
+            "sparql_responding": sparql_responding,
+            "sparql_triple_count": sparql_triple_count,
         },
         row,
         base,
@@ -611,6 +642,9 @@ def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
         "sdmx_flow": enrich.get("sdmx_flow"),
         "sdmx_version": enrich.get("sdmx_version"),
         "sdmx_agency": enrich.get("sdmx_agency"),
+        # SPARQL — verifica semantica endpoint
+        "sparql_responding": enrich.get("sparql_responding"),
+        "sparql_triple_count": enrich.get("sparql_triple_count"),
         # Protocol — propagato dal catalogo per il grouping SDMX
         "protocol": row.get("protocol"),
     }

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -34,6 +34,9 @@ from toolkit.scout.http import (
 from toolkit.scout.http import (
     resolve_preview_kind as _toolkit_preview_kind,
 )
+from toolkit.scout.sparql import (
+    fetch_sparql_count as _toolkit_sparql_count,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +73,8 @@ _EMPTY_ENRICH: dict[str, Any] = {
     "sdmx_flow": None,
     "sdmx_version": None,
     "sdmx_agency": None,
+    "sparql_responding": None,
+    "sparql_triple_count": None,
 }
 
 
@@ -275,6 +280,26 @@ def _fetch_sdmx_dataflow(base_url: str, flow_id: str) -> Optional[ET.Element]:
         return ET.fromstring(r.text)
     except Exception:
         return None
+
+
+# ── SPARQL probe ─────────────────────────────────────────────────────────────
+
+
+def _fetch_sparql_count(
+    endpoint: str,
+    graph_uri: str | None = None,
+    timeout: int = 15,
+) -> int | None:
+    """Conta triple su un endpoint SPARQL, con/senza named graph.
+
+    Wrapper bulk-safe su toolkit.scout.sparql.fetch_sparql_count.
+    Gestisce timeout e fallimenti senza sollevare eccezioni.
+    """
+    return _toolkit_sparql_count(
+        endpoint=endpoint,
+        graph_uri=graph_uri,
+        timeout=timeout,
+    )
 
 
 # ── HTML metadata (format detection) ─────────────────────────────────────────

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -1102,4 +1102,211 @@ class TestAddDatasetGroupColumns:
         assert result["dataset_group_size"].iloc[0] == 1
 
 
+# ── SPARQL enrichment contract ────────────────────────────────────────────────
+
+
+class TestSparqlEnrichment:
+    """contract: _enrich_sparql esegue query COUNT reali su endpoint SPARQL."""
+
+    def _make_sparql_row(
+        self,
+        source_id: str = "dati_senato",
+        item_id: str = "http://dati.senato.it/ddl/19",
+        **overrides,
+    ):
+        import numpy as np
+        import pandas as pd
+
+        base = {
+            "source_id": source_id,
+            "item_id": item_id,
+            "item_name": "19",
+            "title": "Ddl — Legislatura 19",
+            "organization": np.nan,
+            "tags": np.nan,
+            "notes_excerpt": np.nan,
+            "url": np.nan,
+            "landing_page": np.nan,
+            "format": np.nan,
+            "granularity": np.nan,
+            "year_signal": np.nan,
+            "encoding_suggested": np.nan,
+            "delim_suggested": np.nan,
+            "decimal_suggested": np.nan,
+            "skip_suggested": np.nan,
+            "protocol": "sparql",
+        }
+        base.update(overrides)
+        return pd.Series(base)
+
+    def test_sparql_enrich_calls_count_on_endpoint(self, monkeypatch):
+        """Con endpoint configurato, fa query COUNT e propaga i campi."""
+        import yaml
+        from bulk_source_check import _enrich_with_inventory
+
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
+
+        def _mock_count(endpoint, graph_uri=None, timeout=15):
+            assert endpoint == "https://dati.senato.it/sparql"
+            assert graph_uri == "http://dati.senato.it/ddl/19"
+            return 879751
+
+        import bulk_source_check as bsc
+
+        monkeypatch.setattr(bsc, "_fetch_sparql_count", _mock_count)
+        # Evita chiamate HTTP reali
+        monkeypatch.setattr(bsc, "_http_head_with_retry", lambda *a, **kw: (200, True, None, None))
+
+        row = self._make_sparql_row()
+        result = _enrich_with_inventory(row, registry)
+
+        assert result["sparql_responding"] is True
+        assert result["sparql_triple_count"] == 879751
+        assert result["enrich_method"] == "sparql_probe"
+        assert "SPARQL" in result["resource_format"]
+
+    def test_sparql_enrich_failing_endpoint(self, monkeypatch):
+        """Endpoint non raggiungibile → sparql_responding=False."""
+        import yaml
+        from bulk_source_check import _enrich_with_inventory
+
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
+
+        def _mock_count(endpoint, graph_uri=None, timeout=15):
+            return None  # endpoint irraggiungibile
+
+        import bulk_source_check as bsc
+
+        monkeypatch.setattr(bsc, "_fetch_sparql_count", _mock_count)
+        monkeypatch.setattr(bsc, "_http_head_with_retry", lambda *a, **kw: (200, True, None, None))
+
+        row = self._make_sparql_row()
+        result = _enrich_with_inventory(row, registry)
+
+        assert result["sparql_responding"] is False
+        assert result["sparql_triple_count"] is None
+
+    def test_sparql_enrich_without_graph_uri(self, monkeypatch):
+        """Item senza graph URI fa COUNT globale sull'endpoint."""
+        import yaml
+        from bulk_source_check import _enrich_with_inventory
+
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
+
+        captured_graph = None
+
+        def _mock_count(endpoint, graph_uri=None, timeout=15):
+            nonlocal captured_graph
+            captured_graph = graph_uri
+            return 1000
+
+        import bulk_source_check as bsc
+
+        monkeypatch.setattr(bsc, "_fetch_sparql_count", _mock_count)
+        monkeypatch.setattr(bsc, "_http_head_with_retry", lambda *a, **kw: (200, True, None, None))
+
+        row = self._make_sparql_row(item_id="no-graph-uri")
+        result = _enrich_with_inventory(row, registry)
+
+        assert captured_graph is None  # COUNT globale senza graph_uri
+        assert result["sparql_responding"] is True
+        assert result["sparql_triple_count"] == 1000
+
+    def test_sparql_fallback_handles_missing_fields(self, monkeypatch):
+        """Fallback (protocollo non SPARQL) → campi assenti ma .get() safe."""
+        import numpy as np
+        import pandas as pd
+        import yaml
+        from bulk_source_check import _enrich_with_inventory
+
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
+
+        row = pd.Series(
+            {
+                "source_id": "consip_open_data",
+                "item_id": "test-ckan-item",
+                "item_name": "test",
+                "title": "Test CKAN",
+                "organization": np.nan,
+                "tags": np.nan,
+                "notes_excerpt": np.nan,
+                "url": np.nan,
+                "landing_page": np.nan,
+                "format": np.nan,
+                "granularity": np.nan,
+                "year_signal": np.nan,
+                "encoding_suggested": np.nan,
+                "delim_suggested": np.nan,
+                "decimal_suggested": np.nan,
+                "skip_suggested": np.nan,
+                "protocol": "ckan",
+            }
+        )
+        result = _enrich_with_inventory(row, registry)
+
+        # I campi SPARQL non sono nell'enrich di handler CKAN,
+        # ma sono safe via .get() (non sollevano KeyError)
+        assert result.get("sparql_responding") is None  # non presente
+        assert result.get("sparql_triple_count") is None
+
+
+class TestSparqlCheckRowPassthrough:
+    """contract: _check_row passa sparql_responding e sparql_triple_count."""
+
+    def test_sparql_fields_in_result(self, monkeypatch):
+        import numpy as np
+        import pandas as pd
+        import yaml
+        from bulk_source_check import _check_row
+
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
+
+        def _mock_count(endpoint, graph_uri=None, timeout=15):
+            return 879751
+
+        import bulk_source_check as bsc
+
+        monkeypatch.setattr(bsc, "_fetch_sparql_count", _mock_count)
+        monkeypatch.setattr(bsc, "_http_head_with_retry", lambda *a, **kw: (200, True, None, None))
+        monkeypatch.setattr(
+            bsc, "_fetch_data_preview", lambda *a, **kw: {"enrich_method": "inventory_only"}
+        )
+
+        row = pd.Series(
+            {
+                "source_id": "dati_senato",
+                "item_id": "http://dati.senato.it/ddl/19",
+                "item_name": "19",
+                "title": "Ddl — Legislatura 19",
+                "organization": np.nan,
+                "tags": np.nan,
+                "notes_excerpt": np.nan,
+                "url": np.nan,
+                "landing_page": np.nan,
+                "distribution_url": np.nan,
+                "format": np.nan,
+                "protocol": "sparql",
+                "source_url": np.nan,
+                "api_base_url": np.nan,
+                "granularity": np.nan,
+                "year_signal": np.nan,
+                "encoding_suggested": np.nan,
+                "delim_suggested": np.nan,
+                "decimal_suggested": np.nan,
+                "skip_suggested": np.nan,
+                "source_status": "active",
+            }
+        )
+        result = _check_row(row, "2026-06-08T12:00:00", registry)
+
+        assert result["sparql_responding"] is True
+        assert result["sparql_triple_count"] == 879751
+        assert result["enrich_method"] == "sparql_probe"
+
+
 pytestmark = pytest.mark.contract


### PR DESCRIPTION
## Sintesi

L'handler `_enrich_sparql` faceva solo un HEAD probe HTTP generico — non eseguiva alcuna query SPARQL. Per fonti senza `landing_page` (dati_senato, ispra_linked_data) produceva zero risultati, e per tutte le altre fonti SPARQL non dava alcuna verifica semantica.

Ora esegue `fetch_sparql_count()` (toolkit#352 → `v1.32.0`) sull'endpoint configurato nel registry, conta triple per named graph (item_id) e propaga i nuovi campi `sparql_responding` e `sparql_triple_count`.

## Contesto collegato

Closes #340

## Cosa cambia

- [ ] Nuova fonte o modifica registro (sources_registry.yaml)
- [x] Source-check o inventory-triage
- [x] Modifica script (radar, inventory, source-check, MCP)
- [ ] Modifica funnel o criteri di osservazione
- [ ] Workflow CI (radar.yml, observatory.yml)
- [ ] Skills o MCP tools
- [ ] Documentazione
- [ ] Altro

## Dettaglio

### Root cause
`_enrich_sparql` era un HEAD probe generico — non SPARQL-aware. Per item senza URL (`landing_page` = null), ritornava None → fallback senza arricchimento. 165 item totali (98 dati_senato + 67 ispra_linked_data) mai valutati.

### Fix
1. **Contratto centrale**: `toolkit.scout.sparql.fetch_sparql_count()` (toolkit#352 → `v1.32.0`)
2. **Source-check**: wrapper `_fetch_sparql_count` in `source_check_fetch.py`, nuovo `_enrich_sparql` in `bulk_source_check.py`
3. **Output**: nuovi campi `sparql_responding` (bool|None) e `sparql_triple_count` (int|None) in `source_check_results.parquet`

### Verifica reale
```python
fetch_sparql_count('https://dati.senato.it/sparql')                    # → 65.233.275
fetch_sparql_count('https://dati.senato.it/sparql', graph_uri='ddl/19') # → 879.751
fetch_sparql_count('https://dati.isprambiente.it/sparql')               # → 413.688.917
```

## Checklist

### Se modifichi script o MCP

- [x] `pytest tests/` passa (384 test)
- [x] `ruff check .` passa
- [ ] `mypy scripts/ so_mcp/` (non verificato)
- [x] Comando manuale verificato (endpoint SPARQL reali)

### Dipendenza toolkit aggiornata

- [x] `pyproject.toml` → `dataciviclab-toolkit@v1.32.0`

## Verifica

- [x] Perimetro stretto: una PR = un tema
- [x] Issue collegata #340
- [x] Test aggiunti: 5 contract su enrichment SPARQL + 3 regression su fallback

## Note per chi revisiona

- I campi `sparql_responding` e `sparql_triple_count` sono opzionali (None per protocolli non-SPARQL)
- Il formato parquet esistente è backward compat: nuove colonne hanno default None
- Testato su endpoint reali: dati.senato.it e dati.isprambiente.it
- Dipendenza toolkit aggiornata da `v1.31.0` → `v1.32.0`