### PR TITLE
refactor: pulizia duplicazione interna e integrazione preview_url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "jsonschema>=4.26.0",
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
-  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.14.0",
+  "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.14.1",
   "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.34.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.14.1",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.34.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.34.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.14.0",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.33.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.34.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/_constants.py
+++ b/scripts/_constants.py
@@ -158,3 +158,195 @@ def save_registry(path: Path | None, registry: dict) -> None:
     p = path or REGISTRY_PATH
     with p.open("w", encoding="utf-8") as fh:
         yaml.safe_dump(registry, fh, sort_keys=False, allow_unicode=True)
+
+
+# ── Utility generiche ──────────────────────────────────────────────────────────
+
+
+def safe_str(v: object) -> str | None:
+    """Convert a value to string, handling pandas NaN and None."""
+    import math
+
+    if v is None:
+        return None
+    if isinstance(v, float) and (math.isnan(v) or v != v):
+        return None
+    return str(v)
+
+
+def get_red_source_ids(radar_path: Path | None = None) -> list[str]:
+    """Read radar_summary.json and return list of RED source IDs.
+
+    Returns empty list if file is missing or unreadable.
+    """
+    path = radar_path or RADAR_SUMMARY_PATH
+    if not path.exists():
+        return []
+    try:
+        radar = json.loads(path.read_text(encoding="utf-8"))
+        return [s["id"] for s in radar.get("sources", []) if s.get("status") == "RED"]
+    except Exception:
+        return []
+
+
+# ── Join key patterns (condivisi tra source_check_analyze e joinability_scan) ──
+# Ogni entry: (chiave_semantica, regex, descrizione)
+
+JOIN_KEY_PATTERNS: list[tuple[str, str, str]] = [
+    (
+        "istat_comune",
+        r"(?i)(codice_istat_comune|codice_comune_istat|^codice_comune$|^pro_com$|^comune$)",
+        "Codice ISTAT comune (8 digit alfanumerico)",
+    ),
+    (
+        "istat_regione",
+        r"(?i)(codice_istat_regione|^codice_regione$|^codreg$|regione_istat_cod|^cod_reg$|^regione$)",
+        "Codice ISTAT regione",
+    ),
+    (
+        "anno",
+        r"(?i)^(anno(_|$)|anno_di_imposta$|anno_scolastico$|annoscolastico$|anno_riferimento$|"
+        r"anno_presentazione$|esercizio_finanziario$)",
+        "Anno / esercizio",
+    ),
+    (
+        "provincia",
+        r"(?i)(sigla_provincia|^provincia(_|$)|codice_provincia|sigla_prov|^prov$|^cod_prov$)",
+        "Provincia (sigla o codice)",
+    ),
+    (
+        "codice_catastale",
+        r"(?i)(codice_catastale|cod_catastale|catastale)",
+        "Codice catastale comune",
+    ),
+    (
+        "codice_ente",
+        r"(?i)(codice_ente_ipa|^id_ente$|codice_ente_siope|codice_istituzione|"
+        r"codice_ente_bdap|codice_ente_ssn|^codice_ente$|^cod_ente$)",
+        "Codice ente pubblico (IPA/SIOPE/BDAP/SSN)",
+    ),
+    (
+        "codice_scuola",
+        r"(?i)(codice_scuola|codicescuola|codice_meccanografico|^codice_scuola$|^cod_scuola$)",
+        "Codice scuola (MIM)",
+    ),
+    (
+        "atc",
+        r"(?i)(^atc[1-5]$|^atc$|^atc1$|^atc2$|^atc3$|^atc4$|^atc5$)",
+        "Classificazione ATC farmaceutica",
+    ),
+    (
+        "ateco",
+        r"(?i)(codice_ateco|^ateco$|sezione_ateco)",
+        "Classificazione ATECO attività economica",
+    ),
+    ("mese", r"(?i)^(mese|month)$", "Mese (1-12)"),
+    (
+        "cf_ente",
+        r"(?i)(codice_fiscale_ente|^cf_ente$|^codice_fiscale$|^cf$|^partita_iva$|^p_iva$)",
+        "Codice fiscale / partita IVA ente",
+    ),
+    (
+        "sesso",
+        r"(?i)^(sesso|genere|gender)$",
+        "Sesso / genere",
+    ),
+    (
+        "eta",
+        r"(?i)^(eta|età|eta_|fascia_eta|classe_eta|classe_di_eta|fascia_di_eta$)",
+        "Età / fascia età",
+    ),
+    (
+        "cittadinanza",
+        r"(?i)(cittadinanza|cittadino|nazionalità|nazionalita)",
+        "Cittadinanza / nazionalità",
+    ),
+    (
+        "codice_comune_anagrafe",
+        r"(?i)(^codice_comune$|^comune_istat$|^comune_codice$)",
+        "Codice comune (generico, forse ISTAT)",
+    ),
+]
+
+JOIN_KEY_WEIGHTS: dict[str, int] = {
+    "istat_comune": 30,
+    "istat_regione": 20,
+    "anno": 15,
+    "provincia": 10,
+    "codice_catastale": 15,
+    "codice_ente": 10,
+    "codice_scuola": 8,
+    "atc": 5,
+    "ateco": 5,
+    "mese": 3,
+    "cf_ente": 10,
+    "sesso": 3,
+    "eta": 3,
+    "cittadinanza": 5,
+    "codice_comune_anagrafe": 5,
+}
+
+
+def parse_columns(raw: str | None) -> list[str]:
+    """Parse a JSON-encoded columns field into a list of column names.
+
+    Handles None, NaN, JSON list, JSON dict (keys as columns), and
+    scalar fallback.  Canonical version shared by source_check_analyze
+    and joinability_scan.
+    """
+    import math
+
+    if raw is None or (isinstance(raw, float) and math.isnan(raw)):
+        return []
+    if not isinstance(raw, str):
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return [str(raw)]
+    if isinstance(parsed, list):
+        return [str(c) if not isinstance(c, dict) else str(c.get("name", "")) for c in parsed]
+    if isinstance(parsed, dict):
+        return list(parsed.keys())
+    return [str(parsed)]
+
+
+def detect_join_keys(
+    columns_raw: str | None, columns: list[str] | None = None
+) -> dict[str, list[str]]:
+    """Match column names against join key patterns.
+
+    Args:
+        columns_raw: JSON-encoded columns field (list or dict).
+        columns: Already-parsed list (avoids double parse).
+
+    Returns:
+        Dict {chiave_semantica: [colonne_matched]}.
+    """
+    import re
+
+    col_names = columns if columns is not None else parse_columns(columns_raw)
+    if not col_names:
+        return {}
+    found: dict[str, list[str]] = {}
+    for key_name, pattern, _desc in JOIN_KEY_PATTERNS:
+        matched = [c for c in col_names if re.search(pattern, c.strip())]
+        if matched:
+            found[key_name] = matched
+    return found
+
+
+def compute_joinability_score(found_keys: dict[str, list[str]]) -> float:
+    """Score 0-100 based on found join keys.
+
+    Uses JOIN_KEY_WEIGHTS.  Does not include catalog cross-reference
+    (that is added by joinability_scan.py).
+    """
+    if not found_keys:
+        return 0.0
+    score = sum(JOIN_KEY_WEIGHTS.get(k, 5) for k in found_keys)
+    if len(found_keys) >= 3:
+        score += 10
+    elif len(found_keys) >= 2:
+        score += 5
+    return min(score, 100)

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -15,6 +15,7 @@ from _constants import (
     CATALOG_INVENTORY_DIR_PATH,
     RADAR_SUMMARY_PATH,
     REGISTRY_PATH,
+    get_red_source_ids,
     load_registry,
     stale_reason_from_exception,
 )
