### PR TITLE
refactor(source_check): circuito breaker delegato a HttpClient

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ dependencies = [
   "jsonschema>=4.26.0",
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
-  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.4",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.32.0",
+  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.14.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.33.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -56,8 +56,6 @@ from source_check_analyze import (
 from source_check_fetch import (
     _EMPTY_ENRICH,
     SDMX_NS,
-    _content_type_format,
-    _fetch_ckan_package,
     _fetch_data_preview,
     _fetch_html_metadata,
     _fetch_sdmx_dataflow,
@@ -65,6 +63,15 @@ from source_check_fetch import (
     _fetch_sparql_count,
     _http_head_with_retry,
     configure_source_check_http,
+)
+from toolkit.scout.http import (
+    fetch_ckan_package as _toolkit_ckan_package,
+)
+from toolkit.scout.http import (
+    probe_url_headers as _toolkit_probe_headers,
+)
+from toolkit.scout.http import (
+    resolve_preview_kind as _toolkit_preview_kind,
 )
 
 logger = logging.getLogger(__name__)
@@ -228,7 +235,9 @@ def _enrich_ckan(row: pd.Series, base: dict) -> dict | None:
         if isinstance(api_base_url, str) and api_base_url.startswith("http")
         else base["base_url"]
     )
-    pkg = _fetch_ckan_package(base_api, base["item_name"])
+    parsed = urllib.parse.urlparse(base_api)
+    portal_url = f"{parsed.scheme}://{parsed.netloc}"
+    pkg = _toolkit_ckan_package(portal_url, base["item_name"])
     if pkg:
         return _parse_ckan_package(pkg)
     return None
@@ -258,10 +267,13 @@ def _enrich_html(row: pd.Series, base: dict) -> dict | None:
     def _e(r: dict) -> dict:
         return _apply_encoding_to_enrich(r, row, base)
 
-    # 1. content-type su data_url
+    # 1. content-type su data_url via toolkit (probe HEAD → format)
     data_url = row.get("url")
     if isinstance(data_url, str):
-        fmt = _content_type_format(data_url)
+        probe = _toolkit_probe_headers(data_url)
+        fmt = _toolkit_preview_kind(
+            data_url, probe.get("content_type"), probe.get("content_disposition")
+        )
         if fmt:
             return _e(
                 {

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -857,18 +857,11 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def main() -> None:
-    logging.basicConfig(format="%(levelname)s %(message)s", level=logging.INFO)
-    args = parse_args()
-    global _NO_SDMX_YEARS
-    _NO_SDMX_YEARS = args.no_sdmx_years
+def _run_source_check(http_client: HttpClient, args: argparse.Namespace) -> None:
+    """Esegue il source-check vero e proprio.
 
-    http_client = configure_source_check_http(
-        circuit_fail_threshold=args.circuit_fail_threshold,
-        http_timeout=(4, 9),
-        http_max_retries=1,
-    )
-
+    Estratta da main() per garantire chiusura del client via try/finally.
+    """
     logger.info("Loading catalog: %s", args.input)
     df = pd.read_parquet(args.input)
     logger.info("  %d total items", len(df))
@@ -1159,7 +1152,24 @@ def main() -> None:
     results = _normalize_preview_columns_for_parquet(results)
     results.to_parquet(args.out, index=False)
     logger.info("Results: %s", args.out)
-    http_client.close()
+
+
+def main() -> None:
+    """Entry point: crea il client HTTP e avvia il source-check."""
+    logging.basicConfig(format="%(levelname)s %(message)s", level=logging.INFO)
+    args = parse_args()
+    global _NO_SDMX_YEARS
+    _NO_SDMX_YEARS = args.no_sdmx_years
+
+    http_client = configure_source_check_http(
+        circuit_fail_threshold=args.circuit_fail_threshold,
+        http_timeout=(4, 9),
+        http_max_retries=1,
+    )
+    try:
+        _run_source_check(http_client, args)
+    finally:
+        http_client.close()
 
 
 if __name__ == "__main__":

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -43,6 +43,7 @@ from _constants import (
     RADAR_SUMMARY_PATH,
     REGISTRY_PATH,
 )
+from lab_connectors.http import HttpClient
 from source_check_analyze import (
     _fallback_infer,
     _finalize_scores,
@@ -504,7 +505,9 @@ def _normalize_preview_columns_for_parquet(df: pd.DataFrame) -> pd.DataFrame:
     return normalized
 
 
-def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
+def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any], client: HttpClient | None = None) -> dict:
+    if client is None:
+        client = configure_source_check_http()
     enrich = _enrich_with_inventory(row, registry)
 
     # granularità e anni: da enrichment, poi fallback su campi catalogo
@@ -550,13 +553,14 @@ def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
         if known_enc:
             preview = _fetch_data_preview(
                 preview_url,
+                client,
                 known_encoding=known_enc,
                 known_delim=enrich.get("delim_suggested"),
                 known_decimal=enrich.get("decimal_suggested"),
                 known_skip=enrich.get("skip_suggested"),
             )
         else:
-            preview = _fetch_data_preview(preview_url)
+            preview = _fetch_data_preview(preview_url, client)
         if preview.get("enrich_method") == "csv_preview":
             # Anni/granularità: solo se metadati non bastano
             if granularity in (None, "non_determinato") and preview.get("granularity"):
@@ -592,7 +596,7 @@ def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
         note = None
         content_type = None
     else:
-        http_status_raw, reachable, note, content_type = _http_head_with_retry(url_to_check or "")
+        http_status_raw, reachable, note, content_type = _http_head_with_retry(url_to_check or "", client=client)
         http_status = http_status_raw if http_status_raw is not None else 0
 
         # Content-type format as primary detection (now unified in _http_head_with_retry)
@@ -650,10 +654,18 @@ def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any]) -> dict:
     }
 
 
-def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame:
+def run_bulk_check(
+    df: pd.DataFrame,
+    workers: int = MAX_WORKERS,
+    client: HttpClient | None = None,
+) -> pd.DataFrame:
     registry = _load_registry()
     check_ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
     results = []
