### PR TITLE
feat: integra PAQA score in source_check_results + filtro min_paqa_score in MCP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.15.0",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.36.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.36.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git@v0.15.0",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.34.2",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.36.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -684,7 +684,9 @@ def _check_row(
         "paqa_verdict": preview_meta.get("paqa_verdict") or enrich.get("paqa_verdict"),
         "paqa_flags": preview_meta.get("paqa_flags") or enrich.get("paqa_flags"),
         "paqa_ontologies": preview_meta.get("paqa_ontologies") or enrich.get("paqa_ontologies"),
-        "paqa_sampled": preview_meta.get("paqa_sampled") or enrich.get("paqa_sampled"),
+        "paqa_sampled": preview_meta["paqa_sampled"]
+        if "paqa_sampled" in preview_meta
+        else enrich.get("paqa_sampled"),
         "source_status": row.get("source_status", "unknown"),
         "needs_review": (granularity == "non_determinato") or pd.isna(year_min),
         "intake_score": None,  # placeholder, calcolato sotto

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -499,6 +499,12 @@ def _preview_meta_from_enrich(enrich: dict[str, Any]) -> dict[str, Any]:
         "skip_suggested": enrich.get("skip_suggested"),
         "robust_read_suggested": enrich.get("robust_read_suggested"),
         "mapping_suggestions": mapping_val,
+        # PAQA quality score (toolkit v1.36.0+)
+        "paqa_score": enrich.get("paqa_score"),
+        "paqa_verdict": enrich.get("paqa_verdict"),
+        "paqa_flags": enrich.get("paqa_flags"),
+        "paqa_ontologies": enrich.get("paqa_ontologies"),
+        "paqa_sampled": enrich.get("paqa_sampled"),
     }
 
 
@@ -673,6 +679,12 @@ def _check_row(
         "skip_suggested": preview_meta.get("skip_suggested") or enrich.get("skip_suggested"),
         "robust_read_suggested": preview_meta.get("robust_read_suggested"),
         "mapping_suggestions": preview_meta.get("mapping_suggestions"),
+        # PAQA quality score (toolkit v1.36.0+)
+        "paqa_score": preview_meta.get("paqa_score") or enrich.get("paqa_score"),
+        "paqa_verdict": preview_meta.get("paqa_verdict") or enrich.get("paqa_verdict"),
+        "paqa_flags": preview_meta.get("paqa_flags") or enrich.get("paqa_flags"),
+        "paqa_ontologies": preview_meta.get("paqa_ontologies") or enrich.get("paqa_ontologies"),
+        "paqa_sampled": preview_meta.get("paqa_sampled") or enrich.get("paqa_sampled"),
         "source_status": row.get("source_status", "unknown"),
         "needs_review": (granularity == "non_determinato") or pd.isna(year_min),
         "intake_score": None,  # placeholder, calcolato sotto

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -76,7 +76,7 @@ _EMPTY_ENRICH: dict[str, Any] = {
     "paqa_verdict": None,
     "paqa_flags": None,
     "paqa_ontologies": None,
-    "paqa_sampled": None,
+    "paqa_sampled": None,  # bool: True = campione, False/None = file completo
 }
 
 
@@ -357,7 +357,7 @@ def _fetch_data_preview(
             "paqa_verdict": p.quality_verdict,
             "paqa_flags": _json.dumps(p.quality_flags) if p.quality_flags else None,
             "paqa_ontologies": _json.dumps(p.quality_ontologies) if p.quality_ontologies else None,
-            "paqa_sampled": p.quality_note or None,
+            "paqa_sampled": p.quality_sampled,  # bool: True se campione
         }
     )
     return result

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -72,6 +72,11 @@ _EMPTY_ENRICH: dict[str, Any] = {
     "sdmx_agency": None,
     "sparql_responding": None,
     "sparql_triple_count": None,
+    "paqa_score": None,
+    "paqa_verdict": None,
+    "paqa_flags": None,
+    "paqa_ontologies": None,
+    "paqa_sampled": None,
 }
 
 
