### PR TITLE
feat(registry): aggiungi PagoPA S.p.A. al sources registry

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -13,8 +13,8 @@ istat_sdmx:
     method: dataflow_count
     reliability: medium
     note: Re-baseline su endpoint esploradati (MCP ondata). Il valore 4212 e' il
-      conteggio riproducibile via MCP discover_dataflows (no keyword, no 
-      blacklist) dopo filtro NonProductionDataflow. Il valore 509 era il 
+      conteggio riproducibile via MCP discover_dataflows (no keyword, no
+      blacklist) dopo filtro NonProductionDataflow. Il valore 509 era il
       conteggio su sdmx.istat.it (endpoint diverso).
   verdict: go
   note: Endpoint SDMX ricco e ad alto valore per scouting e source-check.
@@ -33,8 +33,8 @@ anac:
     fq: organization:anac
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con fq=organization:anac 
-      restituisce tutti i 70 dataset ANAC con metadata completi. current_list 
+    skip_current_list_reason: package_search con fq=organization:anac
+      restituisce tutti i 70 dataset ANAC con metadata completi. current_list
       non necessario.
   last_probed: '2026-06-11'
   catalog_baseline:
@@ -43,7 +43,7 @@ anac:
     value: 70
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:anac su dati.gov.it. 
+    note: Conteggio via package_search con fq=organization:anac su dati.gov.it.
       70 dataset harvestati dal portale ANAC.
   verdict: go
   note: 'Fonte via dati.gov.it (harvesting ANAC). I download raw vanno al portale
@@ -70,11 +70,11 @@ inps:
     value: 2323
     method: package_list
     reliability: high
-    note: Inventory via package_list + package_show_sample (16 workers). 
-      current_package_list_with_resources testato ma scartato per lentezza a 
+    note: Inventory via package_list + package_show_sample (16 workers).
+      current_package_list_with_resources testato ma scartato per lentezza a
       offset alti. package_show_sample più veloce.
   verdict: go
-  note: Catalogo CKAN INPS — inventory via package_list + package_show_sample 
+  note: Catalogo CKAN INPS — inventory via package_list + package_show_sample
     (current_package_list_with_resources lento a offset alti).
   datasets_in_use:
     - inps_pensioni_trimestrale
@@ -83,7 +83,7 @@ openbdap:
   source_kind: catalog
   protocol: ckan
   observation_mode: catalog-watch
-  base_url: 
+  base_url:
     https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
   inventory:
     timeout: 600
@@ -99,10 +99,10 @@ openbdap:
     value: 3772
     method: package_list
     reliability: medium
-    note: Conteggio totale package rilevati via package_list; package_search 
+    note: Conteggio totale package rilevati via package_list; package_search
       restituisce count inaffidabile.
   verdict: go
-  note: Catalogo CKAN molto ricco; osservazione iniziale stretta a livello 
+  note: Catalogo CKAN molto ricco; osservazione iniziale stretta a livello
     inventario senza intake o monitor diffuso.
   datasets_in_use:
     - bdap_anagrafe_enti
@@ -117,9 +117,9 @@ inail_opendata:
   base_url: https://dati.inail.it/
   last_probed: '2026-06-11'
   verdict: go
-  note: Portale AEM con Open API documentate. Superficie operativa reale = 
-    catalogo AEM + Open API, non CKAN standard (logo nel footer fuorviante). 
-    Baseline inventariale non ancora difendibile; tenere in radar-only finche' 
+  note: Portale AEM con Open API documentate. Superficie operativa reale =
+    catalogo AEM + Open API, non CKAN standard (logo nel footer fuorviante).
+    Baseline inventariale non ancora difendibile; tenere in radar-only finche'
     non definito un metodo stabile.
   datasets_in_use: []
 mim_opendata:
@@ -138,7 +138,7 @@ mim_opendata:
       Personale, Valutazione, Edilizia, Adozioni). 1116 link CSV/XLS. Prefix: ALU=300,
       EDI=282, SCU=132. Nessuna sitemap disponibile.'
   verdict: go