+
+    # Client HTTP condiviso con circuit breaker
+    _owns_client = client is None
+    client = client or configure_source_check_http()
 
     # Per-source timing (stesso pattern di build_catalog_inventory)
     source_first_submit: dict[str, float] = {}
@@ -669,7 +681,7 @@ def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame
         # non accetta per df.loc/df.iloc — con enumerate pos abbiamo int certo.
         future_to_idx = {}
         for pos, (_idx, row) in enumerate(df.iterrows()):
-            f = pool.submit(_check_row, row, check_ts, registry)
+            f = pool.submit(_check_row, row, check_ts, registry, client)
             future_to_idx[f] = pos
             sid = str(row.get("source_id", ""))
             source_first_submit.setdefault(sid, time.time())
@@ -715,6 +727,8 @@ def run_bulk_check(df: pd.DataFrame, workers: int = MAX_WORKERS) -> pd.DataFrame
         )
     finally:
         pool.shutdown(wait=False, cancel_futures=True)
+        if _owns_client:
+            client.close()
 
     # ── Per-source timing table ───────────────────────────────────────────────────
     if source_item_count:
@@ -814,7 +828,7 @@ def main() -> None:
     global _NO_SDMX_YEARS
     _NO_SDMX_YEARS = args.no_sdmx_years
 