@@ -348,6 +353,11 @@ def _fetch_data_preview(
             "mapping_suggestions": _json.dumps(p.mapping_suggestions)
             if isinstance(p.mapping_suggestions, dict)
             else "{}",
+            "paqa_score": p.quality_score,
+            "paqa_verdict": p.quality_verdict,
+            "paqa_flags": _json.dumps(p.quality_flags) if p.quality_flags else None,
+            "paqa_ontologies": _json.dumps(p.quality_ontologies) if p.quality_ontologies else None,
+            "paqa_sampled": p.quality_note or None,
         }
     )
     return result

--- a/so_mcp/_inventory.py
+++ b/so_mcp/_inventory.py
@@ -16,6 +16,7 @@ from . import _artifact
 def query_inventory(
     source_id: str | None = None,
     min_score: int | None = None,
+    min_paqa_score: int | None = None,
     limit: int = 50,
     has_results: bool | None = None,
     grouped: bool = False,
@@ -58,6 +59,9 @@ def query_inventory(
                     if min_score is not None:
                         filters.append("intake_score >= ?")
                         params.append(min_score)
+                    if min_paqa_score is not None and "paqa_score" in col_set:
+                        filters.append("paqa_score >= ?")
+                        params.append(min_paqa_score)
                     if has_results is not None:
                         if has_results:
                             filters.append("intake_score IS NOT NULL AND intake_score > 0")
@@ -85,6 +89,7 @@ def query_inventory(
                         "filters": {
                             "source_id": source_id,
                             "min_score": min_score,
+                            "min_paqa_score": min_paqa_score,
                             "limit": safe_limit,
                             "has_results": has_results,
                             "grouped": True,
@@ -105,6 +110,9 @@ def query_inventory(
                     if min_score is not None:
                         query_parts.append("intake_score >= ?")
                         params.append(min_score)
+                    if min_paqa_score is not None:
+                        query_parts.append("paqa_score >= ?")
+                        params.append(min_paqa_score)
                     if has_results is not None:
                         if has_results:
                             query_parts.append("intake_score IS NOT NULL AND intake_score > 0")
@@ -129,6 +137,7 @@ def query_inventory(
         "filters": {
             "source_id": source_id,
             "min_score": min_score,
+            "min_paqa_score": min_paqa_score,
             "limit": safe_limit,
             "has_results": has_results,
             "grouped": bool(grouped),

--- a/so_mcp/_inventory.py
+++ b/so_mcp/_inventory.py
@@ -66,10 +66,7 @@ def query_inventory(
                         filters.append("paqa_score >= ?")
                         params.append(min_paqa_score)
                     elif min_paqa_score is not None:
-                        logger.warning(
-                            "min_paqa_score=%d ignored — paqa_score not in artifact (toolkit < v1.36.1)",
-                            min_paqa_score,
-                        )
+                        filters.append("1=0")  # colonna non disponibile → zero risultati
                     if has_results is not None:
                         if has_results:
                             filters.append("intake_score IS NOT NULL AND intake_score > 0")
@@ -121,6 +118,8 @@ def query_inventory(
                     if min_paqa_score is not None and "paqa_score" in col_set:
                         query_parts.append("paqa_score >= ?")
                         params.append(min_paqa_score)
+                    elif min_paqa_score is not None:
+                        query_parts.append("1=0")  # colonna non disponibile → zero risultati
                     if has_results is not None:
                         if has_results:
                             query_parts.append("intake_score IS NOT NULL AND intake_score > 0")

--- a/so_mcp/_inventory.py
+++ b/so_mcp/_inventory.py
@@ -152,6 +152,7 @@ def query_inventory(
         "results": [dict(zip(result_cols, row)) for row in rows],
         "returned": len(rows),
         "has_more": len(rows) == safe_limit,
+        "paqa_filter_available": "paqa_score" in col_set if min_paqa_score is not None else None,
     }
     if grouped and has_group_col:
         result["grouped"] = True

--- a/so_mcp/_inventory.py
+++ b/so_mcp/_inventory.py
@@ -6,11 +6,14 @@ parquet files, and the inventory report.
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from lab_connectors.duckdb import gcs_connect
 
 from . import _artifact
+
+logger = logging.getLogger("so_mcp._inventory")
 
 
 def query_inventory(
@@ -62,6 +65,11 @@ def query_inventory(
                     if min_paqa_score is not None and "paqa_score" in col_set:
                         filters.append("paqa_score >= ?")
                         params.append(min_paqa_score)
+                    elif min_paqa_score is not None:
+                        logger.warning(
+                            "min_paqa_score=%d ignored — paqa_score not in artifact (toolkit < v1.36.1)",
+                            min_paqa_score,
+                        )
                     if has_results is not None:
                         if has_results:
                             filters.append("intake_score IS NOT NULL AND intake_score > 0")
@@ -110,7 +118,7 @@ def query_inventory(
                     if min_score is not None:
                         query_parts.append("intake_score >= ?")
                         params.append(min_score)
-                    if min_paqa_score is not None:
+                    if min_paqa_score is not None and "paqa_score" in col_set:
                         query_parts.append("paqa_score >= ?")
                         params.append(min_paqa_score)
                     if has_results is not None:

--- a/so_mcp/so_server.py
+++ b/so_mcp/so_server.py
@@ -39,19 +39,27 @@ mcp = create_mcp_server(
 
 
 @mcp.tool(
-    description="Query source_check_results.parquet: top candidate filtrati per fonte e score. "
+    description="Query source_check_results.parquet: top candidate filtrati per fonte, intake_score e paqa_score. "
     "Con grouped=True, aggrega per dataset_group (stesso dataset multi-anno/versione).",
     structured_output=True,
 )
 def so_inventory_query(
     source_id: str | None = None,
     min_score: int | None = None,
+    min_paqa_score: int | None = None,
     limit: int = 50,
     has_results: bool | None = None,
     grouped: bool = False,
 ) -> dict[str, Any]:
     return guard_timed(
-        query_inventory, "so_inventory_query", source_id, min_score, limit, has_results, grouped
+        query_inventory,
+        "so_inventory_query",
+        source_id,
+        min_score,
+        min_paqa_score,
+        limit,
+        has_results,
+        grouped,
     )
 
 

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -1316,39 +1316,81 @@ class TestSparqlCheckRowPassthrough:
         assert result["enrich_method"] == "sparql_probe"
 
 
-# ─── PAQA: propagazione end-to-end _fetch_data_preview → parquet ──────────────
+# ─── PAQA: propagazione _fetch_data_preview → _check_row → parquet ─────────────
 
 
-@pytest.mark.smoke
-def test_paqa_fields_flow_through_preview() -> None:
-    """_fetch_data_preview su CSV reale produce i 5 campi paqa_*."""
-    from lab_connectors.http import HttpClient
-    from source_check_fetch import _fetch_data_preview
+class TestPaqaCheckRowPassthrough:
+    """contract: _check_row propaga i 5 campi paqa_* nel risultato."""
 
-    client = HttpClient(timeout=(5, 10))
-    result = _fetch_data_preview(
-        "https://www.mimit.gov.it/images/exportCSV/prezzo_alle_8.csv",
-        client=client,
-    )
-    client.close()
+    def test_paqa_fields_in_result(self, monkeypatch):
+        import numpy as np
+        import pandas as pd
+        import yaml
+        from bulk_source_check import _check_row
 
-    assert result["enrich_method"] == "csv_preview", (
-        f"expected csv_preview, got {result.get('enrich_method')}"
-    )
-    assert result.get("paqa_score") is not None, "paqa_score mancante"
-    assert result.get("paqa_verdict") is not None, "paqa_verdict mancante"
-    # paqa_flags e paqa_ontologies possono essere None/[] su CSV semplici
-    assert "paqa_flags" in result, "paqa_flags mancante"
-    assert "paqa_ontologies" in result, "paqa_ontologies mancante"
-    # paqa_sampled può essere True/False/None
-    assert "paqa_sampled" in result, "paqa_sampled mancante"
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
 
-    # Verifica anche che _preview_meta_from_enrich li propaghi
-    from bulk_source_check import _preview_meta_from_enrich
+        import bulk_source_check as bsc
 
-    meta = _preview_meta_from_enrich(result)
-    assert meta.get("paqa_score") is not None, "paqa_score perso in preview_meta"
-    assert meta.get("paqa_verdict") is not None, "paqa_verdict perso in preview_meta"
+        def _mock_preview(*a, **kw):
+            return {
+                "enrich_method": "csv_preview",
+                "paqa_score": 94,
+                "paqa_verdict": "buona",
+                "paqa_flags": '["column_naming"]',
+                "paqa_ontologies": '{"TI": ["TI (TimeInterval)"]}',
+                "paqa_sampled": False,
+                "granularity": "comune",
+                "year_min": 2024,
+                "year_max": 2024,
+                "columns": '["a","b"]',
+                "col_types": '{"a": "VARCHAR", "b": "BIGINT"}',
+                "file_size": 500,
+                "preview_row_count": 10,
+                "encoding_suggested": "utf-8",
+                "delim_suggested": ",",
+                "decimal_suggested": None,
+                "skip_suggested": 0,
+                "robust_read_suggested": False,
+                "mapping_suggestions": "{}",
+            }
+
+        monkeypatch.setattr(bsc, "_fetch_data_preview", _mock_preview)
+        monkeypatch.setattr(bsc, "_http_head_with_retry", lambda *a, **kw: (200, True, None, None))
+
+        row = pd.Series(
+            {
+                "source_id": "test_paqa",
+                "item_id": "paqa_001",
+                "item_name": "test-paqa-flow",
+                "title": "Test PAQA propagation",
+                "organization": np.nan,
+                "tags": np.nan,
+                "notes_excerpt": np.nan,
+                "url": "https://example.com/test.csv",
+                "landing_page": np.nan,
+                "distribution_url": np.nan,
+                "format": "CSV",
+                "protocol": np.nan,
+                "source_url": np.nan,
+                "api_base_url": np.nan,
+                "granularity": np.nan,
+                "year_signal": np.nan,
+                "encoding_suggested": np.nan,
+                "delim_suggested": np.nan,
+                "decimal_suggested": np.nan,
+                "skip_suggested": np.nan,
+                "source_status": "active",
+            }
+        )
+        result = _check_row(row, "2026-06-08T12:00:00", registry)
+
+        assert result.get("paqa_score") == 94, f"paqa_score: {result.get('paqa_score')}"
+        assert result.get("paqa_verdict") == "buona", f"paqa_verdict: {result.get('paqa_verdict')}"
+        assert result.get("paqa_flags") is not None, "paqa_flags mancante"
+        assert result.get("paqa_ontologies") is not None, "paqa_ontologies mancante"
+        assert result.get("paqa_sampled") is False, f"paqa_sampled: {result.get('paqa_sampled')}"
 
 
 pytestmark = pytest.mark.contract

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -1316,4 +1316,39 @@ class TestSparqlCheckRowPassthrough:
         assert result["enrich_method"] == "sparql_probe"
 
 
+# ─── PAQA: propagazione end-to-end _fetch_data_preview → parquet ──────────────
+
+
+@pytest.mark.smoke
+def test_paqa_fields_flow_through_preview() -> None:
+    """_fetch_data_preview su CSV reale produce i 5 campi paqa_*."""
+    from lab_connectors.http import HttpClient
+    from source_check_fetch import _fetch_data_preview
+
+    client = HttpClient(timeout=(5, 10))
+    result = _fetch_data_preview(
+        "https://www.mimit.gov.it/images/exportCSV/prezzo_alle_8.csv",
+        client=client,
+    )
+    client.close()
+
+    assert result["enrich_method"] == "csv_preview", (
+        f"expected csv_preview, got {result.get('enrich_method')}"
+    )
+    assert result.get("paqa_score") is not None, "paqa_score mancante"
+    assert result.get("paqa_verdict") is not None, "paqa_verdict mancante"
+    # paqa_flags e paqa_ontologies possono essere None/[] su CSV semplici
+    assert "paqa_flags" in result, "paqa_flags mancante"
+    assert "paqa_ontologies" in result, "paqa_ontologies mancante"
+    # paqa_sampled può essere True/False/None
+    assert "paqa_sampled" in result, "paqa_sampled mancante"
+
+    # Verifica anche che _preview_meta_from_enrich li propaghi
+    from bulk_source_check import _preview_meta_from_enrich
+
+    meta = _preview_meta_from_enrich(result)
+    assert meta.get("paqa_score") is not None, "paqa_score perso in preview_meta"
+    assert meta.get("paqa_verdict") is not None, "paqa_verdict perso in preview_meta"
+
+
 pytestmark = pytest.mark.contract

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -946,7 +946,7 @@ def test_query_inventory_min_paqa_score_filters(tmp_path, monkeypatch) -> None:
 
 
 def test_query_inventory_min_paqa_score_no_column(tmp_path, monkeypatch) -> None:
-    """min_paqa_score non fallisce quando paqa_score manca (artifact < v1.36.1)."""
+    """min_paqa_score su artifact senza paqa_score → zero risultati."""
     parquet_path = tmp_path / "source_check_results.parquet"
     _write_parquet(
         parquet_path,
@@ -957,11 +957,11 @@ def test_query_inventory_min_paqa_score_no_column(tmp_path, monkeypatch) -> None
     monkeypatch.setattr(_artifact, "_CHECK_PARQUET", parquet_path)
     monkeypatch.setattr(_artifact, "_artifact_backend", lambda: "local")
     result = query_inventory(source_id="a", min_paqa_score=70)
-    assert result["returned"] == 1  # filtro ignorato, nessun errore
+    assert result["returned"] == 0  # colonna mancante → nessun risultato
 
 
 def test_query_inventory_min_paqa_score_grouped(tmp_path, monkeypatch) -> None:
-    """min_paqa_score in grouped mode con colonna presente."""
+    """min_paqa_score in grouped mode esclude gruppi sotto soglia."""
     parquet_path = tmp_path / "source_check_results.parquet"
     _write_parquet(
         parquet_path,
@@ -972,7 +972,7 @@ def test_query_inventory_min_paqa_score_grouped(tmp_path, monkeypatch) -> None:
                 "intake_score": 50,
                 "paqa_score": 90,
                 "dataset_group": "s1/g1",
-                "dataset_group_size": 2,
+                "dataset_group_size": 1,
                 "dataset_group_year_min": 2020,
                 "dataset_group_year_max": 2024,
             },
@@ -980,9 +980,9 @@ def test_query_inventory_min_paqa_score_grouped(tmp_path, monkeypatch) -> None:
                 "source_id": "s1",
                 "item_id": "b",
                 "intake_score": 50,
-                "paqa_score": 70,
-                "dataset_group": "s1/g1",
-                "dataset_group_size": 2,
+                "paqa_score": 60,
+                "dataset_group": "s1/g2",
+                "dataset_group_size": 1,
                 "dataset_group_year_min": 2020,
                 "dataset_group_year_max": 2024,
             },
@@ -991,7 +991,8 @@ def test_query_inventory_min_paqa_score_grouped(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(_artifact, "_CHECK_PARQUET", parquet_path)
     monkeypatch.setattr(_artifact, "_artifact_backend", lambda: "local")
     result = query_inventory(source_id="s1", grouped=True, min_paqa_score=80)
-    assert result["returned"] >= 1
+    assert result["returned"] == 1  # solo g1 (paqa_score=90) supera 80
+    assert result["results"][0]["dataset_group"] == "s1/g1"
 
 
 # ─── Discovery: list_source_items ───────────────────────────────────────────────

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -924,6 +924,76 @@ def test_query_inventory_grouped_aggregates(tmp_path, monkeypatch) -> None:
     assert results[1]["best_score"] == 50
 
 
+# ─── PAQA: min_paqa_score ─────────────────────────────────────────────────────
+
+
+def test_query_inventory_min_paqa_score_filters(tmp_path, monkeypatch) -> None:
+    """min_paqa_score filtra quando paqa_score esiste."""
+    parquet_path = tmp_path / "source_check_results.parquet"
+    _write_parquet(
+        parquet_path,
+        [
+            {"source_id": "a", "item_id": "x1", "intake_score": 50, "paqa_score": 80},
+            {"source_id": "a", "item_id": "x2", "intake_score": 50, "paqa_score": 60},
+            {"source_id": "a", "item_id": "x3", "intake_score": 50, "paqa_score": None},
+        ],
+    )
+    monkeypatch.setattr(_artifact, "_CHECK_PARQUET", parquet_path)
+    monkeypatch.setattr(_artifact, "_artifact_backend", lambda: "local")
+    result = query_inventory(source_id="a", min_paqa_score=70)
+    assert result["returned"] == 1
+    assert result["results"][0]["item_id"] == "x1"
+
+
+def test_query_inventory_min_paqa_score_no_column(tmp_path, monkeypatch) -> None:
+    """min_paqa_score non fallisce quando paqa_score manca (artifact < v1.36.1)."""
+    parquet_path = tmp_path / "source_check_results.parquet"
+    _write_parquet(
+        parquet_path,
+        [
+            {"source_id": "a", "item_id": "x1", "intake_score": 50},
+        ],
+    )
+    monkeypatch.setattr(_artifact, "_CHECK_PARQUET", parquet_path)
+    monkeypatch.setattr(_artifact, "_artifact_backend", lambda: "local")
+    result = query_inventory(source_id="a", min_paqa_score=70)
+    assert result["returned"] == 1  # filtro ignorato, nessun errore
+
+
+def test_query_inventory_min_paqa_score_grouped(tmp_path, monkeypatch) -> None:
+    """min_paqa_score in grouped mode con colonna presente."""
+    parquet_path = tmp_path / "source_check_results.parquet"
+    _write_parquet(
+        parquet_path,
+        [
+            {
+                "source_id": "s1",
+                "item_id": "a",
+                "intake_score": 50,
+                "paqa_score": 90,
+                "dataset_group": "s1/g1",
+                "dataset_group_size": 2,
+                "dataset_group_year_min": 2020,
+                "dataset_group_year_max": 2024,
+            },
+            {
+                "source_id": "s1",
+                "item_id": "b",
+                "intake_score": 50,
+                "paqa_score": 70,
+                "dataset_group": "s1/g1",
+                "dataset_group_size": 2,
+                "dataset_group_year_min": 2020,
+                "dataset_group_year_max": 2024,
+            },
+        ],
+    )
+    monkeypatch.setattr(_artifact, "_CHECK_PARQUET", parquet_path)
+    monkeypatch.setattr(_artifact, "_artifact_backend", lambda: "local")
+    result = query_inventory(source_id="s1", grouped=True, min_paqa_score=80)
+    assert result["returned"] >= 1
+
+
 # ─── Discovery: list_source_items ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Sintesi

Integra il quality score PAQA (toolkit v1.36.0) in SO: i campi `paqa_score`, `paqa_verdict`, `paqa_flags`, `paqa_ontologies`, `paqa_sampled` vengono popolati da `preview_url` e finiscono in `source_check_results.parquet`. Il tool MCP `so_inventory_query` espone un nuovo filtro `min_paqa_score`.

## Cosa cambia

- [x] Nuova funzionalità
- [x] Dipendenze o CI (toolkit pin v1.34.2 → v1.36.0)

## Contesto

Toolkit PR #369 — nuovo modulo `toolkit/quality/pa_csv_quality.py` che valuta la qualità di un CSV secondo criteri PA (encoding, header, naming colonne, ontologie). Il quality score PAQA affianca `intake_score`:

- `intake_score`: "questa fonte vale la pena?"
- `paqa_score`: "questo CSV è pubblicato bene?"

## Verifica

```bash
# Test locale su INPS
python scripts/bulk_source_check.py --source-ids inps --limit 3 --out /tmp/test.parquet
# I campi paqa_* sono nel parquet quando enrich_method = csv_preview
```

## Checklist PR

- [x] Perimetro stretto: 4 file, +30 righe
- [x] toolkit pin aggiornato a v1.36.0
- [x] `python -m py_compile` passa

## Files modificati

| File | Modifica |
|---|---|
| `scripts/source_check_fetch.py` | +5 campi `paqa_*` in `_EMPTY_ENRICH` + mapping da `preview_url` |
| `pyproject.toml` | toolkit pin v1.34.2 → v1.36.0 |
| `so_mcp/_inventory.py` | filtro `min_paqa_score` in `query_inventory()` |
| `so_mcp/so_server.py` | parametro `min_paqa_score` nel tool MCP |