-  note: Portale Ministero Istruzione — csv_magnet scan via area_pages (no 
+  note: Portale Ministero Istruzione — csv_magnet scan via area_pages (no
     sitemap).
   html_portal:
     topic_hint: istruzione
@@ -168,7 +168,7 @@ dati_camera:
     method: sparql_query
     query_name: camera_dcat
     reliability: medium
-    note: Baseline fissata con query custom Camera perché il catalogo usa 
+    note: Baseline fissata con query custom Camera perché il catalogo usa
       proprietà DC 1.1 Elements per titolo e descrizione.
   sparql:
     endpoint_url: https://dati.camera.it/sparql
@@ -182,8 +182,8 @@ dati_camera:
       \  OPTIONAL { ?dataset dct:modified ?modified . }\n  OPTIONAL { ?dataset dcat:landingPage
       ?landingPage . }\n}\nORDER BY ?dataset\nLIMIT 5000\n"
   verdict: go
-  note: Catalogo linked-data Camera inventariabile via query SPARQL custom. Il 
-    template DCAT generico non valorizza titolo e descrizione perché l'endpoint 
+  note: Catalogo linked-data Camera inventariabile via query SPARQL custom. Il
+    template DCAT generico non valorizza titolo e descrizione perché l'endpoint
     usa dc:title e dc:description.
   datasets_in_use:
     - camera_deputati_legislature
@@ -195,7 +195,7 @@ dati_senato:
   base_url: https://dati.senato.it/sparql
   inventory:
     timeout: 600
-    timeout_reason: 99 query SPARQL (1 discover + 98 schema enrich × 15 pred). 
+    timeout_reason: 99 query SPARQL (1 discover + 98 schema enrich × 15 pred).
       stimate 5s/query su Virtuoso. 99 × 5 × 1.2 = 594s
   last_probed: '2026-06-11'
   catalog_baseline:
@@ -205,8 +205,8 @@ dati_senato:
     method: named_graphs
     query_name: named_graphs
     reliability: medium
-    note: Baseline via enumerazione named graphs SPARQL. ~98 grafi organizzati 
-      per categoria (composizione, ddl, votazioni, emendamenti, ecc.) e 
+    note: Baseline via enumerazione named graphs SPARQL. ~98 grafi organizzati
+      per categoria (composizione, ddl, votazioni, emendamenti, ecc.) e
       legislatura (01-19). Fonte non ha DCAT catalog.
   sparql:
     endpoint_url: https://dati.senato.it/sparql
@@ -227,9 +227,9 @@ dati_senato:
       - facets
       - teseo
   verdict: go
-  note: Portale Open Data Senato. SPARQL endpoint Virtuoso (GET). Inventory via 
-    enumerazione named graphs (~98 grafi categoria/legislatura). Download 
-    CSV/JSON via POST form autenticato (non crawlabile). CC BY 3.0. Speculare a 
+  note: Portale Open Data Senato. SPARQL endpoint Virtuoso (GET). Inventory via
+    enumerazione named graphs (~98 grafi categoria/legislatura). Download
+    CSV/JSON via POST form autenticato (non crawlabile). CC BY 3.0. Speculare a
     dati_camera ma senza DCAT catalog.
   datasets_in_use: []
 dati_cultura:
@@ -245,8 +245,8 @@ dati_cultura:
     method: sparql_query
     query_name: dcat_datasets
     reliability: medium
-    note: Catalogo linked-data MiC (ArCo) con metadati DCAT interrogabili via 
-      SPARQL. ~150 dataset/thesaurus nel catalogo. Pilot per inventory SPARQL 
+    note: Catalogo linked-data MiC (ArCo) con metadati DCAT interrogabili via
+      SPARQL. ~150 dataset/thesaurus nel catalogo. Pilot per inventory SPARQL
       oltre ISPRA.
   sparql:
     endpoint_url: https://dati.cultura.gov.it/sparql
@@ -254,7 +254,7 @@ dati_cultura:
     limit: 5000
     timeout_seconds: 90
   verdict: go