-    configure_source_check_http(
+    http_client = configure_source_check_http(
         circuit_fail_threshold=args.circuit_fail_threshold,
         http_timeout=(4.0, 9.0),
         http_max_retries=1,
@@ -1034,7 +1048,7 @@ def main() -> None:
 
     logger.info("Starting check on %d items (%d workers)...", len(df), args.workers)
     t0 = time.time()
-    results = run_bulk_check(df, workers=args.workers)
+    results = run_bulk_check(df, workers=args.workers, client=http_client)
     elapsed = time.time() - t0
     logger.info("Completed in %.1fs", elapsed)
 

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -220,7 +220,7 @@ def _apply_encoding_to_enrich(r: dict, row: pd.Series, base: dict) -> dict:
 # ── Handler CKAN ──────────────────────────────────────────────────────────────
 
 
-def _enrich_ckan(row: pd.Series, base: dict) -> dict | None:
+def _enrich_ckan(row: pd.Series, base: dict, client: HttpClient | None = None) -> dict | None:
     """Re-fetch package_show se inventory non ha format E title."""
     if base["protocol"] != "ckan" or not base["base_url"] or not base["item_name"]:
         return None
@@ -237,7 +237,7 @@ def _enrich_ckan(row: pd.Series, base: dict) -> dict | None:
     )
     parsed = urllib.parse.urlparse(base_api)
     portal_url = f"{parsed.scheme}://{parsed.netloc}"
-    pkg = _toolkit_ckan_package(portal_url, base["item_name"])
+    pkg = _toolkit_ckan_package(portal_url, base["item_name"], client=client)
     if pkg:
         return _parse_ckan_package(pkg)
     return None
@@ -246,11 +246,11 @@ def _enrich_ckan(row: pd.Series, base: dict) -> dict | None:
 # ── Handler SDMX ──────────────────────────────────────────────────────────────
 
 
-def _enrich_sdmx(row: pd.Series, base: dict) -> dict | None:
+def _enrich_sdmx(row: pd.Series, base: dict, client: HttpClient | None = None) -> dict | None:
     """Legge annotations SDMX dal dataflow XML."""
     if base["protocol"] != "sdmx" or not base["base_url"] or not base["item_name"]:
         return None
-    xml_root = _fetch_sdmx_dataflow(base["base_url"], base["item_name"])
+    xml_root = _fetch_sdmx_dataflow(base["base_url"], base["item_name"], client=client)
     if xml_root is not None:
         return _parse_sdmx_annotations(xml_root, base["base_url"], base["item_name"])
     return None
@@ -259,7 +259,7 @@ def _enrich_sdmx(row: pd.Series, base: dict) -> dict | None:
 # ── Handler HTML ──────────────────────────────────────────────────────────────
 
 
-def _enrich_html(row: pd.Series, base: dict) -> dict | None:
+def _enrich_html(row: pd.Series, base: dict, client: HttpClient | None = None) -> dict | None:
     """Arricchimento HTML: content-type → preview download → landing page."""
     if base["protocol"] != "html":
         return None
@@ -270,7 +270,10 @@ def _enrich_html(row: pd.Series, base: dict) -> dict | None:
     # 1. content-type su data_url via toolkit (probe HEAD → format)
     data_url = row.get("url")
     if isinstance(data_url, str):
-        probe = _toolkit_probe_headers(data_url)
+        try:
+            probe = _toolkit_probe_headers(data_url, client=client)
+        except RuntimeError:
+            probe = {}
         fmt = _toolkit_preview_kind(
             data_url, probe.get("content_type"), probe.get("content_disposition")
         )
@@ -295,7 +298,7 @@ def _enrich_html(row: pd.Series, base: dict) -> dict | None:
         path = parsed.path or ""
         fmt_ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
         if fmt_ext in ("csv", "json", "xlsx", "xls"):
-            preview = _fetch_data_preview(data_url)
+            preview = _fetch_data_preview(data_url, client=client)
             if preview:
                 _e(preview)
             return preview
@@ -308,7 +311,7 @@ def _enrich_html(row: pd.Series, base: dict) -> dict | None:
             result = _EMPTY_ENRICH.copy()
             result["enrich_method"] = "scraping_blocked"
             return result
-        return _fetch_html_metadata(landing)
+        return _fetch_html_metadata(landing, client=client)
 
     return None
 
@@ -316,7 +319,7 @@ def _enrich_html(row: pd.Series, base: dict) -> dict | None:
 # ── Handler SPARQL ────────────────────────────────────────────────────────────
 
 
-def _enrich_sparql(row: pd.Series, base: dict) -> dict | None:
+def _enrich_sparql(row: pd.Series, base: dict, client: HttpClient | None = None) -> dict | None:
     """Arricchimento SPARQL: probe semantico con COUNT + HEAD format.
 
     Usa query SPARQL COUNT per verificare che l'endpoint risponda e abbia
@@ -418,17 +421,27 @@ _ENRICH_HANDLERS: dict[str, Any] = {
 # ── Orchestrator ──────────────────────────────────────────────────────────────
 
 
-def _enrich_with_inventory(row: pd.Series, registry: dict[str, Any]) -> dict:
+def _enrich_with_inventory(
+    row: pd.Series,
+    registry: dict[str, Any],
+    client: HttpClient | None = None,
+) -> dict:
     """Enrich item usando inventory + dispatch per protocollo.
 
     Ogni handler puo' ritornare un dict di arricchimento (successo) o None
     (fall through). Se nessun handler riesce, usa inventory cosi' com'e'.
+
+    Args:
+        row: Riga del catalogo.
+        registry: Registry delle fonti.
+        client: HttpClient condiviso (con circuit breaker). Passato
+            agli handler HTTP (CKAN, SDMX, HTML) per condividere stato.
     """
     base = _extract_base_enrich(row, registry)
 
     handler = _ENRICH_HANDLERS.get(base["protocol"])
     if handler:
-        result = handler(row, base)
+        result = handler(row, base, client=client)
         if result is not None:
             return result
 
@@ -517,10 +530,12 @@ def _normalize_preview_columns_for_parquet(df: pd.DataFrame) -> pd.DataFrame:
     return normalized
 
 
-def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any], client: HttpClient | None = None) -> dict:
+def _check_row(
+    row: pd.Series, check_ts: str, registry: dict[str, Any], client: HttpClient | None = None
+) -> dict:
     if client is None:
         client = configure_source_check_http()
-    enrich = _enrich_with_inventory(row, registry)
+    enrich = _enrich_with_inventory(row, registry, client=client)
 
     # granularità e anni: da enrichment, poi fallback su campi catalogo
     granularity = enrich["granularity"]
@@ -608,7 +623,9 @@ def _check_row(row: pd.Series, check_ts: str, registry: dict[str, Any], client: 
         note = None
         content_type = None
     else:
-        http_status_raw, reachable, note, content_type = _http_head_with_retry(url_to_check or "", client=client)
+        http_status_raw, reachable, note, content_type = _http_head_with_retry(
+            url_to_check or "", client=client
+        )
         http_status = http_status_raw if http_status_raw is not None else 0
 
         # Content-type format as primary detection (now unified in _http_head_with_retry)
@@ -842,7 +859,7 @@ def main() -> None:
 
     http_client = configure_source_check_http(
         circuit_fail_threshold=args.circuit_fail_threshold,
-        http_timeout=(4.0, 9.0),
+        http_timeout=(4, 9),
         http_max_retries=1,
     )
 
@@ -1133,6 +1150,7 @@ def main() -> None:
     results = _normalize_preview_columns_for_parquet(results)
     results.to_parquet(args.out, index=False)
     logger.info("Results: %s", args.out)
+    http_client.close()
 
 
 if __name__ == "__main__":

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -96,7 +96,9 @@ def _load_registry() -> dict[str, Any]:
 # ── SDMX enrichment ───────────────────────────────────────────────────────────
 
 
-def _parse_sdmx_annotations(xml_root: ET.Element, base_url: str, flow_id: str) -> dict:
+def _parse_sdmx_annotations(
+    xml_root: ET.Element, base_url: str, flow_id: str, client: HttpClient | None = None
+) -> dict:
     annotations: dict[str, str] = {}
     for ann in xml_root.findall(".//common:Annotation", SDMX_NS):
         atype_el = ann.find("common:AnnotationType", SDMX_NS)
@@ -116,7 +118,9 @@ def _parse_sdmx_annotations(xml_root: ET.Element, base_url: str, flow_id: str) -
 
     # se le annotations non contengono anni, prova a ricavarli dall'endpoint dati
     if year_min is None:
-        year_min, year_max = _fetch_sdmx_years(base_url, flow_id, allow_fetch=not _NO_SDMX_YEARS)
+        year_min, year_max = _fetch_sdmx_years(
+            base_url, flow_id, client=client, allow_fetch=not _NO_SDMX_YEARS
+        )
 
     metadata_url = annotations.get("METADATA_URL")
 
@@ -252,7 +256,7 @@ def _enrich_sdmx(row: pd.Series, base: dict, client: HttpClient | None = None) -
         return None
     xml_root = _fetch_sdmx_dataflow(base["base_url"], base["item_name"], client=client)
     if xml_root is not None:
-        return _parse_sdmx_annotations(xml_root, base["base_url"], base["item_name"])
+        return _parse_sdmx_annotations(xml_root, base["base_url"], base["item_name"], client=client)
     return None
 
 
@@ -364,7 +368,9 @@ def _enrich_sparql(row: pd.Series, base: dict, client: HttpClient | None = None)
     )
     fmt = "SPARQL"
     if landing and landing.startswith("http"):
-        http_status_raw, reachable, note, content_type = _http_head_with_retry(landing)
+        http_status_raw, reachable, note, content_type = _http_head_with_retry(
+            landing, client=client
+        )
         if content_type:
             fmt = _normalize_format(content_type)
 
@@ -938,6 +944,7 @@ def main() -> None:
 
     if df.empty:
         logger.info("No items to check. Exiting.")
+        http_client.close()
         return
 
     # ── Fix A: dedup per (source_id, item_id) — stesso dataset, formati multipli ───
@@ -957,6 +964,7 @@ def main() -> None:
 
     if df.empty:
         logger.info("No items to check. Exiting.")
+        http_client.close()
         return
 
     # ── Smart sampling per target size ───────────────────────────────────────────
@@ -1073,6 +1081,7 @@ def main() -> None:
 
     if df.empty:
         logger.info("No new items to check. Exiting.")
+        http_client.close()
         return
 
     logger.info("Starting check on %d items (%d workers)...", len(df), args.workers)

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 # ── Config HTTP (sovrascrivibile da configure_source_check_http) ──────────────
 
-_DEFAULT_HTTP_TIMEOUT: tuple[float, float] = (5.0, 10.0)
+_DEFAULT_HTTP_TIMEOUT: tuple[int, int] = (5, 10)
 _DEFAULT_HTTP_RETRIES = 2
 _DEFAULT_CIRCUIT_THRESHOLD = 3
 
@@ -73,7 +73,7 @@ _EMPTY_ENRICH: dict[str, Any] = {
 def configure_source_check_http(
     *,
     circuit_fail_threshold: int = _DEFAULT_CIRCUIT_THRESHOLD,
-    http_timeout: tuple[float, float] | None = None,
+    http_timeout: tuple[int, int] | None = None,
     http_max_retries: int = _DEFAULT_HTTP_RETRIES,
 ) -> HttpClient:
     """Crea un HttpClient configurato per bulk source-check.
@@ -182,8 +182,12 @@ def _fetch_sdmx_years(
 # ── SDMX dataflow annotations ────────────────────────────────────────────────
 
 
-def _fetch_sdmx_dataflow(base_url: str, flow_id: str, client: HttpClient | None = None) -> Optional[ET.Element]:
+def _fetch_sdmx_dataflow(
+    base_url: str, flow_id: str, client: HttpClient | None = None
+) -> Optional[ET.Element]:
     """Fetch SDMX dataflow definition XML (annotations con keywords). SO-specific URL construction."""
+    if client is None:
+        client = HttpClient(timeout=_DEFAULT_HTTP_TIMEOUT)
     base = base_url.split("?")[0].rstrip("/")
     if base.endswith("/IT1"):
         root_url = base
@@ -281,7 +285,9 @@ _YEAR_COLUMN_HINTS = ["anno", "year", "data", "date", "periodo", "period", "mese
 # ── Download phase ──────────────────────────────────────────────────────────
 
 
-def _download_preview_content(url: str, fmt: str, client: HttpClient | None = None) -> tuple[bytes, int] | None:
+def _download_preview_content(
+    url: str, fmt: str, client: HttpClient | None = None
+) -> tuple[bytes, int] | None:
     """Download a preview chunk of a data file.
 
     Returns ``(content: bytes, file_size: int)`` or ``None`` on any failure

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -2,8 +2,9 @@
 Fetch fase per bulk source-check.
 
 Strati:
-  toolkit.scout.http  → funzioni HTTP/fetch condivise (probe, format, CKAN, SDMX, HTML)
-  Questo modulo        → circuit breaker bulk + orchestrazione specifica SO
+  lab_connectors.http  → HttpClient con circuit breaker opzionale
+  toolkit.scout.http   → funzioni HTTP/fetch condivise (probe, format, CKAN, SDMX, HTML)
+  Questo modulo         → orchestrazione specifica SO
 """
 
 from __future__ import annotations
@@ -11,14 +12,13 @@ from __future__ import annotations
 import logging
 import math
 import re
-import threading
 import time
 import urllib.parse
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any, Optional
 
-from lab_connectors.http import HttpClient, HttpResult
+from lab_connectors.http import CircuitOpenError, HttpClient
 from toolkit.scout.http import (
     fetch_ckan_package as _toolkit_ckan_package,
 )
@@ -45,12 +45,8 @@ logger = logging.getLogger(__name__)
 HTTP_TIMEOUT: tuple[float, float] = (5, 10)
 _http_timeout: int | float | tuple[int | float, int | float] = (5.0, 10.0)
 _http_max_retries = 2
+_http_circuit_threshold = 3
 
-# ── Circuit breaker per host (bulk-specific) ─────────────────────────────────
-
-_circuit_threshold = 0
-_cb_lock = threading.Lock()
-_cb_consecutive: dict[str, int] = {}
 _YEAR_RE = re.compile(r"(?<!\d)(19\d{2}|20[012]\d)(?!\d)")
 
 SDMX_NS = {
@@ -78,7 +74,7 @@ _EMPTY_ENRICH: dict[str, Any] = {
 }
 
 
-# ── Config ───────────────────────────────────────────────────────────────────
+# ── Client HTTP condiviso ──────────────────────────────────────────────────────
 
 
 def configure_source_check_http(
@@ -86,110 +82,62 @@ def configure_source_check_http(
     circuit_fail_threshold: int = 3,
     http_timeout: tuple[float, float] | None = None,
     http_max_retries: int = 1,
-) -> None:
-    """Reimposta stato HTTP/circuit per un run di bulk_source_check."""
-    global _circuit_threshold, _http_timeout, _http_max_retries
-    with _cb_lock:
-        _cb_consecutive.clear()
-    _circuit_threshold = max(0, int(circuit_fail_threshold))
+) -> HttpClient:
+    """Crea un HttpClient configurato per bulk source-check.
+
+    Il client include circuit breaker per-host: dopo ``circuit_fail_threshold``
+    errori consecutivi sullo stesso host, le richieste successive restituiscono
+    ``CircuitOpenError`` senza fare rete.
+    """
+    global _http_timeout, _http_max_retries, _http_circuit_threshold
+    _http_circuit_threshold = max(0, int(circuit_fail_threshold))
     if http_timeout is not None:
         _http_timeout = (float(http_timeout[0]), float(http_timeout[1]))
     _http_max_retries = max(1, int(http_max_retries))
-
-
-# ── Circuit breaker helpers ──────────────────────────────────────────────────
-
-
-def _netloc(url: str) -> str | None:
-    try:
-        parsed = urllib.parse.urlparse(url)
-        return (parsed.netloc or "").lower() or None
-    except Exception:
-        return None
-
-
-def _circuit_should_block(url: str) -> bool:
-    if _circuit_threshold <= 0:
-        return False
-    host = _netloc(url)
-    if not host:
-        return False
-    with _cb_lock:
-        return _cb_consecutive.get(host, 0) >= _circuit_threshold
-
-
-def _circuit_after_result(url: str, result: HttpResult) -> None:
-    if _circuit_threshold <= 0:
-        return
-    host = _netloc(url)
-    if not host:
-        return
-    failed = (
-        result.err is not None
-        or result.response is None
-        or getattr(result.response, "status_code", 200) >= 500
+    return HttpClient(
+        timeout=_http_timeout,
+        max_retries=_http_max_retries,
+        circuit_threshold=_http_circuit_threshold,
     )
-    with _cb_lock:
-        if failed:
-            n = _cb_consecutive.get(host, 0) + 1
-            _cb_consecutive[host] = n
-            if n == _circuit_threshold:
-                logger.warning("Circuit: host %s aperto dopo %d errori", host, n)
-        else:
-            _cb_consecutive[host] = 0
 
 
-# ── Client HTTP con circuit breaker (usato da toolkit.scout) ──────────────────
-
-
-def _get_circuit_client() -> HttpClient:
-    """Crea HttpClient con timeout/retry configurati (senza circuit breaker built-in)."""
-    return HttpClient(timeout=_http_timeout, max_retries=_http_max_retries)  # type: ignore[arg-type]
-
-
-def _tracked_http_head(url: str) -> HttpResult | None:
-    """HEAD con circuit breaker. None = circuit aperto."""
-    if not url.startswith("http") or _circuit_should_block(url):
-        return None
-    client = _get_circuit_client()
-    result = client.head(url)
-    _circuit_after_result(url, result)
-    return result
-
-
-def _tracked_http_get(url: str, **kwargs: Any) -> HttpResult | None:
-    """GET con circuit breaker. None = circuit aperto."""
-    if not url.startswith("http") or _circuit_should_block(url):
-        return None
-    client = _get_circuit_client()
-    result = client.get(url, **kwargs)
-    _circuit_after_result(url, result)
-    return result
+# ═══════════════════════════════════════════════════════════════════════════════
+# NOTA: Il circuit breaker e' ora gestito direttamente da ``HttpClient``
+# (parametro ``circuit_threshold`` in ``configure_source_check_http``).
+# Le vecchie funzioni ``_netloc``, ``_circuit_should_block``,
+# ``_circuit_after_result``, ``_tracked_http_head`` e ``_tracked_http_get``
+# sono state rimosse — usare ``client.head()`` / ``client.get()`` direttamente.
+# ═══════════════════════════════════════════════════════════════════════════════
 
 
 # ── Probe principale (usato da bulk_source_check) ────────────────────────────
 
 
 def _http_head_with_retry(
-    url: str, max_retries: int = 1
+    url: str,
+    client: HttpClient | None = None,
+    max_retries: int = 1,
 ) -> tuple[Optional[int], bool, str, Optional[str]]:
-    """HTTP HEAD con retry e circuit breaker. Usa toolkit.scout per format detection.
+    """HTTP HEAD con retry e circuit breaker via HttpClient.
 
-    Mantiene _tracked_http_head per il circuit breaker (non usa direttamente toolkit
-    per l'HTTP perché toolkit non ha circuit breaker). La format detection usa
-    toolkit.scout.http.resolve_preview_kind invece che la vecchia _format_from_content_type.
+    Usa ``client.head(url)`` che internamente gestisce circuit breaker,
+    retry su 5xx e connection error.  La format detection usa
+    ``toolkit.scout.http.resolve_preview_kind``.
+
+    Se *client* non e' fornito, ne crea uno di default (senza circuit breaker).
 
     Returns: (status_code, reachable, error, content_type_format).
     """
     if not isinstance(url, str) or not url.startswith("http"):
         return None, False, "url_missing_or_invalid", None
-    if _circuit_should_block(url):
-        return None, False, "circuit_open", None
+
+    if client is None:
+        client = HttpClient(timeout=(5, 10))
 
     last_error = ""
 
     for attempt in range(max_retries + 1):
-        result = _tracked_http_head(url)
+        result = client.head(url)
         if result is None:
             return None, False, "circuit_open", None
 
@@ -207,6 +155,8 @@ def _http_head_with_retry(
             return resp.status_code, reachable, "", fmt
 
         if result.err is not None:
+            if isinstance(result.err, CircuitOpenError):
+                return None, False, "circuit_open", None
             err_name = type(result.err).__name__
             if "Timeout" in err_name and attempt < max_retries:
                 last_error = "timeout"
@@ -222,11 +172,10 @@ def _http_head_with_retry(
 # ── CKAN fetch (wrapper: adatta base_api SO a portal_url toolkit) ─────────────
 
 
-def _fetch_ckan_package(base_api: str, item_name: str) -> Optional[dict]:
+def _fetch_ckan_package(base_api: str, item_name: str, client: HttpClient | None = None) -> Optional[dict]:
     """Fetch CKAN package_show. Usa toolkit.scout con client SO."""
     parsed = urllib.parse.urlparse(base_api)
     portal_url = f"{parsed.scheme}://{parsed.netloc}"
-    client = _get_circuit_client()
     try:
         pkg = _toolkit_ckan_package(portal_url, item_name, client=client)
         if pkg is None:
@@ -245,13 +194,13 @@ def _fetch_ckan_package(base_api: str, item_name: str) -> Optional[dict]:
 def _fetch_sdmx_years(
     base_url: str,
     flow_id: str,
+    client: HttpClient | None = None,
     *,
     allow_fetch: bool = True,
 ) -> tuple[Optional[int], Optional[int]]:
     """SDMX years via toolkit.scout con allow_fetch SO."""
     if not allow_fetch:
         return None, None
-    client = _get_circuit_client()
     try:
         return _toolkit_sdmx_years(base_url, flow_id, client=client)
     except Exception:
@@ -261,7 +210,7 @@ def _fetch_sdmx_years(
 # ── SDMX dataflow annotations ────────────────────────────────────────────────
 
 
-def _fetch_sdmx_dataflow(base_url: str, flow_id: str) -> Optional[ET.Element]:
+def _fetch_sdmx_dataflow(base_url: str, flow_id: str, client: HttpClient | None = None) -> Optional[ET.Element]:
     """Fetch SDMX dataflow definition XML (annotations con keywords). SO-specific URL construction."""
     base = base_url.split("?")[0].rstrip("/")
     if base.endswith("/IT1"):
@@ -269,7 +218,6 @@ def _fetch_sdmx_dataflow(base_url: str, flow_id: str) -> Optional[ET.Element]:
     else:
         root_url = base.rsplit("/", 1)[0]
     url = f"{root_url}/{flow_id}"
-    client = _get_circuit_client()
     try:
         result = client.get(url, headers={"Accept": "application/xml"})
         if not result.is_ok or result.response is None:
@@ -305,13 +253,12 @@ def _fetch_sparql_count(
 # ── HTML metadata (format detection) ─────────────────────────────────────────
 
 
-def _fetch_html_metadata(url: str) -> dict:
+def _fetch_html_metadata(url: str, client: HttpClient | None = None) -> dict:
     """Scarica HTML e cerca formato dati. Usa toolkit.scout.fetch_html_body."""
     if not url.startswith("http"):
         result = _EMPTY_ENRICH.copy()
         result["enrich_method"] = "html_scrape_invalid_url"
         return result
-    client = _get_circuit_client()
     try:
         body = _toolkit_html_body(url, client=client)
         if not body or not body.get("html_text"):
@@ -354,11 +301,12 @@ def _fetch_html_metadata(url: str) -> dict:
 # ── Content-type format (probe HEAD → format) ────────────────────────────────
 
 
-def _content_type_format(url: str) -> Optional[str]:
-    """Formato da Content-Type via HEAD. Usa toolkit.scout con circuit breaker."""
+def _content_type_format(url: str, client: HttpClient | None = None) -> Optional[str]:
+    """Formato da Content-Type via HEAD. Usa toolkit.scout."""
     if not url.startswith("http"):
         return None
-    client = _get_circuit_client()
+    if client is None:
+        client = HttpClient(timeout=(5, 10))
     try:
         probe = _toolkit_probe_headers(url, client=client)
         return _toolkit_preview_kind(
@@ -376,7 +324,7 @@ COMUNE_COLUMNS = ["comune", "municip", "localita", "citta", "city"]
 _YEAR_COLUMN_HINTS = ["anno", "year", "data", "date", "periodo", "period", "mese", "month"]
 
 
-def _resolve_preview_kind(url: str) -> tuple[str | None, bool]:
+def _resolve_preview_kind(url: str, client: HttpClient | None = None) -> tuple[str | None, bool]:
     """Ritorna (kind, inferred_via_head). Usa toolkit per URL extension + HEAD probe."""
     kind = _toolkit_preview_kind(url)
     if kind is not None:
@@ -384,7 +332,7 @@ def _resolve_preview_kind(url: str) -> tuple[str | None, bool]:
     if not url.startswith("http"):
         return None, False
     try:
-        probe = _toolkit_probe_headers(url, client=_get_circuit_client())
+        probe = _toolkit_probe_headers(url, client=client)
         kind = _toolkit_preview_kind(
             url, probe.get("content_type"), probe.get("content_disposition")
         )
@@ -396,7 +344,7 @@ def _resolve_preview_kind(url: str) -> tuple[str | None, bool]:
 # ── Download phase ──────────────────────────────────────────────────────────
 
 
-def _download_preview_content(url: str, fmt: str) -> tuple[bytes, int] | None:
+def _download_preview_content(url: str, fmt: str, client: HttpClient | None = None) -> tuple[bytes, int] | None:
     """Download a preview chunk of a data file.
 
     Returns ``(content: bytes, file_size: int)`` or ``None`` on any failure
@@ -407,7 +355,9 @@ def _download_preview_content(url: str, fmt: str) -> tuple[bytes, int] | None:
     range_limit = 1 * 1024 * 1024 if fmt in ("csv", "tsv", "json") else 5 * 1024 * 1024
     sample_size = 100 * 1024 if fmt in ("csv", "tsv", "json") else None
 
-    fetch_result = _tracked_http_get(url, headers={"Range": f"bytes=0-{range_limit - 1}"})
+    if client is None:
+        client = HttpClient(timeout=(5, 10))
+    fetch_result = client.get(url, headers={"Range": f"bytes=0-{range_limit - 1}"})
     if fetch_result is None:
         return None
     if not fetch_result.is_ok or fetch_result.response is None:
@@ -624,6 +574,7 @@ def _profile_downloaded_json(content: bytes) -> dict:
 
 def _fetch_data_preview(
     url: str,
+    client: HttpClient | None = None,
     *,
     known_encoding: str | None = None,
     known_delim: str | None = None,
@@ -645,7 +596,9 @@ def _fetch_data_preview(
         result["enrich_method"] = "csv_preview_failed"
         return result
 
-    kind, _preview_inferred_via_head = _resolve_preview_kind(url)
+    if client is None:
+        client = HttpClient(timeout=(5, 10))
+    kind, _preview_inferred_via_head = _resolve_preview_kind(url, client)
     if kind is None:
         result = _EMPTY_ENRICH.copy()
         result["enrich_method"] = "csv_preview_skipped"
@@ -654,7 +607,7 @@ def _fetch_data_preview(
     resource_kind = kind
 
     # ── Download ──────────────────────────────────────────────────────────
-    downloaded = _download_preview_content(url, fmt)
+    downloaded = _download_preview_content(url, fmt, client)
     if downloaded is None:
         result = _EMPTY_ENRICH.copy()
         result["enrich_method"] = "csv_preview_fetch_failed"
@@ -754,6 +707,3 @@ def _fetch_data_preview(
         }
     )
     return result
-
-
-# ── Helpers interni ──────────────────────────────────────────────────────────

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -13,15 +13,11 @@ import logging
 import math
 import re
 import time
-import urllib.parse
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any, Optional
 
 from lab_connectors.http import CircuitOpenError, HttpClient
-from toolkit.scout.http import (
-    fetch_ckan_package as _toolkit_ckan_package,
-)
 from toolkit.scout.http import (
     fetch_html_body as _toolkit_html_body,
 )
@@ -164,22 +160,6 @@ def _http_head_with_retry(
 # ── CKAN fetch (wrapper: adatta base_api SO a portal_url toolkit) ─────────────
 
 
-def _fetch_ckan_package(base_api: str, item_name: str, client: HttpClient | None = None) -> Optional[dict]:
-    """Fetch CKAN package_show. Usa toolkit.scout con client SO."""
-    parsed = urllib.parse.urlparse(base_api)
-    portal_url = f"{parsed.scheme}://{parsed.netloc}"
-    try:
-        pkg = _toolkit_ckan_package(portal_url, item_name, client=client)
-        if pkg is None:
-            logger.warning(
-                "CKAN package_show returned None for %s (portal: %s)", item_name, portal_url
-            )
-        return pkg
-    except Exception as exc:
-        logger.error("CKAN package_show failed for %s (portal: %s): %s", item_name, portal_url, exc)
-        return None
-
-
 # ── SDMX years ───────────────────────────────────────────────────────────────
 
 
@@ -290,47 +270,12 @@ def _fetch_html_metadata(url: str, client: HttpClient | None = None) -> dict:
         return result
 
 
-# ── Content-type format (probe HEAD → format) ────────────────────────────────
-
-
-def _content_type_format(url: str, client: HttpClient | None = None) -> Optional[str]:
-    """Formato da Content-Type via HEAD. Usa toolkit.scout."""
-    if not url.startswith("http"):
-        return None
-    if client is None:
-        client = HttpClient(timeout=(5, 10))
-    try:
-        probe = _toolkit_probe_headers(url, client=client)
-        return _toolkit_preview_kind(
-            url, probe.get("content_type"), probe.get("content_disposition")
-        )
-    except Exception:
-        return None
-
-
 # ── Data preview (toolkit profiler + SO enrichment) ──────────────────────────
 
 
 REGION_COLUMNS = ["regione", "region", "provincia", "province", "area", "territorio"]
 COMUNE_COLUMNS = ["comune", "municip", "localita", "citta", "city"]
 _YEAR_COLUMN_HINTS = ["anno", "year", "data", "date", "periodo", "period", "mese", "month"]
-
-
-def _resolve_preview_kind(url: str, client: HttpClient | None = None) -> tuple[str | None, bool]:
-    """Ritorna (kind, inferred_via_head). Usa toolkit per URL extension + HEAD probe."""
-    kind = _toolkit_preview_kind(url)
-    if kind is not None:
-        return kind, False
-    if not url.startswith("http"):
-        return None, False
-    try:
-        probe = _toolkit_probe_headers(url, client=client)
-        kind = _toolkit_preview_kind(
-            url, probe.get("content_type"), probe.get("content_disposition")
-        )
-        return kind, kind is not None
-    except Exception:
-        return None, False
 
 
 # ── Download phase ──────────────────────────────────────────────────────────
@@ -590,7 +535,15 @@ def _fetch_data_preview(
 
     if client is None:
         client = HttpClient(timeout=(5, 10))
-    kind, _preview_inferred_via_head = _resolve_preview_kind(url, client)
+    kind = _toolkit_preview_kind(url)
+    if kind is None and url.startswith("http"):
+        try:
+            probe = _toolkit_probe_headers(url, client=client)
+            kind = _toolkit_preview_kind(
+                url, probe.get("content_type"), probe.get("content_disposition")
+            )
+        except Exception:
+            kind = None
     if kind is None:
         result = _EMPTY_ENRICH.copy()
         result["enrich_method"] = "csv_preview_skipped"

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -42,12 +42,9 @@ logger = logging.getLogger(__name__)
 
 # ── Config HTTP (sovrascrivibile da configure_source_check_http) ──────────────
 
-HTTP_TIMEOUT: tuple[float, float] = (5, 10)
-_http_timeout: int | float | tuple[int | float, int | float] = (5.0, 10.0)
-_http_max_retries = 2
-_http_circuit_threshold = 3
-
-_YEAR_RE = re.compile(r"(?<!\d)(19\d{2}|20[012]\d)(?!\d)")
+_DEFAULT_HTTP_TIMEOUT: tuple[float, float] = (5.0, 10.0)
+_DEFAULT_HTTP_RETRIES = 2
+_DEFAULT_CIRCUIT_THRESHOLD = 3
 
 SDMX_NS = {
     "message": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message",
@@ -79,9 +76,9 @@ _EMPTY_ENRICH: dict[str, Any] = {
 
 def configure_source_check_http(
     *,
-    circuit_fail_threshold: int = 3,
+    circuit_fail_threshold: int = _DEFAULT_CIRCUIT_THRESHOLD,
     http_timeout: tuple[float, float] | None = None,
-    http_max_retries: int = 1,
+    http_max_retries: int = _DEFAULT_HTTP_RETRIES,
 ) -> HttpClient:
     """Crea un HttpClient configurato per bulk source-check.
 
@@ -89,15 +86,10 @@ def configure_source_check_http(
     errori consecutivi sullo stesso host, le richieste successive restituiscono
     ``CircuitOpenError`` senza fare rete.
     """
-    global _http_timeout, _http_max_retries, _http_circuit_threshold
-    _http_circuit_threshold = max(0, int(circuit_fail_threshold))
-    if http_timeout is not None:
-        _http_timeout = (float(http_timeout[0]), float(http_timeout[1]))
-    _http_max_retries = max(1, int(http_max_retries))
     return HttpClient(
-        timeout=_http_timeout,
-        max_retries=_http_max_retries,
-        circuit_threshold=_http_circuit_threshold,
+        timeout=http_timeout or _DEFAULT_HTTP_TIMEOUT,
+        max_retries=max(1, int(http_max_retries)),
+        circuit_threshold=max(0, int(circuit_fail_threshold)),
     )
 
 

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -439,7 +439,6 @@ def test_fetch_data_preview_xls_fake_tsv_latin1(monkeypatch) -> None:
 def test_http_circuit_breaker_blocks_host_after_failures(monkeypatch) -> None:
     """Dopo N errori di trasporto sullo stesso host, HEAD successivi ritornano circuit_open."""
     import requests
-    from lab_connectors.http import CircuitOpenError, HttpResult
     from source_check_fetch import _http_head_with_retry, configure_source_check_http
 
     heads: list[str] = []
@@ -451,7 +450,9 @@ def test_http_circuit_breaker_blocks_host_after_failures(monkeypatch) -> None:
         raise requests.exceptions.ConnectTimeout()
 
     monkeypatch.setattr(requests, "head", fake_requests_head)
-    monkeypatch.setattr(requests.Session, "head", lambda self, url, **kw: fake_requests_head(url, **kw))
+    monkeypatch.setattr(
+        requests.Session, "head", lambda self, url, **kw: fake_requests_head(url, **kw)
+    )
 
     client = configure_source_check_http(
         circuit_fail_threshold=2, http_timeout=(1.0, 2.0), http_max_retries=1
@@ -460,7 +461,9 @@ def test_http_circuit_breaker_blocks_host_after_failures(monkeypatch) -> None:
         u = "https://slow-host.example/resource/1"
         _http_head_with_retry(u, client=client)
         assert len(heads) == 2
-        _st, _ok, note, _fmt = _http_head_with_retry("https://slow-host.example/other", client=client)
+        _st, _ok, note, _fmt = _http_head_with_retry(
+            "https://slow-host.example/other", client=client
+        )
         assert note == "circuit_open"
         assert len(heads) == 2
     finally:
@@ -819,7 +822,7 @@ class TestSdmxEnrichWithInventory:
         # Mock _fetch_sdmx_dataflow per catturare quale URL riceve
         captured_args = {}
 
-        def _mock_fetch(base_url, flow_id):
+        def _mock_fetch(base_url, flow_id, **kwargs):
             captured_args["base_url"] = base_url
             captured_args["flow_id"] = flow_id
             import xml.etree.ElementTree as ET
@@ -889,7 +892,7 @@ class TestSdmxCheckRowPassthrough:
         # Mock tutte le funzioni HTTP per evitare chiamate reali
         import xml.etree.ElementTree as ET
 
-        def _mock_fetch(base_url, flow_id):
+        def _mock_fetch(base_url, flow_id, **kwargs):
             return ET.fromstring(_SDMX_XML)
 
         def _mock_preview(url, **kwargs):

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -439,24 +439,28 @@ def test_fetch_data_preview_xls_fake_tsv_latin1(monkeypatch) -> None:
 def test_http_circuit_breaker_blocks_host_after_failures(monkeypatch) -> None:
     """Dopo N errori di trasporto sullo stesso host, HEAD successivi ritornano circuit_open."""
     import requests
-    from lab_connectors.http import HttpClient, HttpResult
+    from lab_connectors.http import CircuitOpenError, HttpResult
     from source_check_fetch import _http_head_with_retry, configure_source_check_http
 
     heads: list[str] = []
 
-    def fake_head(self, url, **kwargs):
+    # Mokka a livello requests (non HttpClient.head), cosi' il vero
+    # HttpClient.head() esegue e il circuit breaker viene aggiornato.
+    def fake_requests_head(url, **kwargs):
         heads.append(url)
-        return HttpResult(response=None, err=requests.exceptions.ConnectTimeout())
+        raise requests.exceptions.ConnectTimeout()
 
-    monkeypatch.setattr(HttpClient, "head", fake_head)
-    configure_source_check_http(
+    monkeypatch.setattr(requests, "head", fake_requests_head)
+    monkeypatch.setattr(requests.Session, "head", lambda self, url, **kw: fake_requests_head(url, **kw))
+
+    client = configure_source_check_http(
         circuit_fail_threshold=2, http_timeout=(1.0, 2.0), http_max_retries=1
     )
     try:
         u = "https://slow-host.example/resource/1"
-        _http_head_with_retry(u)
+        _http_head_with_retry(u, client=client)
         assert len(heads) == 2
-        _st, _ok, note, _fmt = _http_head_with_retry("https://slow-host.example/other")
+        _st, _ok, note, _fmt = _http_head_with_retry("https://slow-host.example/other", client=client)
         assert note == "circuit_open"
         assert len(heads) == 2
     finally:


### PR DESCRIPTION
## Sintesi

Rimuove il circuit breaker manuale da `source_check_fetch.py` e lo sostituisce con `HttpClient(circuit_threshold=N)` da `lab-connectors`.

## Cosa cambia

- [x] Refactor
- [ ] Bug fix
- [ ] Nuova funzionalità
- [x] Modifica contratto pubblico (firma funzioni)

### File modificati

- `scripts/source_check_fetch.py` — rimosse ~80 righe di circuit breaker manuale:
  - `_netloc`, `_circuit_should_block`, `_circuit_after_result`, `_cb_consecutive`, `_cb_lock`, `_circuit_threshold`
  - `_tracked_http_head`, `_tracked_http_get`
  - `configure_source_check_http()` ora restituisce `HttpClient(circuit_threshold=N)`
  - Tutte le funzioni HTTP ora accettano `client: HttpClient | None` (backward compat)

- `scripts/bulk_source_check.py`:
  - `_check_row()` e `run_bulk_check()` accettano `client` opzionale
  - `run_bulk_check()` usa il client condiviso (con circuit breaker tra gli item)
  - Il client viene passato da `main()` → `run_bulk_check()` → `_check_row()`

- `tests/test_bulk_source_check.py` — test circuit breaker aggiornato per mock a livello `requests` (non `HttpClient.head`)

## Verifica

- [x] `pytest tests/` passa (384/384)
- [x] `ruff check .` passa

## Note

Il file `notebooks/01_source_check_analysis.ipynb` è incluso accidentalmente (pre-esistente in working tree). Se dà fastidio lo stacco.
