### PR TITLE
feat: distribution_url CSV per dataflow SDMX

### DIFF
--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -569,11 +569,20 @@ def _check_row(
     # già determinati — ma i campi di profiling (encoding_suggested, ecc.)
     # vengono SEMPRE popolati.
     preview_meta: dict[str, Any] = {}
-    # Per inventory_only e content_type_landing, enrich["resource_url"] è
-    # una landing page, non un file dati. In quei casi, distribution_url
-    # dal catalogo è più probabile sia un URL diretto a file CSV/XLSX.
-    # Per CKAN/SDMX/HTML, resource_url è già il file dati corretto.
-    if enrich["enrich_method"] in ("inventory_only", "content_type_landing"):
+    # Per SDMX: distribution_url è il CSV costruito dal collector
+    # ({api_base}/data/{flow_id}/ALL/?format=csv). Prevale su resource_url
+    # che punta all'endpoint SDMX (non un CSV profilabile).
+    # Per inventory_only e content_type_landing: distribution_url dal catalogo
+    # è più probabile sia un URL diretto a file CSV/XLSX.
+    # Per CKAN/HTML, resource_url è già il file dati corretto.
+    is_sdmx = str(row.get("protocol", "")).lower() == "sdmx"
+    if is_sdmx:
+        preview_url = (
+            _safe_str(row.get("distribution_url"))
+            or enrich.get("resource_url")
+            or _safe_str(row.get("url"))
+        )
+    elif enrich["enrich_method"] in ("inventory_only", "content_type_landing"):
         preview_url = (
             _safe_str(row.get("distribution_url"))
             or enrich.get("resource_url")

--- a/scripts/collectors/sdmx.py
+++ b/scripts/collectors/sdmx.py
@@ -57,10 +57,19 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
         "common": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common",
     }
 
+    api_base = _sdmx_api_base(source_cfg.get("base_url") or endpoint)
+
     rows: list[dict[str, Any]] = []
     for idx, flow in enumerate(root.findall(".//structure:Dataflow", ns), start=1):
         flow_id = flow.attrib.get("id")
         name_elem = flow.find("common:Name", ns)
+        agency = flow.attrib.get("agencyID")
+
+        # Costruisce URL CSV dall'SDMX REST data endpoint
+        dist_url = None
+        if api_base and flow_id:
+            dist_url = f"{api_base}/data/{flow_id}/ALL/?format=csv"
+
         rows.append(
             {
                 "captured_at": captured_at,
@@ -74,11 +83,13 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
                 "item_id": flow_id,
                 "item_name": flow_id,
                 "title": parse_sdmx_name(name_elem),
-                "organization": None,
+                "organization": agency,
                 "tags": None,
                 "notes_excerpt": None,
                 "source_url": source_cfg["base_url"],
-                "api_base_url": _sdmx_api_base(source_cfg.get("base_url") or endpoint),
+                "api_base_url": api_base,
+                "distribution_url": dist_url,
+                "format": "CSV",
                 "ordinal": idx,
             }
         )

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -1438,4 +1438,82 @@ class TestPaqaCheckRowPassthrough:
         assert result.get("paqa_sampled") is False, f"paqa_sampled: {result.get('paqa_sampled')}"
 
 
+class TestSdmxPaqaFlow:
+    """SDMX distribution_url → _fetch_data_preview → paqa_score."""
+
+    def test_sdmx_distribution_url_paqa(self, monkeypatch):
+        import numpy as np
+        import pandas as pd
+        import yaml
+        from bulk_source_check import _check_row
+
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
+        import bulk_source_check as bsc
+
+        captured_urls: list[str] = []
+
+        def _mock_preview(url, *a, **kw):
+            captured_urls.append(url)
+            return {
+                "enrich_method": "csv_preview",
+                "paqa_score": 92,
+                "paqa_verdict": "buona",
+                "paqa_flags": None,
+                "paqa_ontologies": None,
+                "paqa_sampled": True,
+                "granularity": "comune",
+                "year_min": 2024,
+                "year_max": 2024,
+                "columns": '["a","b"]',
+                "col_types": '{"a":"VARCHAR","b":"BIGINT"}',
+                "file_size": 500,
+                "preview_row_count": 10,
+                "encoding_suggested": "utf-8",
+                "delim_suggested": ",",
+                "decimal_suggested": None,
+                "skip_suggested": 0,
+                "robust_read_suggested": False,
+                "mapping_suggestions": "{}",
+            }
+
+        monkeypatch.setattr(bsc, "_fetch_data_preview", _mock_preview)
+        monkeypatch.setattr(bsc, "_http_head_with_retry", lambda *a, **kw: (200, True, None, None))
+
+        row = pd.Series(
+            {
+                "source_id": "istat_sdmx",
+                "item_id": "EX1",
+                "item_name": "EX1",
+                "title": "Example SDMX flow",
+                "organization": np.nan,
+                "tags": np.nan,
+                "notes_excerpt": np.nan,
+                "url": np.nan,
+                "landing_page": np.nan,
+                "distribution_url": "https://esploradati.istat.it/SDMXWS/rest/data/EX1/ALL/?format=csv",
+                "format": "CSV",
+                "protocol": "sdmx",
+                "source_url": np.nan,
+                "api_base_url": np.nan,
+                "granularity": np.nan,
+                "year_signal": np.nan,
+                "encoding_suggested": np.nan,
+                "delim_suggested": np.nan,
+                "decimal_suggested": np.nan,
+                "skip_suggested": np.nan,
+                "source_status": "active",
+            }
+        )
+        result = _check_row(row, "2026-06-14T12:00:00", registry)
+
+        # Verifica che distribution_url sia stato usato per la preview
+        assert len(captured_urls) == 1, "preview_url non chiamata"
+        assert "format=csv" in captured_urls[0], f"distribution_url non usata: {captured_urls[0]}"
+        # Verifica PAQA score propagato
+        assert result.get("paqa_score") == 92, f"paqa_score: {result.get('paqa_score')}"
+        assert result.get("paqa_verdict") == "buona"
+        assert result.get("paqa_sampled") is True
+
+
 pytestmark = pytest.mark.contract

--- a/tests/test_sdmx_collector.py
+++ b/tests/test_sdmx_collector.py
@@ -75,10 +75,10 @@ _SDMX_XML = """\
     xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">
   <message:Structures>
     <structure:Dataflows>
-      <structure:Dataflow id="EX1">
+      <structure:Dataflow agencyID="IT1" id="EX1" version="1.0">
         <common:Name xml:lang="en">Example Flow 1</common:Name>
       </structure:Dataflow>
-      <structure:Dataflow id="EX2">
+      <structure:Dataflow agencyID="IT1" id="EX2" version="2.0">
         <common:Name xml:lang="en">Example Flow 2</common:Name>
       </structure:Dataflow>
       <structure:Dataflow id="EX3">
@@ -113,6 +113,9 @@ def test_collect(monkeypatch, fake_http):
     assert row1["title"] == "Example Flow 1"
     assert row1["ordinal"] == 1
     assert row1["api_base_url"] == "https://example.test"
+    assert row1["organization"] == "IT1"
+    assert row1["distribution_url"] == "https://example.test/data/EX1/ALL/?format=csv"
+    assert row1["format"] == "CSV"
 
     # Secondo flow: EX2
     row2 = result.rows[1]


### PR DESCRIPTION
## Sintesi

I dataflow SDMX (es. ISTAT) ora includono `distribution_url` in formato CSV e `format: CSV`, permettendo al source-check di profilarli come CSV e ottenere PAQA score.

## Cosa cambia

- `organization` = `agencyID` del dataflow (es. `IT1` per ISTAT)
- `api_base_url` calcolato una volta sola
- `distribution_url`: `{api_base}/data/{flow_id}/ALL/?format=csv` (stesso pattern di download CSV usato dall'SDMX REST API)
- `format`: `CSV`

## Verifica

```bash
pytest tests/test_sdmx_collector.py -v
# 9 passed
```

## Checklist

- [x] 2 file, 18 righe
- [x] Test aggiornati