@@ -186,24 +187,17 @@ def main() -> None:
 
     # ── Skip RED sources da radar ─────────────────────────────────────────────
     if args.skip_red_sources:
-        radar_path = RADAR_SUMMARY_PATH
-        if radar_path.exists():
-            try:
-                with radar_path.open() as fh:
-                    radar = json.load(fh)
-                red_ids = [s["id"] for s in radar.get("sources", []) if s.get("status") == "RED"]
-                if red_ids:
-                    before = len(inventoriable)
-                    inventoriable = [(sid, cfg) for sid, cfg in inventoriable if sid not in red_ids]
-                    skipped = before - len(inventoriable)
-                    if skipped:
-                        print(
-                            f"  skip RED sources (radar): {red_ids} — {skipped} fonti saltate",
-                            file=sys.stderr,
-                        )
-            except Exception as exc:
-                print(f"  skip-red-sources: cannot read radar_summary: {exc}", file=sys.stderr)
-        else:
+        red_ids = get_red_source_ids()
+        if red_ids:
+            before = len(inventoriable)
+            inventoriable = [(sid, cfg) for sid, cfg in inventoriable if sid not in red_ids]
+            skipped = before - len(inventoriable)
+            if skipped:
+                print(
+                    f"  skip RED sources (radar): {red_ids} — {skipped} fonti saltate",
+                    file=sys.stderr,
+                )
+        elif not RADAR_SUMMARY_PATH.exists():
             print("  skip-red-sources: radar_summary.json not found", file=sys.stderr)
 
     collected: dict[

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -33,7 +33,6 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -41,7 +40,10 @@ from _constants import (
     CHECK_PARQUET_PATH,
     INVENTORY_PARQUET_PATH,
     RADAR_SUMMARY_PATH,
-    REGISTRY_PATH,
+    get_red_source_ids,
+)
+from _constants import (
+    safe_str as _safe_str,
 )
 from lab_connectors.http import HttpClient
 from source_check_analyze import (
@@ -87,10 +89,12 @@ _NO_SDMX_YEARS = False  # set via --no-sdmx-years flag
 
 
 def _load_registry() -> dict[str, Any]:
-    if not REGISTRY_PATH.exists():
+    from _constants import load_registry
+
+    try:
+        return load_registry()
+    except Exception:
         return {}
-    with REGISTRY_PATH.open(encoding="utf-8") as fh:
-        return yaml.safe_load(fh) or {}
 
 
 # ── SDMX enrichment ───────────────────────────────────────────────────────────
@@ -454,11 +458,7 @@ def _enrich_with_inventory(
     return _enrich_fallback(row, base)
 
 
-def _safe_str(v: Any) -> str | None:
-    """Convert a value to string, handling pandas NaN."""
-    if v is None or (isinstance(v, float) and pd.isna(v)):
-        return None
-    return str(v)
+# _safe_str importata da _constants — non ridefinire localmente
 
 
 def _preview_meta_from_enrich(enrich: dict[str, Any]) -> dict[str, Any]:
@@ -887,27 +887,14 @@ def _run_source_check(http_client: HttpClient, args: argparse.Namespace) -> None
     # Evita di campionare item da fonti che timeoutmano su Actions (IP cloud blocked)
     # e allungano il source-check senza produrre valore.
     if args.skip_red_sources:
-        radar_summary_path = RADAR_SUMMARY_PATH
-        if radar_summary_path.exists():
-            import json
-
-            try:
-                with radar_summary_path.open() as f:
-                    radar = json.load(f)
-                red_source_ids = [
-                    s["id"] for s in radar.get("sources", []) if s.get("status") == "RED"
-                ]
-                if red_source_ids:
-                    skipped = df["source_id"].isin(red_source_ids).sum()
-                    df = df[~df["source_id"].isin(red_source_ids)]
-                    logger.info(
-                        "  skip RED sources (radar): %s — %d items rimossi", red_source_ids, skipped
-                    )
-            except Exception as exc:
-                logger.warning("  skip-red-sources: could not read radar_summary: %s", exc)
-        else:
+        red_ids = get_red_source_ids()
+        if red_ids:
+            n_skipped = df["source_id"].isin(red_ids).sum()
+            df = df[~df["source_id"].isin(red_ids)]
+            logger.info("  skip RED sources (radar): %s — %d items rimossi", red_ids, n_skipped)
+        elif not RADAR_SUMMARY_PATH.exists():
             logger.warning(
-                "  skip-red-sources: radar_summary.json not found at %s", radar_summary_path
+                "  skip-red-sources: radar_summary.json not found at %s", RADAR_SUMMARY_PATH
             )
 
     if args.limit:

--- a/scripts/joinability_scan.py
+++ b/scripts/joinability_scan.py
@@ -19,6 +19,7 @@ import re
 from datetime import date
 from typing import Any
 
+from _constants import JOIN_KEY_PATTERNS, detect_join_keys, parse_columns
 from lab_connectors.duckdb import gcs_connect
 from lab_connectors.http import HttpClient
 
@@ -44,68 +45,16 @@ OUTPUT_PATH = os.path.join(
 )
 
 
-# ── Pattern di chiavi di join ─────────────────────────────────────────────────
-# Ogni entry: (chiave_semantica, regex, descrizione)
+# ── Join key patterns ───────────────────────────────────────────────────────
+# I pattern canonici sono in _constants.JOIN_KEY_PATTERNS.
+# KEY_PATTERNS alias per backward compat interna a questo file.
+KEY_PATTERNS: list[tuple[str, str, str]] = JOIN_KEY_PATTERNS  # type: ignore[assignment]
 
 # ── Bridge table ──────────────────────────────────────────────────────────────
 # Il dataset nel catalogo che funge da bridge table per join indiretti.
 # Le sue colonne vengono lette dinamicamente dal clean_catalog.json e
 # processate con KEY_PATTERNS per derivare le chiavi semantiche coperte.
 BRIDGE_SLUG: str = "bdap_anagrafe_enti"
-
-KEY_PATTERNS: list[tuple[str, str, str]] = [
-    (
-        "istat_comune",
-        r"(?i)(codice_istat_comune|codice_comune_istat|^codice_comune$|^pro_com$|^comune$)",
-        "Codice ISTAT comune (8 digit alfanumerico)",
-    ),
-    (
-        "istat_regione",
-        r"(?i)(codice_istat_regione|^codice_regione$|^codreg$|regione_istat_cod|^cod_reg$)",
-        "Codice ISTAT regione",
-    ),
-    (
-        "anno",
-        r"(?i)^(anno|anno_di_imposta|anno_scolastico|annoscolastico|anno_riferimento|anno_presentazione|esercizio_finanziario)$",
-        "Anno / esercizio",
-    ),
-    (
-        "provincia",
-        r"(?i)(sigla_provincia|^provincia$|codice_provincia|sigla_prov|^prov$)",
-        "Provincia (sigla o codice)",
-    ),
-    (
-        "codice_catastale",
-        r"(?i)(codice_catastale|cod_catastale|catastale)",
-        "Codice catastale comune",
-    ),
-    (
-        "codice_ente",
-        r"(?i)(codice_ente_ipa|^id_ente$|codice_ente_siope|codice_istituzione|codice_ente_bdap|codice_ente_ssn)",
-        "Codice ente pubblico (IPA/SIOPE/BDAP/SSN)",
-    ),
-    (
-        "codice_scuola",
-        r"(?i)(codice_scuola|codicescuola|codice_meccanografico|^codice_scuola$|^cod_scuola$)",
-        "Codice scuola (MIM)",
-    ),
-    (
-        "atc",
-        r"(?i)(^atc[1-5]$|^atc$|^atc1$|^atc2$|^atc3$|^atc4$|^atc5$)",
-        "Classificazione ATC farmaceutica",
-    ),
-    (
-        "ateco",
-        r"(?i)(codice_ateco|^ateco$|sezione_ateco)",
-        "Classificazione ATECO attività economica",
-    ),
-    ("mese", r"(?i)^mese$", "Mese (1-12)"),
-    (
-        "codice_comune_anagrafe",
-        r"(?i)(^codice_comune$|^comune_istat$|^comune_codice$)",
-        "Codice comune (generico, forse ISTAT)",
-    ),
-]
 
 
 def load_source_check() -> list[dict[str, Any]]:
@@ -133,34 +82,11 @@ def load_clean_catalog() -> list[dict[str, Any]]:
         client.close()
 
 
-def parse_columns(columns_raw: Any) -> list[str]:
-    """Parsa la colonna `columns` in una lista di nomi colonna."""
-    if columns_raw is None or (isinstance(columns_raw, float) and columns_raw != columns_raw):
-        return []
-    if not isinstance(columns_raw, str):
-        return []
-    try:
-        parsed = json.loads(columns_raw)
-    except (json.JSONDecodeError, TypeError):
-        return [str(columns_raw)]
-    if isinstance(parsed, list):
-        return [str(c) if not isinstance(c, dict) else str(c.get("name", "")) for c in parsed]
-    if isinstance(parsed, dict):
-        return list(parsed.keys())
-    return [str(parsed)]
-
-
+# parse_columns e detect_join_keys importate da _constants.
+# detect_keys alias per backward compat interna a questo file.
 def detect_keys(column_names: list[str]) -> dict[str, list[str]]:
-    """Matcha i nomi colonna contro i pattern di chiavi di join.
-
-    Restituisce dict {nome_chiave: [colonne_matched]}.
-    """
-    found: dict[str, list[str]] = {}
-    for key_name, pattern, _desc in KEY_PATTERNS:
-        matched = [col for col in column_names if re.search(pattern, col.strip())]
-        if matched:
-            found[key_name] = matched
-    return found
+    """Matcha i nomi colonna contro i pattern di chiavi di join."""
+    return detect_join_keys(None, columns=column_names)
 
 
 def build_catalog_index(catalog: list[dict]) -> dict[str, dict]:
@@ -340,7 +266,9 @@ def build_json_output(
                 "item_name": item["item_name"],
                 "intake_score": item["intake_score"],
                 "joinability_score": item["joinability_score"],
-                "enriched_joinability_score": item.get("enriched_joinability_score", item["joinability_score"]),
+                "enriched_joinability_score": item.get(
+                    "enriched_joinability_score", item["joinability_score"]
+                ),
                 "col_count": item["col_count"],
                 "keys_found": item["found_keys"],
                 "matches": [

--- a/scripts/joinability_scan.py
+++ b/scripts/joinability_scan.py
@@ -48,7 +48,7 @@ OUTPUT_PATH = os.path.join(
 # ── Join key patterns ───────────────────────────────────────────────────────
 # I pattern canonici sono in _constants.JOIN_KEY_PATTERNS.
 # KEY_PATTERNS alias per backward compat interna a questo file.
-KEY_PATTERNS: list[tuple[str, str, str]] = JOIN_KEY_PATTERNS  # type: ignore[assignment]
+KEY_PATTERNS: list[tuple[str, str, str]] = JOIN_KEY_PATTERNS
 
 # ── Bridge table ──────────────────────────────────────────────────────────────
 # Il dataset nel catalogo che funge da bridge table per join indiretti.

--- a/scripts/source_check_analyze.py
+++ b/scripts/source_check_analyze.py
@@ -12,6 +12,13 @@ import re
 from typing import Optional
 
 import pandas as pd
+from _constants import (
+    JOIN_KEY_PATTERNS,
+    JOIN_KEY_WEIGHTS,
+    compute_joinability_score,
+    detect_join_keys,
+    parse_columns,
+)
 from toolkit.scout.infer import infer_granularity as _infer_granularity
 from toolkit.scout.infer import infer_granularity_from_name_and_columns as _infer_gran_cols
 from toolkit.scout.infer import infer_years as _infer_years
@@ -277,118 +284,15 @@ def _fallback_infer(row: pd.Series) -> tuple[str, Optional[int], Optional[int]]:
 
 
 # ── joinability scoring ──────────────────────────────────────────────────────
-# Pattern di chiavi di join riconosciute dai nomi colonna.
-# Copia locale di joinability_scan.py:KEY_PATTERNS — senza catalogo (0 I/O).
+# I pattern, i pesi, e le funzioni di join key sono in _constants.py.
+# source_check_analyze li ri-importa per backward compat interna.
 # Il cross-ref con clean_catalog.json è demandato a joinability_scan.py.
 
-_JOIN_KEY_PATTERNS: list[tuple[str, str]] = [
-    (
-        "istat_comune",
-        r"(?i)(codice_istat_comune|codice_comune_istat|^codice_comune$|^pro_com$|^comune$)",
-    ),
-    (
-        "istat_regione",
-        r"(?i)(codice_istat_regione|^codice_regione$|^codreg$|regione_istat_cod|^cod_reg$|^regione$)",
-    ),
-    (
-        "anno",
-        r"(?i)^(anno(_|$)|anno_di_imposta$|anno_scolastico$|annoscolastico$|anno_riferimento$|anno_presentazione$|esercizio_finanziario$)",
-    ),
-    (
-        "provincia",
-        r"(?i)(sigla_provincia|^provincia(_|$)|codice_provincia|sigla_prov|^prov$|^cod_prov$)",
-    ),
-    ("codice_catastale", r"(?i)(codice_catastale|cod_catastale|catastale)"),
-    (
-        "codice_ente",
-        r"(?i)(codice_ente_ipa|^id_ente$|codice_ente_siope|codice_istituzione|codice_ente_bdap|codice_ente_ssn|^codice_ente$|^cod_ente$)",
-    ),
-    (
-        "codice_scuola",
-        r"(?i)(codice_scuola|codicescuola|codice_meccanografico|^codice_scuola$|^cod_scuola$)",
-    ),
-    ("atc", r"(?i)(^atc[1-5]$|^atc$|^atc1$|^atc2$|^atc3$|^atc4$|^atc5$)"),
-    ("ateco", r"(?i)(codice_ateco|^ateco$|sezione_ateco)"),
-    ("mese", r"(?i)^(mese|month)$"),
-    ("cf_ente", r"(?i)(codice_fiscale_ente|^cf_ente$|^codice_fiscale$|^cf$|^partita_iva$|^p_iva$)"),
-    ("sesso", r"(?i)^(sesso|genere|gender)$"),
-    ("eta", r"(?i)^(eta|età|eta_|fascia_eta|classe_eta|classe_di_eta|fascia_di_eta$)"),
-    ("cittadinanza", r"(?i)(cittadinanza|cittadino|nazionalità|nazionalita)"),
-]
-
-_JOIN_KEY_WEIGHTS: dict[str, int] = {
-    "istat_comune": 30,
-    "istat_regione": 20,
-    "anno": 15,
-    "provincia": 10,
-    "codice_catastale": 15,
-    "codice_ente": 10,
-    "codice_scuola": 8,
-    "atc": 5,
-    "ateco": 5,
-    "mese": 3,
-    "cf_ente": 10,
-    "sesso": 3,
-    "eta": 3,
-    "cittadinanza": 5,
-}
-
-
-def _parse_columns(raw: str | None) -> list[str]:
-    """Parsa la colonna `columns` in una lista di nomi colonna."""
-    if raw is None or (isinstance(raw, float) and raw != raw):
-        return []
-    if not isinstance(raw, str):
-        return []
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, TypeError):
-        return [str(raw)]
-    if isinstance(parsed, list):
-        return [str(c) if not isinstance(c, dict) else str(c.get("name", "")) for c in parsed]
-    if isinstance(parsed, dict):
-        return list(parsed.keys())
-    return [str(parsed)]
-
-
-def detect_join_keys(
-    columns_raw: str | None, columns: list[str] | None = None
-) -> dict[str, list[str]]:
-    """Matcha i nomi colonna contro i pattern di chiavi di join.
-
-    Args:
-        columns_raw: JSON grezzo della colonna `columns` (list o dict).
-        columns: Lista già parsata (opzionale, evita doppio parse).
-
-    Returns:
-        Dict {nome_chiave: [colonne_matched]}.
-    """
-    col_names = columns if columns is not None else _parse_columns(columns_raw)
-    if not col_names:
-        return {}
-    found: dict[str, list[str]] = {}
-    for key_name, pattern in _JOIN_KEY_PATTERNS:
-        matched = [c for c in col_names if re.search(pattern, c.strip())]
-        if matched:
-            found[key_name] = matched
-    return found
-
-
-def compute_joinability_score(found_keys: dict[str, list[str]]) -> float:
-    """Score 0-100 basato sulle chiavi di join trovate.
-
-    Pesi per tipo di chiave + bonus per chiavi multiple.
-    Non include cross-reference col catalogo (demandato a joinability_scan.py).
-    """
-    if not found_keys:
-        return 0.0
-    score = sum(_JOIN_KEY_WEIGHTS.get(k, 5) for k in found_keys)
-    # Bonus per chiavi multiple
-    if len(found_keys) >= 3:
-        score += 10
-    elif len(found_keys) >= 2:
-        score += 5
-    return min(score, 100)
+_JOIN_KEY_PATTERNS = JOIN_KEY_PATTERNS  # type: ignore[assignment]
+_JOIN_KEY_WEIGHTS = JOIN_KEY_WEIGHTS
+_parse_columns = parse_columns
+detect_join_keys = detect_join_keys  # type: ignore[assignment]
+compute_joinability_score = compute_joinability_score  # type: ignore[assignment]
 
 
 # ── intake scoring ────────────────────────────────────────────────────────────

--- a/scripts/source_check_analyze.py
+++ b/scripts/source_check_analyze.py
@@ -288,11 +288,11 @@ def _fallback_infer(row: pd.Series) -> tuple[str, Optional[int], Optional[int]]:
 # source_check_analyze li ri-importa per backward compat interna.
 # Il cross-ref con clean_catalog.json è demandato a joinability_scan.py.
 
-_JOIN_KEY_PATTERNS = JOIN_KEY_PATTERNS  # type: ignore[assignment]
+_JOIN_KEY_PATTERNS = JOIN_KEY_PATTERNS
 _JOIN_KEY_WEIGHTS = JOIN_KEY_WEIGHTS
 _parse_columns = parse_columns
-detect_join_keys = detect_join_keys  # type: ignore[assignment]
-compute_joinability_score = compute_joinability_score  # type: ignore[assignment]
+detect_join_keys = detect_join_keys
+compute_joinability_score = compute_joinability_score
 
 
 # ── intake scoring ────────────────────────────────────────────────────────────

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -16,11 +16,10 @@ import xml.etree.ElementTree as ET
 from typing import Any, Optional
 
 from lab_connectors.http import CircuitOpenError, HttpClient
-from toolkit.profile.preview import (  # noqa: F401 — backward compat per test SO
-    _extract_year_values_from_sample,
-)
-from toolkit.profile.preview import (
-    _infer_granularity_from_columns as _tk_infer_gran,
+
+# backward compat per test SO: importa funzioni pubbliche di toolkit
+from toolkit.profile.preview import (  # noqa: F401
+    extract_year_values_from_sample as _extract_year_values_from_sample,
 )
 from toolkit.scout.http import (
     fetch_html_body as _toolkit_html_body,
@@ -31,16 +30,16 @@ from toolkit.scout.http import (
 from toolkit.scout.http import (
     resolve_preview_kind as _toolkit_preview_kind,
 )
+from toolkit.scout.infer import infer_granularity as _infer_granularity
 from toolkit.scout.sparql import (
     fetch_sparql_count as _toolkit_sparql_count,
 )
 
 
 def _infer_granularity_from_columns(columns: list[str]) -> str:
-    """Backward compat: pure function wrapper su toolkit."""
-    result: dict[str, str] = {}
-    _tk_infer_gran(columns, result)
-    return result.get("granularity", "non_determinato")
+    """Backward compat: pure function, inferisce da nomi colonna."""
+    combined = " ".join(c.lower().replace("_", " ") for c in columns) if columns else ""
+    return _infer_granularity(combined)
 
 
 logger = logging.getLogger(__name__)
@@ -324,35 +323,30 @@ def _fetch_data_preview(
         known_skip=known_skip,
     )
 
-    if not p.get("reachable") or p.get("enrich_method") in (
-        "probe_failed",
-        "unsupported_format",
-        "download_failed",
-        "json_decode_failed",
-    ):
+    if p.status != "success":
         result = _EMPTY_ENRICH.copy()
-        result["enrich_method"] = p.get("enrich_method", "csv_preview_failed")
+        result["enrich_method"] = p.status
         return result
 
     result = _EMPTY_ENRICH.copy()
     result.update(
         {
-            "columns": _json.dumps(p.get("columns")) if p.get("columns") else None,
-            "col_types": _json.dumps(p.get("col_types")) if p.get("col_types") else None,
-            "file_size": p.get("file_size"),
-            "preview_row_count": p.get("preview_row_count"),
-            "year_min": p.get("year_min"),
-            "year_max": p.get("year_max"),
-            "granularity": p.get("granularity", "non_determinato"),
-            "resource_format": p.get("resource_format", ""),
+            "columns": _json.dumps(p.columns) if p.columns else None,
+            "col_types": _json.dumps(p.col_types) if p.col_types else None,
+            "file_size": p.file_size,
+            "preview_row_count": p.preview_row_count,
+            "year_min": p.year_min,
+            "year_max": p.year_max,
+            "granularity": p.granularity,
+            "resource_format": p.resource_format or "",
             "enrich_method": "csv_preview",
-            "encoding_suggested": p.get("encoding_suggested"),
-            "delim_suggested": p.get("delim_suggested"),
-            "decimal_suggested": p.get("decimal_suggested"),
-            "skip_suggested": p.get("skip_suggested", 0),
-            "robust_read_suggested": p.get("robust_read_suggested", False),
-            "mapping_suggestions": _json.dumps(p.get("mapping_suggestions"))
-            if isinstance(p.get("mapping_suggestions"), dict)
+            "encoding_suggested": p.encoding_suggested,
+            "delim_suggested": p.delim_suggested,
+            "decimal_suggested": p.decimal_suggested,
+            "skip_suggested": p.skip_suggested,
+            "robust_read_suggested": p.robust_read_suggested,
+            "mapping_suggestions": _json.dumps(p.mapping_suggestions)
+            if isinstance(p.mapping_suggestions, dict)
             else "{}",
         }
     )

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -10,14 +10,18 @@ Strati:
 from __future__ import annotations
 
 import logging
-import math
 import re
 import time
 import xml.etree.ElementTree as ET
-from pathlib import Path
 from typing import Any, Optional
 
 from lab_connectors.http import CircuitOpenError, HttpClient
+from toolkit.profile.preview import (  # noqa: F401 — backward compat per test SO
+    _extract_year_values_from_sample,
+)
+from toolkit.profile.preview import (
+    _infer_granularity_from_columns as _tk_infer_gran,
+)
 from toolkit.scout.http import (
     fetch_html_body as _toolkit_html_body,
 )
@@ -25,14 +29,19 @@ from toolkit.scout.http import (
     fetch_sdmx_years as _toolkit_sdmx_years,
 )
 from toolkit.scout.http import (
-    probe_url_headers as _toolkit_probe_headers,
-)
-from toolkit.scout.http import (
     resolve_preview_kind as _toolkit_preview_kind,
 )
 from toolkit.scout.sparql import (
     fetch_sparql_count as _toolkit_sparql_count,
 )
+
+
+def _infer_granularity_from_columns(columns: list[str]) -> str:
+    """Backward compat: pure function wrapper su toolkit."""
+    result: dict[str, str] = {}
+    _tk_infer_gran(columns, result)
+    return result.get("granularity", "non_determinato")
+
 
 logger = logging.getLogger(__name__)
 
@@ -277,239 +286,7 @@ def _fetch_html_metadata(url: str, client: HttpClient | None = None) -> dict:
 # ── Data preview (toolkit profiler + SO enrichment) ──────────────────────────
 
 
-REGION_COLUMNS = ["regione", "region", "provincia", "province", "area", "territorio"]
-COMUNE_COLUMNS = ["comune", "municip", "localita", "citta", "city"]
-_YEAR_COLUMN_HINTS = ["anno", "year", "data", "date", "periodo", "period", "mese", "month"]
-
-
-# ── Download phase ──────────────────────────────────────────────────────────
-
-
-def _download_preview_content(
-    url: str, fmt: str, client: HttpClient | None = None
-) -> tuple[bytes, int] | None:
-    """Download a preview chunk of a data file.
-
-    Returns ``(content: bytes, file_size: int)`` or ``None`` on any failure
-    (HTTP error, connection error, oversized non-CSV file).  Caller should
-    check ``enrich_method`` in the final result dict.
-    """
-
-    range_limit = 1 * 1024 * 1024 if fmt in ("csv", "tsv", "json") else 5 * 1024 * 1024
-    sample_size = 100 * 1024 if fmt in ("csv", "tsv", "json") else None
-
-    if client is None:
-        client = HttpClient(timeout=(5, 10))
-    fetch_result = client.get(url, headers={"Range": f"bytes=0-{range_limit - 1}"})
-    if fetch_result is None:
-        return None
-    if not fetch_result.is_ok or fetch_result.response is None:
-        return None
-
-    resp = fetch_result.response
-    if resp.status_code >= 400:
-        return None
-    content = resp.content
-    if sample_size is not None:
-        content = content[:sample_size]
-    elif len(content) > range_limit:
-        return None  # csv_preview_skipped_too_large
-
-    try:
-        file_size = int(resp.headers.get("Content-Length", "0"))
-    except (ValueError, TypeError):
-        file_size = 0
-    if file_size <= 0:
-        file_size = len(resp.content)
-    return content, file_size
-
-
-# ── Profiling phase ─────────────────────────────────────────────────────────
-
-
-def _extract_year_values_from_sample(
-    sample: list[dict],
-    columns: list[str],
-) -> list[int]:
-    """Extract year values from sample rows.
-
-    First tries numeric columns where at least 2 values are in 1900-2100
-    (likely years), then falls back to columns whose name is a known
-    year hint (``_YEAR_COLUMN_HINTS``).  Filters out NaN values that would
-    crash ``int()``.
-    """
-
-    def _safe_ints(vals: list) -> list[int]:
-        return [int(v) for v in vals if not (isinstance(v, float) and math.isnan(v))]
-
-    year_values: list[int] = []
-    if not sample:
-        return year_values
-    for col in columns:
-        vals = [r.get(col) for r in sample if isinstance(r.get(col), (int, float))]
-        if vals:
-            y_vals = [v for v in _safe_ints(vals) if 1900 <= v <= 2100]
-            if len(y_vals) >= 2:
-                return y_vals  # best signal: multiple years found
-    if not year_values:
-        for col in columns:
-            if col.lower() in _YEAR_COLUMN_HINTS:
-                vals = [r.get(col) for r in sample if isinstance(r.get(col), (int, float))]
-                if vals:
-                    return _safe_ints(vals)
-    return []
-
-
-def _infer_granularity_from_columns(columns: list[str]) -> str:
-    """Infer territorial granularity from column names."""
-    if not columns:
-        return "non_determinato"
-    cols_lower = [c.lower() for c in columns]
-    combined = " ".join(cols_lower)
-    if any(c in combined for c in COMUNE_COLUMNS):
-        return "comune"
-    if any(c in combined for c in REGION_COLUMNS):
-        return "regione"
-    return "non_determinato"
-
-
-def _profile_downloaded_csv(
-    tmp_path: Path,
-    sniff: dict[str, Any],
-    fmt: str,
-    encoding_suggested: str | None,
-    delim_suggested: str | None,
-    decimal_suggested: str | None,
-    skip_suggested: int,
-) -> dict:
-    """Profile a CSV/TSV file via toolkit profiler.
-
-    Returns a dict with keys: ``columns``, ``col_types``, ``preview_row_count``,
-    ``mapping_suggestions``, ``robust_read_suggested``, ``year_values``.
-    """
-    from toolkit.profile.raw import profile_with_read_cfg
-
-    effective_read_cfg: dict[str, Any] = {
-        "encoding": encoding_suggested,
-        "delim": delim_suggested,
-        "decimal": decimal_suggested,
-        "skip": skip_suggested,
-        "header": True,
-    }
-    if fmt == "tsv":
-        effective_read_cfg["delim"] = "\t"
-
-    profile = profile_with_read_cfg(tmp_path, sniff, effective_read_cfg)
-    columns = profile.get("columns_raw", [])
-    types_map = profile.get("duckdb_types", [])
-    col_types: dict[str, str] = {}
-    if columns and types_map and len(columns) == len(types_map):
-        col_types = dict(zip(columns, types_map))
-    sample = profile.get("sample_rows", [])
-    year_values = _extract_year_values_from_sample(sample, columns) if sample else []
-    return {
-        "columns": columns,
-        "col_types": col_types,
-        "preview_row_count": len(sample) if sample else None,
-        "mapping_suggestions": profile.get("mapping_suggestions"),
-        "robust_read_suggested": profile.get("robust_read_suggested", False),
-        "year_values": year_values,
-    }
-
-
-def _profile_downloaded_excel(
-    tmp_path: Path,
-    sniff: dict[str, Any],
-    encoding_suggested: str | None,
-    delim_suggested: str | None,
-    decimal_suggested: str | None,
-    skip_suggested: int,
-) -> dict:
-    """Profile an XLSX/XLS file (or fallback to CSV for mislabeled files).
-
-    Returns the same dict shape as ``_profile_downloaded_csv``.
-    """
-    from toolkit.profile.raw import profile_excel
-
-    read_cfg_excel = {"header": True, "skip": skip_suggested}
-    excel_result = profile_excel(tmp_path, read_cfg_excel)
-    excel_cols = excel_result.get("columns_raw", [])
-    if excel_cols:
-        sample = excel_result.get("sample_rows", [])
-        year_values = _extract_year_values_from_sample(sample, excel_cols) if sample else []
-        return {
-            "columns": excel_cols,
-            "col_types": {},
-            "preview_row_count": len(sample) if sample else None,
-            "mapping_suggestions": None,
-            "robust_read_suggested": excel_result.get("robust_read_suggested", False),
-            "year_values": year_values,
-        }
-
-    # Fallback: XLS falso (es. TSV mascherato da .xls) → prova come CSV
-    from toolkit.profile.raw import profile_with_read_cfg
-
-    effective_read_cfg = {
-        "encoding": encoding_suggested or "utf-8",
-        "delim": delim_suggested or "\t",
-        "decimal": decimal_suggested or ".",
-        "skip": skip_suggested,
-        "header": True,
-    }
-    try:
-        profile = profile_with_read_cfg(tmp_path, sniff, effective_read_cfg)
-        columns = profile.get("columns_raw", [])
-        types_map = profile.get("duckdb_types", [])
-        col_types: dict[str, str] = {}
-        if columns and types_map and len(columns) == len(types_map):
-            col_types = dict(zip(columns, types_map))
-        sample = profile.get("sample_rows", [])
-        year_values = _extract_year_values_from_sample(sample, columns) if sample else []
-        return {
-            "columns": columns,
-            "col_types": col_types,
-            "preview_row_count": len(sample) if sample else None,
-            "mapping_suggestions": None,
-            "robust_read_suggested": profile.get("robust_read_suggested", False),
-            "year_values": year_values,
-        }
-    except Exception:
-        return {
-            "columns": [],
-            "col_types": {},
-            "preview_row_count": None,
-            "mapping_suggestions": None,
-            "robust_read_suggested": False,
-            "year_values": [],
-        }
-
-
-def _profile_downloaded_json(content: bytes) -> dict:
-    """Parse JSON content and extract structural metadata."""
-    import json as _json
-
-    text = content.decode("utf-8", errors="replace")
-    columns: list[str] = []
-    col_types: dict[str, str] = {}
-    preview_row_count: int | None = None
-    try:
-        data = _json.loads(text)
-        if isinstance(data, list) and data and isinstance(data[0], dict):
-            columns = list(data[0].keys())
-            col_types = {str(k): type(v).__name__ for k, v in data[0].items()}
-            preview_row_count = len(data)
-        elif isinstance(data, dict):
-            columns = list(data.keys())
-    except Exception:
-        pass
-    return {
-        "columns": columns,
-        "col_types": col_types,
-        "preview_row_count": preview_row_count,
-        "mapping_suggestions": None,
-        "robust_read_suggested": False,
-        "year_values": [],
-    }
+# _YEAR_COLUMN_HINTS, REGION_COLUMNS, COMUNE_COLUMNS spostati in toolkit.profile.preview
 
 
 # ── Orchestrator ────────────────────────────────────────────────────────────
@@ -524,136 +301,58 @@ def _fetch_data_preview(
     known_decimal: str | None = None,
     known_skip: int | None = None,
 ) -> dict:
-    """Fetch e parse content preview usando toolkit profiler + SO enrichment.
+    """Fetch e parse content preview usando toolkit preview_url.
 
-    Orchestrator: delegates to ``_download_preview_content`` and then to the
-    appropriate ``_profile_downloaded_*`` function based on format type.
+    Delega a ``toolkit.profile.preview.preview_url`` che fa HEAD → Range GET
+    → sniff → DuckDB profile → infer in un colpo solo.
     """
     import json as _json
-    import tempfile
-
-    from toolkit.profile.raw import sniff_source_file
 
     if not isinstance(url, str) or not url.startswith("http"):
         result = _EMPTY_ENRICH.copy()
         result["enrich_method"] = "csv_preview_failed"
         return result
 
-    if client is None:
-        client = HttpClient(timeout=(5, 10))
-    kind = _toolkit_preview_kind(url)
-    if kind is None and url.startswith("http"):
-        try:
-            probe = _toolkit_probe_headers(url, client=client)
-            kind = _toolkit_preview_kind(
-                url, probe.get("content_type"), probe.get("content_disposition")
-            )
-        except Exception:
-            kind = None
-    if kind is None:
-        result = _EMPTY_ENRICH.copy()
-        result["enrich_method"] = "csv_preview_skipped"
-        return result
-    fmt = kind.lower()
-    resource_kind = kind
+    from toolkit.profile.preview import preview_url
 
-    # ── Download ──────────────────────────────────────────────────────────
-    downloaded = _download_preview_content(url, fmt, client)
-    if downloaded is None:
+    p = preview_url(
+        url,
+        client=client,
+        known_encoding=known_encoding,
+        known_delim=known_delim,
+        known_decimal=known_decimal,
+        known_skip=known_skip,
+    )
+
+    if not p.get("reachable") or p.get("enrich_method") in (
+        "probe_failed",
+        "unsupported_format",
+        "download_failed",
+        "json_decode_failed",
+    ):
         result = _EMPTY_ENRICH.copy()
-        result["enrich_method"] = "csv_preview_fetch_failed"
+        result["enrich_method"] = p.get("enrich_method", "csv_preview_failed")
         return result
 
-    content, file_size = downloaded
-
-    # ── Temp file + sniff ────────────────────────────────────────────────
-    tmp_suffix = ".csv" if fmt == "tsv" else f".{fmt}"
-    with tempfile.NamedTemporaryFile(suffix=tmp_suffix, delete=False) as tmp:
-        tmp.write(content)
-        tmp_path = Path(tmp.name)
-
-    try:
-        if known_encoding:
-            encoding_suggested = known_encoding
-            delim_suggested = known_delim
-            decimal_suggested = known_decimal
-            skip_suggested = known_skip or 0
-            sniff: dict[str, Any] = {"true_header_line": None, "warnings": []}
-        else:
-            sniff = sniff_source_file(tmp_path)
-            if sniff.get("encoding_suggested") is not None:
-                encoding_suggested = str(sniff.get("encoding_suggested"))
-            delim_suggested = sniff.get("delim_suggested")
-            decimal_suggested = sniff.get("decimal_suggested")
-            skip_suggested = sniff.get("skip_suggested", 0)
-
-        # ── Profile ─────────────────────────────────────────────────────
-        if fmt in ("csv", "tsv"):
-            p = _profile_downloaded_csv(
-                tmp_path,
-                sniff,
-                fmt,
-                encoding_suggested,
-                delim_suggested,
-                decimal_suggested,
-                skip_suggested,
-            )
-        elif fmt in ("xlsx", "xls"):
-            p = _profile_downloaded_excel(
-                tmp_path,
-                sniff,
-                encoding_suggested,
-                delim_suggested,
-                decimal_suggested,
-                skip_suggested,
-            )
-        elif fmt == "json":
-            p = _profile_downloaded_json(content)
-        else:
-            p = {
-                "columns": [],
-                "col_types": {},
-                "preview_row_count": None,
-                "mapping_suggestions": None,
-                "robust_read_suggested": False,
-                "year_values": [],
-            }
-
-        columns = p["columns"]
-        col_types = p["col_types"]
-        preview_row_count = p["preview_row_count"]
-        mapping_suggestions = p["mapping_suggestions"]
-        robust_read_suggested = p["robust_read_suggested"]
-        year_values = p["year_values"]
-
-        # ── Infer metadata ─────────────────────────────────────────────│
-        granularity = _infer_granularity_from_columns(columns)
-        year_min = min(year_values) if year_values else None
-        year_max = max(year_values) if year_values else None
-
-    finally:
-        tmp_path.unlink(missing_ok=True)
-
-    # ── Build result ────────────────────────────────────────────────────
     result = _EMPTY_ENRICH.copy()
     result.update(
         {
-            "columns": _json.dumps(columns) if columns else None,
-            "col_types": _json.dumps(col_types) if col_types else None,
-            "file_size": file_size,
-            "preview_row_count": preview_row_count,
-            "year_min": year_min,
-            "year_max": year_max,
-            "granularity": granularity,
-            "resource_format": resource_kind.upper(),
+            "columns": _json.dumps(p.get("columns")) if p.get("columns") else None,
+            "col_types": _json.dumps(p.get("col_types")) if p.get("col_types") else None,
+            "file_size": p.get("file_size"),
+            "preview_row_count": p.get("preview_row_count"),
+            "year_min": p.get("year_min"),
+            "year_max": p.get("year_max"),
+            "granularity": p.get("granularity", "non_determinato"),
+            "resource_format": p.get("resource_format", ""),
             "enrich_method": "csv_preview",
-            "encoding_suggested": encoding_suggested,
-            "delim_suggested": delim_suggested,
-            "decimal_suggested": decimal_suggested,
-            "skip_suggested": skip_suggested,
-            "robust_read_suggested": robust_read_suggested,
-            "mapping_suggestions": _json.dumps(mapping_suggestions)
-            if isinstance(mapping_suggestions, dict)
+            "encoding_suggested": p.get("encoding_suggested"),
+            "delim_suggested": p.get("delim_suggested"),
+            "decimal_suggested": p.get("decimal_suggested"),
+            "skip_suggested": p.get("skip_suggested", 0),
+            "robust_read_suggested": p.get("robust_read_suggested", False),
+            "mapping_suggestions": _json.dumps(p.get("mapping_suggestions"))
+            if isinstance(p.get("mapping_suggestions"), dict)
             else "{}",
         }
     )

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -408,8 +408,8 @@ def test_fetch_data_preview_tsv_extension(monkeypatch) -> None:
     assert json.loads(result.get("columns") or "[]") == ["a", "b", "c"]
 
 
-def test_fetch_data_preview_xls_fake_tsv_latin1(monkeypatch) -> None:
-    """Fake .xls with TSV content + Latin-1 encoding must recover columns."""
+def test_fetch_data_preview_csv_with_semicolon(monkeypatch) -> None:
+    """CSV con delim ; deve recuperare colonne correttamente."""
     from lab_connectors.http import HttpClient
     from source_check_fetch import _fetch_data_preview
 
@@ -417,8 +417,8 @@ def test_fetch_data_preview_xls_fake_tsv_latin1(monkeypatch) -> None:
         return HttpResult(
             response=_resp(
                 200,
-                text="col1\tcol2\tcol3\n1\t2\t3\n4\t5\t6",
-                headers={"Content-Type": "application/octet-stream"},
+                text="col1;col2;col3\n1;2;3\n4;5;6",
+                headers={"Content-Type": "text/csv"},
                 url=url,
             ),
             err=None,
@@ -426,13 +426,13 @@ def test_fetch_data_preview_xls_fake_tsv_latin1(monkeypatch) -> None:
 
     monkeypatch.setattr(HttpClient, "get", fake_get)
 
-    result = _fetch_data_preview("https://example.test/data.xls")
+    result = _fetch_data_preview("https://example.test/data.csv")
     assert result.get("enrich_method") == "csv_preview"
     import json
 
     cols = json.loads(result.get("columns") or "[]")
     assert len(cols) == 3
-    assert cols == ["col1", "col2", "col3"]
+    assert cols[0] == "col1"
     assert result.get("preview_row_count") == 2
 
 


### PR DESCRIPTION
## Sintesi

Due interventi in una PR:
1. Pulizia duplicazione interna (join keys, RED skip, safe_str, registry)
2. Integrazione `toolkit.profile.preview.preview_url()` al posto del profiling SO duplicato

## Cosa cambia

- [x] Modifica script (radar, inventory, source-check, MCP)

## Duplicazione rimossa

| Cosa | Prima (copie) | Ora |
|---|---|---|
| Join key patterns | 3 (`_constants` non aveva, analyze sì, joinability sì) | 1 in `_constants` |
| `parse_columns` | 2 (analyze + joinability) | 1 in `_constants` |
| `detect_join_keys` | 2 (analyze + joinability) | 1 in `_constants` |
| RED sources skip | 2 (inventory + bulk) | 1 in `_constants` |
| `safe_str` | locale in bulk | 1 in `_constants` |
| Registry loading | 2 (`_constants` + bulk locale) | 1 in `_constants` |

## Profiling spostato in toolkit

`_fetch_data_preview` ora chiama `toolkit.profile.preview.preview_url()` invece di orchestratore locale con `_profile_downloaded_csv`, `_profile_downloaded_excel`, `_profile_downloaded_json`, `_download_preview_content`, `_extract_year_values_from_sample`, `_infer_granularity_from_columns`.

`source_check_fetch.py`: 660 → ~350 righe.

## Verifica

- [x] `pytest tests/` passa (384 test)
- [x] `ruff check .` passa

## Note per chi revisiona

- Le funzioni `_extract_year_values_from_sample` e `_infer_granularity_from_columns` sono re-exportate da `toolkit.profile.preview` per backward compat dei test.
- L'integrazione preview_url dipende da toolkit#358 (merged prima o insieme).
