### PR TITLE
fix: MergeError in add_dataset_group_columns (colonne già presenti)

### DIFF
--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -130,12 +130,6 @@ def parse_args() -> argparse.Namespace:
         default=False,
         help="Skip fonti con status RED in radar_summary.json (evita timeout su fonti down).",
     )
-    parser.add_argument(
-        "--limit",
-        type=int,
-        default=None,
-        help="Max item per source (per test rapidi, default: tutti).",
-    )
     return parser.parse_args()
 
 
@@ -373,9 +367,6 @@ def main() -> None:
             row["source_status"] = "active"
             row["stale_reason"] = None
             row["last_successful_fetch"] = captured_at
-
-        if args.limit:
-            rows = rows[: args.limit]
 
         all_rows.extend(rows)
 

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -130,6 +130,12 @@ def parse_args() -> argparse.Namespace:
         default=False,
         help="Skip fonti con status RED in radar_summary.json (evita timeout su fonti down).",
     )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max item per source (per test rapidi, default: tutti).",
+    )
     return parser.parse_args()
 
 
@@ -367,6 +373,9 @@ def main() -> None:
             row["source_status"] = "active"
             row["stale_reason"] = None
             row["last_successful_fetch"] = captured_at
+
+        if args.limit:
+            rows = rows[: args.limit]
 
         all_rows.extend(rows)
 

--- a/scripts/source_check_analyze.py
+++ b/scripts/source_check_analyze.py
@@ -182,6 +182,11 @@ def add_dataset_group_columns(df: pd.DataFrame) -> pd.DataFrame:
         .reset_index()
     )
 
+    # Drop existing group columns to avoid MergeError on suffixes
+    for col in ("dataset_group_size", "dataset_group_year_min", "dataset_group_year_max"):
+        if col in df.columns:
+            df = df.drop(columns=[col])
+
     # Merge back
     df = df.merge(group_agg, on="dataset_group", how="left")
     return df

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -1108,6 +1108,51 @@ class TestAddDatasetGroupColumns:
         assert result["dataset_group"].iloc[0] is not None
         assert result["dataset_group_size"].iloc[0] == 1
 
+    def test_regression_pre_existing_group_columns(self):
+        """add_dataset_group_columns non crasha se colonne aggreg. gia' esistono.
+
+        Regressione: pandas MergeError quando l'inventory contiene gia'
+        dataset_group_size, dataset_group_year_min, dataset_group_year_max.
+        Vedi PR #353.
+        """
+        import pandas as pd
+        from source_check_analyze import add_dataset_group_columns
+
+        df = pd.DataFrame(
+            [
+                {
+                    "source_id": "s1",
+                    "item_id": "a",
+                    "title": "Dataset X",
+                    "year_min": 2020,
+                    "year_max": 2024,
+                    "dataset_group": "s1/x",
+                    "intake_score": 50,
+                    "dataset_group_size": 2,
+                    "dataset_group_year_min": 2020,
+                    "dataset_group_year_max": 2024,
+                },
+                {
+                    "source_id": "s1",
+                    "item_id": "b",
+                    "title": "Dataset X",
+                    "year_min": 2020,
+                    "year_max": 2024,
+                    "dataset_group": "s1/x",
+                    "intake_score": 80,
+                    "dataset_group_size": 2,
+                    "dataset_group_year_min": 2020,
+                    "dataset_group_year_max": 2024,
+                },
+            ]
+        )
+        # Prima del fix sollevava pandas MergeError
+        result = add_dataset_group_columns(df)
+        assert "dataset_group_size" in result.columns
+        assert result["dataset_group_size"].iloc[0] == 2
+        assert "dataset_group_year_min" in result.columns
+        assert "dataset_group_year_max" in result.columns
+
 
 # ── SPARQL enrichment contract ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Sintesi

Fix per `pandas.errors.MergeError` che blocca l'observatory CI:
```
Passing 'suffixes' which cause duplicate columns
{'dataset_group_year_min_x', 'dataset_group_size_x', ...} is not allowed.
```

La funzione `add_dataset_group_columns` prova a mergiare colonne aggregate
su un DataFrame che già le contiene (dall'inventory). I suffissi `_x`/`_y`
generano conflitto.

## Fix

Drop delle colonne `dataset_group_size`, `dataset_group_year_min`,
`dataset_group_year_max` prima della merge, se già presenti.

## Verifica

```bash
pytest tests/ -k "group" -v
```

## Checklist

- [x] Fix mirato (6 righe)
- [x] Bug CI reale (run #27478042097)