-  note: Catalogo ArCo MiC inventariabile via SPARQL DCAT. Source-check 
+  note: Catalogo ArCo MiC inventariabile via SPARQL DCAT. Source-check
     completato con verdict catalog-watch.
   datasets_in_use: []
 ispra_linked_data:
@@ -276,8 +276,8 @@ ispra_linked_data:
     query_name: dcat_datasets
     limit: 5000
   verdict: go
-  note: Catalogo linked-data ISPRA con metadati DCAT interrogabili via SPARQL. 
-    Pilot per inventory SPARQL; non sostituisce le fonti operative ISPRA già 
+  note: Catalogo linked-data ISPRA con metadati DCAT interrogabili via SPARQL.
+    Pilot per inventory SPARQL; non sostituisce le fonti operative ISPRA già
     usate per pipeline tabellari.
   datasets_in_use:
     - ispra_consumo_suolo
@@ -296,12 +296,12 @@ consip_open_data:
     value: 17
     method: package_list
     reliability: medium
-    note: Baseline iniziale su CKAN package_list. I source-check del 2026-04-10 
-      hanno confermato almeno due dataset primari difendibili (bandi-e-gare, 
+    note: Baseline iniziale su CKAN package_list. I source-check del 2026-04-10
+      hanno confermato almeno due dataset primari difendibili (bandi-e-gare,
       consumi-convenzioni) e un support dataset chiaro (operatori-economici).
   verdict: go
-  note: Catalogo CKAN piccolo ma difendibile per catalog-watch. I source-check 
-    dataset-specifici hanno confermato che il catalogo contiene almeno due 
+  note: Catalogo CKAN piccolo ma difendibile per catalog-watch. I source-check
+    dataset-specifici hanno confermato che il catalogo contiene almeno due
     target primari e un support dataset utile per il filone Consip acquisti PA.
   datasets_in_use: []
 lavoro_opendata:
@@ -313,8 +313,8 @@ lavoro_opendata:
     fq: organization:ministero-del-lavoro
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
-      fq=organization:ministero-del-lavoro restituisce 83 dataset con metadata 
+    skip_current_list_reason: package_search con
+      fq=organization:ministero-del-lavoro restituisce 83 dataset con metadata
       completi. current_list non necessario.
   last_probed: '2026-06-11'
   catalog_baseline:
@@ -323,12 +323,12 @@ lavoro_opendata:
     value: 83
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:ministero-del-lavoro 
+    note: Conteggio via package_search con fq=organization:ministero-del-lavoro
       su dati.gov.it. 83 dataset harvestati dal portale Ministero del Lavoro.
   verdict: go
-  note: Fonte via dati.gov.it (harvesting Ministero del Lavoro). Sostituisce 
-    fonte diretta dati.lavoro.gov.it che aveva WAF. 83 dataset su lavoro 
-    (rapporti attivati/cessati, missioni, qualifiche professionali, genere, 
+  note: Fonte via dati.gov.it (harvesting Ministero del Lavoro). Sostituisce
+    fonte diretta dati.lavoro.gov.it che aveva WAF. 83 dataset su lavoro
+    (rapporti attivati/cessati, missioni, qualifiche professionali, genere,
     settore ATECO, ripartizione geografica).
   datasets_in_use: []
 mur_ustat:
@@ -340,8 +340,8 @@ mur_ustat:
     fq: organization:ministero-universita-e-ricerca
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
-      fq=organization:ministero-universita-e-ricerca restituisce 69 dataset con 
+    skip_current_list_reason: package_search con
+      fq=organization:ministero-universita-e-ricerca restituisce 69 dataset con
       metadata completi. current_list non necessario.
   last_probed: '2026-06-11'
   catalog_baseline:
@@ -350,12 +350,12 @@ mur_ustat:
     value: 69
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-universita-e-ricerca su dati.gov.it. 69 dataset 
+    note: Conteggio via package_search con
+      fq=organization:ministero-universita-e-ricerca su dati.gov.it. 69 dataset
       harvestati dal portale MUR.
   verdict: go
-  note: Fonte via dati.gov.it (harvesting MUR). Sostituisce fonte diretta 
-    dati-ustat.mur.gov.it che aveva ConnectTimeout. 69 dataset su istruzione 
+  note: Fonte via dati.gov.it (harvesting MUR). Sostituisce fonte diretta
+    dati-ustat.mur.gov.it che aveva ConnectTimeout. 69 dataset su istruzione
     universitaria (contribuzione atenei, DSU regionale, collegi, AFAM).
   datasets_in_use:
     - mur_contribuzione_universitaria
@@ -383,8 +383,8 @@ opencoesione:
     value: 561
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:pcm-opencoesione su 
-      dati.gov.it. 561 dataset harvestati da OpenCoesione (3 core + 558 
+    note: Conteggio via package_search con fq=organization:pcm-opencoesione su
+      dati.gov.it. 561 dataset harvestati da OpenCoesione (3 core + 558
       granulari per tema/ciclo/ambito).
   datasets_in_use:
     - opencoesione_progetti
@@ -392,7 +392,7 @@ mef_irpef:
   source_kind: catalog
   protocol: html
   observation_mode: catalog-watch
-  base_url: 
+  base_url:
     https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
   last_probed: '2026-06-11'
   catalog_baseline:
@@ -405,12 +405,12 @@ mef_irpef:
       totali su singola pagina statica. Nessuna sitemap ne sottopagine. Prefix: REG,
       cla, sesso, Redditi. Serie 2010-2025.'
   verdict: go
-  note: Portale MEF Dipartimento Finanze — Open Data IRPEF comunale. Dati 
+  note: Portale MEF Dipartimento Finanze — Open Data IRPEF comunale. Dati
     fiscali regionali per tipo reddito, classi, sesso. Alta rilevanza civica per
     analisi disuguaglianza e gettito regionale.
   html_portal:
     topic_hint: fisco
-    homepage: 
+    homepage:
       https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
     delay_seconds: 0.2
     probe_content_type: true
@@ -429,10 +429,10 @@ opencivitas:
     value: 1084
     method: csv_magnet_area_pages_paginated
     reliability: medium
-    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback 
+    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback
       necessario per cert invalido.
   verdict: go
-  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL 
+  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL
     fallback attivo. ZIP con CSV/XLSX dentro.
   html_portal:
     topic_hint: trasparenza
@@ -496,7 +496,7 @@ openga:
   source_kind: catalog
   protocol: ckan
   observation_mode: catalog-watch
-  base_url: 
+  base_url:
     https://openga.giustizia-amministrativa.it/api/3/action/package_list?limit=1
   last_probed: '2026-06-11'
   verdict: go
@@ -600,7 +600,7 @@ ministero_interno:
     fq: organization:ministero-dell-interno
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
+    skip_current_list_reason: package_search con
       fq=organization:ministero-dell-interno restituisce 38 dataset con metadata
       completi.
   last_probed: '2026-06-11'
@@ -610,13 +610,13 @@ ministero_interno:
     value: 38
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-dell-interno su dati.gov.it. 38 dataset su 
+    note: Conteggio via package_search con
+      fq=organization:ministero-dell-interno su dati.gov.it. 38 dataset su
       elezioni (per comune) e ANPR (popolazione).
   verdict: go
-  note: Fonte via dati.gov.it. Dati elezioni (Politiche 2022, Comunali 2024, 
-    Europee 2024, Regionali) per comune + ANPR (popolazione residente, cambi 
-    residenza, certificati, AIRE). Alto valore civico per analisi territoriale 
+  note: Fonte via dati.gov.it. Dati elezioni (Politiche 2022, Comunali 2024,
+    Europee 2024, Regionali) per comune + ANPR (popolazione residente, cambi
+    residenza, certificati, AIRE). Alto valore civico per analisi territoriale
     del voto.
   datasets_in_use: []
 agid:
@@ -628,8 +628,8 @@ agid:
     fq: organization:agenzia-per-l-italia-digitale
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
-      fq=organization:agenzia-per-l-italia-digitale restituisce 40 dataset con 
+    skip_current_list_reason: package_search con
+      fq=organization:agenzia-per-l-italia-digitale restituisce 40 dataset con
       metadata completi.
   last_probed: '2026-06-11'
   catalog_baseline:
@@ -638,8 +638,8 @@ agid:
     value: 40
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:agenzia-per-l-italia-digitale su dati.gov.it. 40 dataset 
+    note: Conteggio via package_search con
+      fq=organization:agenzia-per-l-italia-digitale su dati.gov.it. 40 dataset
       IPA (enti, PEC, domicili digitali, servizi, RTD).
   verdict: go
   note: 'Fonte via dati.gov.it. IPA — Indice delle PA: enti, unita organizzative,
@@ -653,10 +653,10 @@ noipa_sparql:
   base_url: https://sparql-noipa.mef.gov.it/sparql
   last_probed: '2026-06-11'
   verdict: hold
-  note: NoiPA SPARQL — MEF/RGS. Dati mensili personale PA (entries-{YYYYMM}, 
-    2019-2026) + pensioni PA (entriesPensioni-{YYYYMM}, 2017-oggi). ~490k 
-    soggetti/mese. L'endpoint risponde solo in XML 
-    (application/sparql-results+xml). Inventory non funzionante finché 
+  note: NoiPA SPARQL — MEF/RGS. Dati mensili personale PA (entries-{YYYYMM},
+    2019-2026) + pensioni PA (entriesPensioni-{YYYYMM}, 2017-oggi). ~490k
+    soggetti/mese. L'endpoint risponde solo in XML
+    (application/sparql-results+xml). Inventory non funzionante finché
     execute_sparql() in lab-connectors non supporta XML. Radar-only in attesa di
     parser XML o di endpoint JSON.
   datasets_in_use: []
@@ -669,8 +669,8 @@ mimit_rna:
     fq: organization:ministero-delle-imprese-e-del-made-in-italy
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
-      fq=organization:ministero-delle-imprese-e-del-made-in-italy restituisce 
+    skip_current_list_reason: package_search con
+      fq=organization:ministero-delle-imprese-e-del-made-in-italy restituisce
       370 dataset (RNA Aiuti + RNA Misure) con metadata.
   last_probed: '2026-06-11'
   catalog_baseline:
@@ -679,8 +679,8 @@ mimit_rna:
     value: 370
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-delle-imprese-e-del-made-in-italy su 
+    note: Conteggio via package_search con
+      fq=organization:ministero-delle-imprese-e-del-made-in-italy su
       dati.gov.it. 370 dataset (133 RNA Aiuti + 237 RNA Misure).
   verdict: go
   note: 'Fonte via dati.gov.it. RNA — Registro Nazionale Aiuti di Stato. 133 dataset
@@ -698,8 +698,8 @@ ministero_salute:
     fq: organization:ministero-della-salute
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
-      fq=organization:ministero-della-salute restituisce 51 dataset con 
+    skip_current_list_reason: package_search con
+      fq=organization:ministero-della-salute restituisce 51 dataset con
       metadata.
   last_probed: '2026-06-11'
   catalog_baseline:
@@ -708,9 +708,9 @@ ministero_salute:
     value: 51
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-della-salute su dati.gov.it. 51 dataset 
-      (farmacie, posti letto, personale SSN, dispositivi, ASL, fitosanitari). 
+    note: Conteggio via package_search con
+      fq=organization:ministero-della-salute su dati.gov.it. 51 dataset
+      (farmacie, posti letto, personale SSN, dispositivi, ASL, fitosanitari).
       URL raw su dati.salute.gov.it (portale in migrazione).
   verdict: go
   note: 'Fonte via dati.gov.it. Anagrafiche sanitarie nazionali: farmacie, parafarmacie,
@@ -731,8 +731,8 @@ agcm:
     fq: organization:agcm
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con fq=organization:agcm 
-      restituisce 53 dataset (rating legalita', concentrazioni). current_list 
+    skip_current_list_reason: package_search con fq=organization:agcm
+      restituisce 53 dataset (rating legalita', concentrazioni). current_list
       non necessario.
   last_probed: '2026-06-11'
   catalog_baseline:
@@ -741,7 +741,7 @@ agcm:
     value: 53
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:agcm su dati.gov.it. 
+    note: Conteggio via package_search con fq=organization:agcm su dati.gov.it.
       53 dataset (rating di legalità, operazioni di concentrazione).
   verdict: go
   note: "Fonte via dati.gov.it (AGCM). 53 dataset su concorrenza e mercato: rating
@@ -754,13 +754,13 @@ unioncamere:
   observation_mode: catalog-watch
   base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
   inventory:
-    fq: 
+    fq:
       organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
+    skip_current_list_reason: package_search con
       fq=organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
-      restituisce 352 dataset (imprese per provincia). current_list non 
+      restituisce 352 dataset (imprese per provincia). current_list non
       necessario.
   last_probed: '2026-06-11'
   catalog_baseline:
@@ -769,14 +769,36 @@ unioncamere:
     value: 352
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
+    note: Conteggio via package_search con
       fq=organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
-      su dati.gov.it. 352 dataset provincia per provincia su demografia 
-      d'impresa (natimortalità, femminili, giovanili, straniere, artigiane, 
+      su dati.gov.it. 352 dataset provincia per provincia su demografia
+      d'impresa (natimortalità, femminili, giovanili, straniere, artigiane,
       ATECO). ~340 provincia-specific, ~12 nazionali aggregati.
   verdict: go
   note: "Fonte via dati.gov.it (Unioncamere). 352 dataset su demografia d'impresa
     per provincia: femminili, giovanili, straniere, artigiane, ATECO, forma giuridica.
     Dataset prevalentemente provincia-specifici (~340). ~12 dataset nazionali aggregati
     (es. 'Italia - Imprese femminili...').\n"
+  datasets_in_use: []
+
+pagopa:
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
+  inventory:
+    fq: organization:pagopa-s-p-a
+    timeout: 180
+    skip_current_list: true
+    skip_current_list_reason: package_search con fq=organization:pagopa-s-p-a restituisce 8 dataset con metadata completi.
+  last_probed: '2026-06-11'
+  catalog_baseline:
+    captured_at: '2026-06-11'
+    metric: package_count
+    value: 8
+    method: package_search
+    reliability: high
+    note: Conteggio via package_search con fq=organization:pagopa-s-p-a su dati.gov.it. 8 dataset (transazioni pagoPA, IO App, SEND).
+  verdict: go
+  note: 'Fonte via dati.gov.it. 8 dataset: pagoPA (transazioni per anno, mese, fascia importo, categoria ente), IO App (messaggi, geografia enti e servizi), SEND (notifiche per ambito, geografia comuni, numero notifiche). Dati su digitalizzazione pagamenti PA e adozione piattaforme digitali (IO, SEND).'
   datasets_in_use: []


### PR DESCRIPTION
## Sintesi

Aggiunge PagoPA S.p.A. come fonte nel sources registry — 8 dataset su dati.gov.it su transazioni pagoPA, IO App e SEND.

## Contesto collegato

Scouting del 2026-06-10: dati.gov.it ha PagoPA S.p.A. come organizzazione con 8 dataset strutturati (CSV/JSON, serie storica dal 2016). Tema: digitalizzazione pagamenti PA.

## Cosa cambia

- [x] Nuova fonte o modifica registro (sources_registry.yaml)

## Checklist

### Se tocchi sources_registry.yaml

- [x] `radar_check.py` gestisce la nuova fonte senza errori
- [x] `observation_mode` impostato correttamente (catalog-watch)

## Verifica

- `git diff` controllato
- YAML valido (validato con `yaml.safe_load`)
- Pre-commit hook passato (trailing-whitespace, yaml, ecc.)

## Note per chi revisiona

Fonte via dati.gov.it (CKAN harvesting). 8 dataset: 3 pagoPA (transazioni per anno/mese/fascia importo/categoria ente), 2 IO App (messaggi, geografia enti), 3 SEND (notifiche per ambito, geografia comuni, numero notifiche).
