### PR TITLE
fix: budget timeout SDMX coerente, distribution_url propagato

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -4,7 +4,7 @@ istat_sdmx:
   observation_mode: catalog-watch
   base_url: https://esploradati.istat.it/SDMXWS/rest/dataflow/IT1
   inventory:
-    timeout: 300
+    timeout: 600
   last_probed: '2026-06-14'
   catalog_baseline:
     captured_at: '2026-04-10'

--- a/notebooks/00_quality_diagnostic.ipynb
+++ b/notebooks/00_quality_diagnostic.ipynb
@@ -12,7 +12,7 @@
     "- **Dataset**: copertura source_check, intake score, reachability, granularità\n",
     "- **Copertura**: % inventario processato, gap\n",
     "\n",
-    "**Data**: 2026-06-08"
+    "**Data**: 2026-06-14"
    ]
   },
   {
@@ -20,10 +20,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:43.863715Z",
-     "iopub.status.busy": "2026-06-08T13:28:43.863237Z",
-     "iopub.status.idle": "2026-06-08T13:28:50.861768Z",
-     "shell.execute_reply": "2026-06-08T13:28:50.859681Z"
+     "iopub.execute_input": "2026-06-14T10:33:06.524077Z",
+     "iopub.status.busy": "2026-06-14T10:33:06.523605Z",
+     "iopub.status.idle": "2026-06-14T10:33:11.741989Z",
+     "shell.execute_reply": "2026-06-14T10:33:11.738590Z"
     }
    },
    "outputs": [
@@ -31,10 +31,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Radar: 30 fonti\n",
-      "Inventory: 15007 rows, 26 fonti\n",
-      "Source-check: 9771 rows, 24 fonti\n",
-      "Signals: 26 fonti controllate\n"
+      "Radar: 32 fonti\n",
+      "Inventory: 14925 rows, 27 fonti\n",
+      "Source-check: 9840 rows, 26 fonti\n",
+      "Signals: 28 fonti controllate\n"
      ]
     }
    ],
@@ -80,10 +80,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:50.944172Z",
-     "iopub.status.busy": "2026-06-08T13:28:50.943532Z",
-     "iopub.status.idle": "2026-06-08T13:28:50.959883Z",
-     "shell.execute_reply": "2026-06-08T13:28:50.957906Z"
+     "iopub.execute_input": "2026-06-14T10:33:11.825136Z",
+     "iopub.status.busy": "2026-06-14T10:33:11.824384Z",
+     "iopub.status.idle": "2026-06-14T10:33:11.841403Z",
+     "shell.execute_reply": "2026-06-14T10:33:11.838490Z"
     }
    },
    "outputs": [
@@ -95,16 +95,21 @@
       "  RADAR HEALTH\n",
       "════════════════════════════════════════════════════════════\n",
       "\n",
-      "GREEN:  30\n",
-      "YELLOW: 0\n",
+      "GREEN:  28\n",
+      "YELLOW: 4\n",
       "RED:    0\n",
       "Persistent RED: 0\n",
       "\n",
       "Fonti non VERDI:\n",
+      "  🔴 istat_sdmx                YELLOW   Timeout (ConnectTimeout)\n",
+      "  🔴 openbdap                  YELLOW   Retry timeout/connection: Timeout (ConnectTimeout)\n",
+      "  🔴 consip_open_data          YELLOW   Retry timeout/connection: Timeout (ConnectTimeout)\n",
+      "  🔴 mef_irpef                 YELLOW   Retry timeout/connection: Timeout (ConnectTimeout)\n",
       "\n",
-      "Fonti non inventariate (4):\n",
+      "Fonti non inventariate (5):\n",
       "  dait                      protocol=html      \n",
       "  inail_opendata            protocol=aem       \n",
+      "  mef_irpef                 protocol=html      \n",
       "  noipa_sparql              protocol=sparql    \n",
       "  terna_opendata            protocol=rest      \n"
      ]
@@ -152,10 +157,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:50.964392Z",
-     "iopub.status.busy": "2026-06-08T13:28:50.963920Z",
-     "iopub.status.idle": "2026-06-08T13:28:50.987791Z",
-     "shell.execute_reply": "2026-06-08T13:28:50.985630Z"
+     "iopub.execute_input": "2026-06-14T10:33:11.846167Z",
+     "iopub.status.busy": "2026-06-14T10:33:11.845781Z",
+     "iopub.status.idle": "2026-06-14T10:33:11.871263Z",
+     "shell.execute_reply": "2026-06-14T10:33:11.867551Z"
     }
    },
    "outputs": [
@@ -174,27 +179,28 @@
       "         opencoesione     ckan    561\n",
       "               openga     ckan    436\n",
       "         mim_opendata     html    372\n",
+      "          unioncamere     ckan    371\n",
       "            mimit_rna     ckan    370\n",
-      "          unioncamere     ckan    352\n",
       "         dati_cultura   sparql    213\n",
-      "            mef_irpef     html    147\n",
       "          dati_camera   sparql    104\n",
       "          dati_senato   sparql     98\n",
       "      lavoro_opendata     ckan     83\n",
-      "                 anac     ckan     70\n",
       "         mit_opendata     ckan     70\n",
+      "                 anac     ckan     70\n",
       "            mur_ustat     ckan     69\n",
-      "    ispra_linked_data   sparql     67\n",
+      "    ispra_linked_data   sparql     69\n",
       "                 agcm     ckan     53\n",
       "     ministero_salute     ckan     51\n",
       "                 aifa     html     42\n",
       "                 agid     ckan     40\n",
       "    ministero_interno     ckan     38\n",
+      "                  aci     ckan     35\n",
       "  cortecostituzionale     html     33\n",
       "     consip_open_data     ckan     16\n",
-      "giustizia_statistiche     html      8\n",
+      "giustizia_statistiche     html      9\n",
+      "               pagopa     ckan      8\n",
       "\n",
-      "Totale item inventario: 15007\n"
+      "Totale item inventario: 14925\n"
      ]
     }
    ],
@@ -215,10 +221,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:50.991354Z",
-     "iopub.status.busy": "2026-06-08T13:28:50.991014Z",
-     "iopub.status.idle": "2026-06-08T13:28:51.000073Z",
-     "shell.execute_reply": "2026-06-08T13:28:50.997393Z"
+     "iopub.execute_input": "2026-06-14T10:33:11.876049Z",
+     "iopub.status.busy": "2026-06-14T10:33:11.875487Z",
+     "iopub.status.idle": "2026-06-14T10:33:11.885824Z",
+     "shell.execute_reply": "2026-06-14T10:33:11.883187Z"
     }
    },
    "outputs": [
@@ -235,7 +241,7 @@
       "    azione: catalog-watch-ready\n",
       "\n",
       "ispra_linked_data      inventory change    \n",
-      "    67 item (sparql_query), delta +1 rispetto al run precedente (66).\n",
+      "    69 item (sparql_query), delta +2 rispetto al run precedente (67).\n",
       "    azione: verificare se variazione attesa; avviare inventory-triage se nuovi dataset\n",
       "\n",
       "mef_irpef              csv_magnet          \n",
@@ -251,12 +257,16 @@
       "    azione: catalog-watch-ready\n",
       "\n",
       "giustizia_statistiche  csv_magnet          \n",
-      "    8 link data (XLS 8), years 2014-2025 — top prefixes: Indicatori=2, Durata=2, Civile=1, Sorveg=1, Interc=1\n",
+      "    9 link data (XLS 9), years 2014-2025 — top prefixes: Indicatori=2, Durata=2, Civile=1, Sorveg=1, Sorveglianza=1\n",
       "    azione: low signal\n",
       "\n",
       "cortecostituzionale    csv_magnet          \n",
       "    33 link data (ZIP 33)\n",
-      "    azione: catalog-watch-ready\n"
+      "    azione: catalog-watch-ready\n",
+      "\n",
+      "unioncamere            inventory change    \n",
+      "    371 item (package_search), delta +19 rispetto al run precedente (352).\n",
+      "    azione: verificare se variazione attesa; avviare inventory-triage se nuovi dataset\n"
      ]
     }
    ],
@@ -281,14 +291,448 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2b. PAQA — Public Administration Quality Assessment\n",
+    "\n",
+    "Quality scores strutturali e semantici per ogni CSV profilato.\n",
+    "Disponibile da Giugno 2026 (toolkit v1.36.0+).\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:51.004172Z",
-     "iopub.status.busy": "2026-06-08T13:28:51.003785Z",
-     "iopub.status.idle": "2026-06-08T13:28:51.041663Z",
-     "shell.execute_reply": "2026-06-08T13:28:51.038868Z"
+     "iopub.execute_input": "2026-06-14T10:33:11.890118Z",
+     "iopub.status.busy": "2026-06-14T10:33:11.889723Z",
+     "iopub.status.idle": "2026-06-14T10:33:11.915143Z",
+     "shell.execute_reply": "2026-06-14T10:33:11.912259Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PANORAMICA PAQA\n",
+      "════════════════════════════════════════════════════════════\n",
+      "Item con PAQA score:   1132  (11.5%)\n",
+      "Item senza PAQA:       8708  (88.5%)\n",
+      "Score medio:           93.2\n",
+      "Score mediano:           94\n",
+      "Dev std:                3.2\n",
+      "Min:                     78\n",
+      "Max:                     98\n",
+      "\n",
+      "  VERDETTI\n",
+      "    buona             996  (88.0%)\n",
+      "    scarsa             90  (8.0%)\n",
+      "    accettabile        46  (4.1%)\n",
+      "\n",
+      "  ITEM CON FLAG:      847\n",
+      "  ITEM CON ONTOLOGIE:   890\n",
+      "  SAMPLED:              233\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  PANORAMICA PAQA\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "total = len(df_scr)\n",
+    "with_paqa = df_scr[\"paqa_score\"].notna().sum()\n",
+    "without_paqa = total - with_paqa\n",
+    "print(f\"Item con PAQA score:  {with_paqa:>5}  ({with_paqa / total * 100:.1f}%)\")\n",
+    "print(f\"Item senza PAQA:      {without_paqa:>5}  ({without_paqa / total * 100:.1f}%)\")\n",
+    "\n",
+    "if with_paqa > 0:\n",
+    "    print(f\"Score medio:          {df_scr['paqa_score'].mean():>5.1f}\")\n",
+    "    print(f\"Score mediano:        {df_scr['paqa_score'].median():>5.0f}\")\n",
+    "    print(f\"Dev std:              {df_scr['paqa_score'].std():>5.1f}\")\n",
+    "    print(f\"Min:                  {df_scr['paqa_score'].min():>5.0f}\")\n",
+    "    print(f\"Max:                  {df_scr['paqa_score'].max():>5.0f}\")\n",
+    "\n",
+    "    print(\"\\n  VERDETTI\")\n",
+    "    verdicts = df_scr[\"paqa_verdict\"].value_counts()\n",
+    "    for v, c in verdicts.items():\n",
+    "        print(f\"    {str(v):<15s} {c:>5}  ({c / with_paqa * 100:.1f}%)\")\n",
+    "\n",
+    "    print(f\"\\n  ITEM CON FLAG:    {df_scr['paqa_flags'].notna().sum():>5}\")\n",
+    "    print(f\"  ITEM CON ONTOLOGIE: {df_scr['paqa_ontologies'].notna().sum():>5}\")\n",
+    "    print(f\"  SAMPLED:            {df_scr['paqa_sampled'].sum():>5}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T10:33:11.919768Z",
+     "iopub.status.busy": "2026-06-14T10:33:11.919315Z",
+     "iopub.status.idle": "2026-06-14T10:33:11.967786Z",
+     "shell.execute_reply": "2026-06-14T10:33:11.964731Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PAQA PER FONTE\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonte                   Item   Avg  Med  Min  Max   Std\n",
+      "----------------------------------------------------\n",
+      "openga                   200    96   95   90   98   1.5\n",
+      "inps                      41    96   95   90   98   2.1\n",
+      "pagopa                     8    95   95   92   98   2.5\n",
+      "ministero_salute           2    95   95   95   95   0.0\n",
+      "ministero_interno         38    94   95   88   98   3.4\n",
+      "aci                        4    94   94   94   94   0.0\n",
+      "unioncamere              353    94   95   78   98   3.3\n",
+      "mit_opendata              32    92   93   80   98   4.8\n",
+      "mim_opendata             371    92   92   81   95   2.5\n",
+      "lavoro_opendata           83    90   90   90   90   0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "print(\"═\" * 60)\n",
+    "print(\"  PAQA PER FONTE\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "src_paqa = (\n",
+    "    df_scr[df_scr[\"paqa_score\"].notna()]\n",
+    "    .groupby(\"source_id\")\n",
+    "    .agg(\n",
+    "        items=(\"paqa_score\", \"count\"),\n",
+    "        avg_score=(\"paqa_score\", \"mean\"),\n",
+    "        med_score=(\"paqa_score\", \"median\"),\n",
+    "        min_score=(\"paqa_score\", \"min\"),\n",
+    "        max_score=(\"paqa_score\", \"max\"),\n",
+    "        std_score=(\"paqa_score\", \"std\"),\n",
+    "    )\n",
+    "    .reset_index()\n",
+    ")\n",
+    "src_paqa = src_paqa.sort_values(\"avg_score\", ascending=False)\n",
+    "\n",
+    "print(f\"{'Fonte':22s} {'Item':>5s} {'Avg':>5s} {'Med':>4s} {'Min':>4s} {'Max':>4s} {'Std':>5s}\")\n",
+    "print(\"-\" * 52)\n",
+    "for _, r in src_paqa.iterrows():\n",
+    "    std_str = f\"{r['std_score']:.1f}\" if pd.notna(r[\"std_score\"]) else \"N/A\"\n",
+    "    print(\n",
+    "        f\"{r['source_id']:22s} {r['items']:5.0f} {r['avg_score']:5.0f} {r['med_score']:4.0f} {r['min_score']:4.0f} {r['max_score']:4.0f} {std_str:>5s}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T10:33:11.973794Z",
+     "iopub.status.busy": "2026-06-14T10:33:11.973217Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.016571Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.013795Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PAQA — FLAG\n",
+      "════════════════════════════════════════════════════════════\n",
+      "Flag combo                                               Item      %\n",
+      "--------------------------------------------------------------------\n",
+      "  [non_iso_dates                                     ]   378  ( 44.6%)\n",
+      "  [column_naming                                     ]   292  ( 34.5%)\n",
+      "  [inconsistent_columns, column_naming               ]    87  ( 10.3%)\n",
+      "  [column_naming, non_iso_dates                      ]    44  (  5.2%)\n",
+      "  [duplicate_columns, column_naming                  ]    15  (  1.8%)\n",
+      "  [encoding_issues, non_iso_dates                    ]    11  (  1.3%)\n",
+      "  [duplicate_columns, high_missing_rate, column_naming]     4  (  0.5%)\n",
+      "  [high_missing_rate                                 ]     3  (  0.4%)\n",
+      "  [duplicate_columns, column_naming, non_iso_dates   ]     2  (  0.2%)\n",
+      "  [high_missing_rate, column_naming                  ]     2  (  0.2%)\n",
+      "  [encoding_issues                                   ]     2  (  0.2%)\n",
+      "  [inconsistent_columns, non_iso_dates               ]     2  (  0.2%)\n",
+      "  [encoding_issues, column_naming                    ]     2  (  0.2%)\n",
+      "  [duplicate_columns, high_missing_rate, column_naming, non_iso_dates]     1  (  0.1%)\n",
+      "  [duplicate_columns                                 ]     1  (  0.1%)\n",
+      "  ... e altre 1 combinazioni\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ast\n",
+    "\n",
+    "print(\"═\" * 60)\n",
+    "print(\"  PAQA — FLAG\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "flags_series = df_scr[\n",
+    "    df_scr[\"paqa_flags\"].notna() & (df_scr[\"paqa_flags\"] != \"[]\") & (df_scr[\"paqa_flags\"] != \"\")\n",
+    "]\n",
+    "\n",
+    "# Parse e conta flag (ogni riga può avere multipli flag in formato JSON array string)\n",
+    "\n",
+    "flag_counter = {}\n",
+    "for raw in flags_series[\"paqa_flags\"]:\n",
+    "    try:\n",
+    "        flags = ast.literal_eval(raw) if isinstance(raw, str) else raw\n",
+    "    except Exception:\n",
+    "        flags = []\n",
+    "    key = \", \".join(flags) if flags else \"empty\"\n",
+    "    flag_counter[key] = flag_counter.get(key, 0) + 1\n",
+    "\n",
+    "sorted_flags = sorted(flag_counter.items(), key=lambda x: -x[1])\n",
+    "print(f\"{'Flag combo':55s} {'Item':>5s} {'%':>6s}\")\n",
+    "print(\"-\" * 68)\n",
+    "for combo, cnt in sorted_flags[:15]:\n",
+    "    print(f\"  [{combo:50s}] {cnt:5d}  ({cnt / flags_series.shape[0] * 100:5.1f}%)\")\n",
+    "\n",
+    "if len(sorted_flags) > 15:\n",
+    "    print(f\"  ... e altre {len(sorted_flags) - 15} combinazioni\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T10:33:12.020895Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.020464Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.094355Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.091413Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PAQA — ONTOLOGIE RILEVATE\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ontologia/e                                              Item\n",
+      "--------------------------------------------------------------\n",
+      "  TI                                                        172\n",
+      "  CPV, TI                                                   167\n",
+      "  ISTAT, TI                                                 121\n",
+      "  CLV, ISTAT, TI                                             80\n",
+      "  CLV, COV, ISTAT, TI                                        67\n",
+      "  CLV, ISTAT                                                 59\n",
+      "  CLV                                                        41\n",
+      "  CPV, QB, TI                                                32\n",
+      "  QB, TI                                                     23\n",
+      "  QB                                                         20\n",
+      "  COV, TI                                                    16\n",
+      "  CLV, ISTAT, QB                                             11\n",
+      "  ... e altre 28 combinazioni\n",
+      "\n",
+      "Item con ontologia/e: 890\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  PAQA — ONTOLOGIE RILEVATE\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "onto_series = df_scr[\n",
+    "    df_scr[\"paqa_ontologies\"].notna()\n",
+    "    & (df_scr[\"paqa_ontologies\"] != \"{}\")\n",
+    "    & (df_scr[\"paqa_ontologies\"] != \"\")\n",
+    "]\n",
+    "\n",
+    "onto_counter = {}\n",
+    "for raw in onto_series[\"paqa_ontologies\"]:\n",
+    "    try:\n",
+    "        onto = ast.literal_eval(raw) if isinstance(raw, str) else raw\n",
+    "    except Exception:\n",
+    "        onto = {}\n",
+    "    # Extract ontology codes\n",
+    "    codes = sorted(onto.keys()) if onto else [\"empty\"]\n",
+    "    key = \", \".join(codes)\n",
+    "    onto_counter[key] = onto_counter.get(key, 0) + 1\n",
+    "\n",
+    "sorted_onto = sorted(onto_counter.items(), key=lambda x: -x[1])\n",
+    "print(f\"{'Ontologia/e':55s} {'Item':>5s}\")\n",
+    "print(\"-\" * 62)\n",
+    "for combo, cnt in sorted_onto[:12]:\n",
+    "    print(f\"  {combo:55s} {cnt:5d}\")\n",
+    "\n",
+    "if len(sorted_onto) > 12:\n",
+    "    print(f\"  ... e altre {len(sorted_onto) - 12} combinazioni\")\n",
+    "\n",
+    "print(f\"\\nItem con ontologia/e: {onto_series.shape[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T10:33:12.098723Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.098247Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.167977Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.164251Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PAQA vs INTAKE SCORE\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correlazione PAQA ↔ Intake: 0.285\n",
+      "(su 1132 item con entrambi gli score)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fascia PAQA      N Avg Intake\n",
+      "  ------------------------------\n",
+      "  70-90          188       53.6\n",
+      "  90-100         944       67.4\n",
+      "\n",
+      "  Top 5 per intake_score (con PAQA):\n",
+      "    unioncamere     intake=100 paqa=95  Vicenza - Imprese Femminili della provincia, storico iscrizi\n",
+      "    unioncamere     intake=100 paqa=98  Modena - esportazioni settore ceramico provincia di Modena d\n",
+      "    unioncamere     intake=100 paqa=98  Modena - esportazioni mezzi di trasporto provincia di Modena\n",
+      "    unioncamere     intake=100 paqa=98  Modena - esportazioni macchine e apparecchiature meccaniche \n",
+      "    unioncamere     intake=100 paqa=98  Modena - esportazioni settore biomedicale provincia di Moden\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "print(\"═\" * 60)\n",
+    "print(\"  PAQA vs INTAKE SCORE\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "both = df_scr[df_scr[\"paqa_score\"].notna() & df_scr[\"intake_score\"].notna()].copy()\n",
+    "if len(both) > 0:\n",
+    "    corr = both[\"paqa_score\"].corr(both[\"intake_score\"])\n",
+    "    print(f\"Correlazione PAQA ↔ Intake: {corr:.3f}\")\n",
+    "    print(f\"(su {len(both)} item con entrambi gli score)\")\n",
+    "\n",
+    "    incrocio = (\n",
+    "        both.groupby(\n",
+    "            pd.cut(both[\"paqa_score\"], bins=[0, 70, 90, 100], labels=[\"<70\", \"70-90\", \"90-100\"])\n",
+    "        )\n",
+    "        .agg(n=(\"intake_score\", \"count\"), avg_intake=(\"intake_score\", \"mean\"))\n",
+    "        .reset_index()\n",
+    "    )\n",
+    "    print(f\"\\n  {'Fascia PAQA':12s} {'N':>5s} {'Avg Intake':>10s}\")\n",
+    "    print(\"  \" + \"-\" * 30)\n",
+    "    for _, r in incrocio.iterrows():\n",
+    "        print(f\"  {str(r['paqa_score']):12s} {r['n']:5.0f} {r['avg_intake']:10.1f}\")\n",
+    "\n",
+    "    # Top item: alto PAQA + alto intake\n",
+    "    top = both.nlargest(5, \"intake_score\")[[\"source_id\", \"title\", \"intake_score\", \"paqa_score\"]]\n",
+    "    print(\"\\n  Top 5 per intake_score (con PAQA):\")\n",
+    "    for _, r in top.iterrows():\n",
+    "        print(\n",
+    "            f\"    {r['source_id']:<15s} intake={r['intake_score']:.0f} paqa={r['paqa_score']:.0f}  {str(r.get('title', ''))[:60]}\"\n",
+    "        )\n",
+    "else:\n",
+    "    print(\"Nessun item con entrambi gli score disponibile\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T10:33:12.172625Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.172023Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.210480Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.207693Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  SAMPLED — PREVIEW TRONCA\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sampled (preview tronca, check S6/S12 disabilitati): 233\n",
+      "Full preview:                                         899\n",
+      "Score medio sampled:   91.3\n",
+      "Score medio full:      93.7\n",
+      "Differenza:            +2.4\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  SAMPLED — PREVIEW TRONCA\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "sampled_true = df_scr[df_scr[\"paqa_sampled\"]]\n",
+    "sampled_false = df_scr[~df_scr[\"paqa_sampled\"]]\n",
+    "print(f\"Sampled (preview tronca, check S6/S12 disabilitati): {len(sampled_true)}\")\n",
+    "print(f\"Full preview:                                         {len(sampled_false)}\")\n",
+    "\n",
+    "if len(sampled_true) > 0 and len(sampled_false) > 0:\n",
+    "    score_sampled = sampled_true[\"paqa_score\"].mean()\n",
+    "    score_full = sampled_false[\"paqa_score\"].mean()\n",
+    "    print(f\"Score medio sampled:   {score_sampled:.1f}\")\n",
+    "    print(f\"Score medio full:      {score_full:.1f}\")\n",
+    "    print(f\"Differenza:            {score_full - score_sampled:+.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T10:33:12.214912Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.214506Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.256762Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.254181Z"
     }
    },
    "outputs": [
@@ -298,39 +742,47 @@
      "text": [
       "════════════════════════════════════════════════════════════\n",
       "  COPERTURA SOURCE-CHECK\n",
-      "════════════════════════════════════════════════════════════\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Fonte                   Inventory   Scored  Coperto\n",
       "--------------------------------------------------\n",
       "istat_sdmx                   4871     3584    73.6%\n",
       "openbdap                     3817     1918    50.2%\n",
-      "inps                         2323     1426    61.4%\n",
+      "inps                         2323     1427    61.4%\n",
       "opencivitas                   703      384    54.6%\n",
-      "opencoesione                  561      504    89.8%\n",
+      "opencoesione                  561      518    92.3%\n",
       "openga                        436      364    83.5%\n",
-      "mim_opendata                  372      387   104.0%\n",
+      "mim_opendata                  372      407   109.4%\n",
+      "unioncamere                   371      371   100.0%\n",
       "mimit_rna                     370       85    23.0%\n",
-      "unioncamere                   352      349    99.1%\n",
       "dati_cultura                  213      213   100.0%\n",
-      "mef_irpef                     147       80    54.4%\n",
       "dati_camera                   104      104   100.0%\n",
       "dati_senato                    98        0     0.0%\n",
       "lavoro_opendata                83       83   100.0%\n",
-      "anac                           70       13    18.6%\n",
       "mit_opendata                   70       62    88.6%\n",
+      "anac                           70       13    18.6%\n",
       "mur_ustat                      69       69   100.0%\n",
-      "ispra_linked_data              67        0     0.0%\n",
+      "ispra_linked_data              69        0     0.0%\n",
       "agcm                           53        4     7.5%\n",
       "ministero_salute               51       48    94.1%\n",
       "aifa                           42       20    47.6%\n",
       "agid                           40        8    20.0%\n",
       "ministero_interno              38       38   100.0%\n",
+      "aci                            35        4    11.4%\n",
       "cortecostituzionale            33       13    39.4%\n",
       "consip_open_data               16       10    62.5%\n",
-      "giustizia_statistiche           8        4    50.0%\n",
+      "giustizia_statistiche           9        4    44.4%\n",
+      "pagopa                          8        8   100.0%\n",
+      "mef_irpef                       0       80  8000.0%\n",
       "\n",
-      "Totale inventory: 15007\n",
-      "Totale scored:    9770\n",
-      "Copertura media:  65.1%\n"
+      "Totale inventory: 14925\n",
+      "Totale scored:    9839\n",
+      "Copertura media:  65.9%\n"
      ]
     }
    ],
@@ -364,13 +816,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:51.045283Z",
-     "iopub.status.busy": "2026-06-08T13:28:51.044911Z",
-     "iopub.status.idle": "2026-06-08T13:28:51.063153Z",
-     "shell.execute_reply": "2026-06-08T13:28:51.060975Z"
+     "iopub.execute_input": "2026-06-14T10:33:12.263049Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.262405Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.281164Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.278403Z"
     }
    },
    "outputs": [
@@ -381,20 +833,14 @@
       "════════════════════════════════════════════════════════════\n",
       "  QUALITA' DATASET\n",
       "════════════════════════════════════════════════════════════\n",
-      "Item totali:              9771\n",
-      "Candidati intake:         1271 (13%)\n",
-      "Needs review:             7946 (81%)\n",
-      "Reachable:                2853 (29%)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Con colonne profilate:    2118 (22%)\n",
-      "Con join_keys:            1009 (10%)\n",
-      "Intake score medio:       26.0\n",
-      "Joinability score medio:    5.1\n"
+      "Item totali:              9840\n",
+      "Candidati intake:         1422 (14%)\n",
+      "Needs review:             7942 (81%)\n",
+      "Reachable:                2923 (30%)\n",
+      "Con colonne profilate:    2172 (22%)\n",
+      "Con join_keys:            1132 (12%)\n",
+      "Intake score medio:       26.5\n",
+      "Joinability score medio:    5.8\n"
      ]
     }
    ],
@@ -427,13 +873,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:51.068025Z",
-     "iopub.status.busy": "2026-06-08T13:28:51.067611Z",
-     "iopub.status.idle": "2026-06-08T13:28:51.081624Z",
-     "shell.execute_reply": "2026-06-08T13:28:51.079069Z"
+     "iopub.execute_input": "2026-06-14T10:33:12.285597Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.285135Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.302998Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.298938Z"
     }
    },
    "outputs": [
@@ -443,24 +889,30 @@
      "text": [
       "════════════════════════════════════════════════════════════\n",
       "  GRANULARITA'\n",
-      "════════════════════════════════════════════════════════════\n",
-      "  non_determinato       6713 (69%)\n",
-      "  regione               1607 (16%)\n",
-      "  comune                 446 (5%)\n",
-      "  provincia              372 (4%)\n",
-      "  nazionale              345 (4%)\n",
-      "  europeo                 99 (1%)\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  non_determinato       6811 (69%)\n",
+      "  regione               1608 (16%)\n",
+      "  provincia              474 (5%)\n",
+      "  comune                 374 (4%)\n",
+      "  nazionale              346 (4%)\n",
+      "  europeo                108 (1%)\n",
       "  mondiale                 2 (0%)\n",
       "\n",
       "  FORMATI\n",
-      "  CSV         4455 (46%)\n",
-      "  SDMX        3584 (37%)\n",
-      "  XLS          640 (7%)\n",
+      "  CSV         4527 (46%)\n",
+      "  SDMX        3584 (36%)\n",
+      "  XLS          700 (7%)\n",
       "  ZIP          437 (4%)\n",
       "               317 (3%)\n",
       "  XML          130 (1%)\n",
       "  JSON          12 (0%)\n",
-      "  PDF            7 (0%)\n"
+      "  XLSX           9 (0%)\n"
      ]
     }
    ],
@@ -489,18 +941,19 @@
     "- Fonti non inventariate → valutare se aggiungere a catalog-watch\n",
     "- Fonti con segnali di drift → verificare\n",
     "- Source_check da completare su fonti a bassa copertura\n",
-    "- Dataset con intake_score alto ma senza join_keys → potenziali falsi negativi"
+    "- Dataset con intake_score alto ma senza join_keys → potenziali falsi negativi\n",
+    "- Fonti con PAQA basso (< 85) → verificare quality check\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:51.085735Z",
-     "iopub.status.busy": "2026-06-08T13:28:51.085271Z",
-     "iopub.status.idle": "2026-06-08T13:28:51.131665Z",
-     "shell.execute_reply": "2026-06-08T13:28:51.129397Z"
+     "iopub.execute_input": "2026-06-14T10:33:12.308022Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.307587Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.370211Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.367165Z"
     }
    },
    "outputs": [
@@ -512,9 +965,9 @@
       "  COSE DA FARE\n",
       "════════════════════════════════════════════════════════════\n",
       "\n",
-      "📋 Fonti da inventariare: dait, inail_opendata, noipa_sparql, terna_opendata\n",
+      "📋 Fonti da inventariare: dait, inail_opendata, mef_irpef, noipa_sparql, terna_opendata\n",
       "\n",
-      "📋 Fonti con segnali attivi (7):\n",
+      "📋 Fonti con segnali attivi (8):\n",
       "     mim_opendata           csv_magnet           catalog-watch-ready\n",
       "     ispra_linked_data      inventory change     verificare se variazione attesa; avviare inventory-triage se\n",
       "     mef_irpef              csv_magnet           verificare raggiungibilità del portale\n",
@@ -522,23 +975,38 @@
       "     aifa                   csv_magnet           catalog-watch-ready\n",
       "     giustizia_statistiche  csv_magnet           low signal\n",
       "     cortecostituzionale    csv_magnet           catalog-watch-ready\n",
+      "     unioncamere            inventory change     verificare se variazione attesa; avviare inventory-triage se\n",
       "\n",
-      "📋 Fonti con copertura < 50% (8):\n",
+      "📋 Fonti con copertura < 50% (10):\n",
       "     dati_senato            0% (0/98)\n",
-      "     ispra_linked_data      0% (0/67)\n",
+      "     ispra_linked_data      0% (0/69)\n",
       "     agcm                   8% (4/53)\n",
+      "     aci                    11% (4/35)\n",
       "     anac                   19% (13/70)\n",
       "     agid                   20% (8/40)\n",
       "     mimit_rna              23% (85/370)\n",
       "     cortecostituzionale    39% (13/33)\n",
-      "     aifa                   48% (20/42)\n",
+      "     giustizia_statistiche  44% (4/9)\n",
+      "     aifa                   48% (20/42)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
-      "📋 Dataset con intake >= 50 MA senza join_keys (927):\n",
-      "     unioncamere     score=100 Modena - esportazioni per settore provincia di Mod\n",
-      "     unioncamere     score=100 Modena - Demografia delle imprese della provincia \n",
-      "     unioncamere     score=100 Modena - esportazioni mezzi di trasporto provincia\n",
-      "     unioncamere     score=100 Modena - esportazioni settore biomedicale provinci\n",
-      "     unioncamere     score=100 Modena - esportazioni settore agroalimentare provi\n"
+      "📋 Dataset con intake >= 50 MA senza join_keys (859):\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n",
+      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n",
+      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n",
+      "     unioncamere     score=100 Modena - Unita locali attive per settori in provin\n",
+      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n"
      ]
     }
    ],

--- a/notebooks/00_quality_diagnostic.ipynb
+++ b/notebooks/00_quality_diagnostic.ipynb
@@ -12,7 +12,7 @@
     "- **Dataset**: copertura source_check, intake score, reachability, granularità\n",
     "- **Copertura**: % inventario processato, gap\n",
     "\n",
-    "**Data**: 2026-06-14"
+    "**Data**: 2026-06-08"
    ]
   },
   {
@@ -20,10 +20,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:06.524077Z",
-     "iopub.status.busy": "2026-06-14T10:33:06.523605Z",
-     "iopub.status.idle": "2026-06-14T10:33:11.741989Z",
-     "shell.execute_reply": "2026-06-14T10:33:11.738590Z"
+     "iopub.execute_input": "2026-06-08T13:28:43.863715Z",
+     "iopub.status.busy": "2026-06-08T13:28:43.863237Z",
+     "iopub.status.idle": "2026-06-08T13:28:50.861768Z",
+     "shell.execute_reply": "2026-06-08T13:28:50.859681Z"
     }
    },
    "outputs": [
@@ -31,10 +31,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Radar: 32 fonti\n",
-      "Inventory: 14925 rows, 27 fonti\n",
-      "Source-check: 9840 rows, 26 fonti\n",
-      "Signals: 28 fonti controllate\n"
+      "Radar: 30 fonti\n",
+      "Inventory: 15007 rows, 26 fonti\n",
+      "Source-check: 9771 rows, 24 fonti\n",
+      "Signals: 26 fonti controllate\n"
      ]
     }
    ],
@@ -80,10 +80,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:11.825136Z",
-     "iopub.status.busy": "2026-06-14T10:33:11.824384Z",
-     "iopub.status.idle": "2026-06-14T10:33:11.841403Z",
-     "shell.execute_reply": "2026-06-14T10:33:11.838490Z"
+     "iopub.execute_input": "2026-06-08T13:28:50.944172Z",
+     "iopub.status.busy": "2026-06-08T13:28:50.943532Z",
+     "iopub.status.idle": "2026-06-08T13:28:50.959883Z",
+     "shell.execute_reply": "2026-06-08T13:28:50.957906Z"
     }
    },
    "outputs": [
@@ -95,21 +95,16 @@
       "  RADAR HEALTH\n",
       "════════════════════════════════════════════════════════════\n",
       "\n",
-      "GREEN:  28\n",
-      "YELLOW: 4\n",
+      "GREEN:  30\n",
+      "YELLOW: 0\n",
       "RED:    0\n",
       "Persistent RED: 0\n",
       "\n",
       "Fonti non VERDI:\n",
-      "  🔴 istat_sdmx                YELLOW   Timeout (ConnectTimeout)\n",
-      "  🔴 openbdap                  YELLOW   Retry timeout/connection: Timeout (ConnectTimeout)\n",
-      "  🔴 consip_open_data          YELLOW   Retry timeout/connection: Timeout (ConnectTimeout)\n",
-      "  🔴 mef_irpef                 YELLOW   Retry timeout/connection: Timeout (ConnectTimeout)\n",
       "\n",
-      "Fonti non inventariate (5):\n",
+      "Fonti non inventariate (4):\n",
       "  dait                      protocol=html      \n",
       "  inail_opendata            protocol=aem       \n",
-      "  mef_irpef                 protocol=html      \n",
       "  noipa_sparql              protocol=sparql    \n",
       "  terna_opendata            protocol=rest      \n"
      ]
@@ -157,10 +152,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:11.846167Z",
-     "iopub.status.busy": "2026-06-14T10:33:11.845781Z",
-     "iopub.status.idle": "2026-06-14T10:33:11.871263Z",
-     "shell.execute_reply": "2026-06-14T10:33:11.867551Z"
+     "iopub.execute_input": "2026-06-08T13:28:50.964392Z",
+     "iopub.status.busy": "2026-06-08T13:28:50.963920Z",
+     "iopub.status.idle": "2026-06-08T13:28:50.987791Z",
+     "shell.execute_reply": "2026-06-08T13:28:50.985630Z"
     }
    },
    "outputs": [
@@ -179,28 +174,27 @@
       "         opencoesione     ckan    561\n",
       "               openga     ckan    436\n",
       "         mim_opendata     html    372\n",
-      "          unioncamere     ckan    371\n",
       "            mimit_rna     ckan    370\n",
+      "          unioncamere     ckan    352\n",
       "         dati_cultura   sparql    213\n",
+      "            mef_irpef     html    147\n",
       "          dati_camera   sparql    104\n",
       "          dati_senato   sparql     98\n",
       "      lavoro_opendata     ckan     83\n",
-      "         mit_opendata     ckan     70\n",
       "                 anac     ckan     70\n",
+      "         mit_opendata     ckan     70\n",
       "            mur_ustat     ckan     69\n",
-      "    ispra_linked_data   sparql     69\n",
+      "    ispra_linked_data   sparql     67\n",
       "                 agcm     ckan     53\n",
       "     ministero_salute     ckan     51\n",
       "                 aifa     html     42\n",
       "                 agid     ckan     40\n",
       "    ministero_interno     ckan     38\n",
-      "                  aci     ckan     35\n",
       "  cortecostituzionale     html     33\n",
       "     consip_open_data     ckan     16\n",
-      "giustizia_statistiche     html      9\n",
-      "               pagopa     ckan      8\n",
+      "giustizia_statistiche     html      8\n",
       "\n",
-      "Totale item inventario: 14925\n"
+      "Totale item inventario: 15007\n"
      ]
     }
    ],
@@ -221,10 +215,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:11.876049Z",
-     "iopub.status.busy": "2026-06-14T10:33:11.875487Z",
-     "iopub.status.idle": "2026-06-14T10:33:11.885824Z",
-     "shell.execute_reply": "2026-06-14T10:33:11.883187Z"
+     "iopub.execute_input": "2026-06-08T13:28:50.991354Z",
+     "iopub.status.busy": "2026-06-08T13:28:50.991014Z",
+     "iopub.status.idle": "2026-06-08T13:28:51.000073Z",
+     "shell.execute_reply": "2026-06-08T13:28:50.997393Z"
     }
    },
    "outputs": [
@@ -241,7 +235,7 @@
       "    azione: catalog-watch-ready\n",
       "\n",
       "ispra_linked_data      inventory change    \n",
-      "    69 item (sparql_query), delta +2 rispetto al run precedente (67).\n",
+      "    67 item (sparql_query), delta +1 rispetto al run precedente (66).\n",
       "    azione: verificare se variazione attesa; avviare inventory-triage se nuovi dataset\n",
       "\n",
       "mef_irpef              csv_magnet          \n",
@@ -257,16 +251,12 @@
       "    azione: catalog-watch-ready\n",
       "\n",
       "giustizia_statistiche  csv_magnet          \n",
-      "    9 link data (XLS 9), years 2014-2025 — top prefixes: Indicatori=2, Durata=2, Civile=1, Sorveg=1, Sorveglianza=1\n",
+      "    8 link data (XLS 8), years 2014-2025 — top prefixes: Indicatori=2, Durata=2, Civile=1, Sorveg=1, Interc=1\n",
       "    azione: low signal\n",
       "\n",
       "cortecostituzionale    csv_magnet          \n",
       "    33 link data (ZIP 33)\n",
-      "    azione: catalog-watch-ready\n",
-      "\n",
-      "unioncamere            inventory change    \n",
-      "    371 item (package_search), delta +19 rispetto al run precedente (352).\n",
-      "    azione: verificare se variazione attesa; avviare inventory-triage se nuovi dataset\n"
+      "    azione: catalog-watch-ready\n"
      ]
     }
    ],
@@ -291,448 +281,14 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 2b. PAQA — Public Administration Quality Assessment\n",
-    "\n",
-    "Quality scores strutturali e semantici per ogni CSV profilato.\n",
-    "Disponibile da Giugno 2026 (toolkit v1.36.0+).\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:11.890118Z",
-     "iopub.status.busy": "2026-06-14T10:33:11.889723Z",
-     "iopub.status.idle": "2026-06-14T10:33:11.915143Z",
-     "shell.execute_reply": "2026-06-14T10:33:11.912259Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "════════════════════════════════════════════════════════════\n",
-      "  PANORAMICA PAQA\n",
-      "════════════════════════════════════════════════════════════\n",
-      "Item con PAQA score:   1132  (11.5%)\n",
-      "Item senza PAQA:       8708  (88.5%)\n",
-      "Score medio:           93.2\n",
-      "Score mediano:           94\n",
-      "Dev std:                3.2\n",
-      "Min:                     78\n",
-      "Max:                     98\n",
-      "\n",
-      "  VERDETTI\n",
-      "    buona             996  (88.0%)\n",
-      "    scarsa             90  (8.0%)\n",
-      "    accettabile        46  (4.1%)\n",
-      "\n",
-      "  ITEM CON FLAG:      847\n",
-      "  ITEM CON ONTOLOGIE:   890\n",
-      "  SAMPLED:              233\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"═\" * 60)\n",
-    "print(\"  PANORAMICA PAQA\")\n",
-    "print(\"═\" * 60)\n",
-    "\n",
-    "total = len(df_scr)\n",
-    "with_paqa = df_scr[\"paqa_score\"].notna().sum()\n",
-    "without_paqa = total - with_paqa\n",
-    "print(f\"Item con PAQA score:  {with_paqa:>5}  ({with_paqa / total * 100:.1f}%)\")\n",
-    "print(f\"Item senza PAQA:      {without_paqa:>5}  ({without_paqa / total * 100:.1f}%)\")\n",
-    "\n",
-    "if with_paqa > 0:\n",
-    "    print(f\"Score medio:          {df_scr['paqa_score'].mean():>5.1f}\")\n",
-    "    print(f\"Score mediano:        {df_scr['paqa_score'].median():>5.0f}\")\n",
-    "    print(f\"Dev std:              {df_scr['paqa_score'].std():>5.1f}\")\n",
-    "    print(f\"Min:                  {df_scr['paqa_score'].min():>5.0f}\")\n",
-    "    print(f\"Max:                  {df_scr['paqa_score'].max():>5.0f}\")\n",
-    "\n",
-    "    print(\"\\n  VERDETTI\")\n",
-    "    verdicts = df_scr[\"paqa_verdict\"].value_counts()\n",
-    "    for v, c in verdicts.items():\n",
-    "        print(f\"    {str(v):<15s} {c:>5}  ({c / with_paqa * 100:.1f}%)\")\n",
-    "\n",
-    "    print(f\"\\n  ITEM CON FLAG:    {df_scr['paqa_flags'].notna().sum():>5}\")\n",
-    "    print(f\"  ITEM CON ONTOLOGIE: {df_scr['paqa_ontologies'].notna().sum():>5}\")\n",
-    "    print(f\"  SAMPLED:            {df_scr['paqa_sampled'].sum():>5}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:11.919768Z",
-     "iopub.status.busy": "2026-06-14T10:33:11.919315Z",
-     "iopub.status.idle": "2026-06-14T10:33:11.967786Z",
-     "shell.execute_reply": "2026-06-14T10:33:11.964731Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "════════════════════════════════════════════════════════════\n",
-      "  PAQA PER FONTE\n",
-      "════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fonte                   Item   Avg  Med  Min  Max   Std\n",
-      "----------------------------------------------------\n",
-      "openga                   200    96   95   90   98   1.5\n",
-      "inps                      41    96   95   90   98   2.1\n",
-      "pagopa                     8    95   95   92   98   2.5\n",
-      "ministero_salute           2    95   95   95   95   0.0\n",
-      "ministero_interno         38    94   95   88   98   3.4\n",
-      "aci                        4    94   94   94   94   0.0\n",
-      "unioncamere              353    94   95   78   98   3.3\n",
-      "mit_opendata              32    92   93   80   98   4.8\n",
-      "mim_opendata             371    92   92   81   95   2.5\n",
-      "lavoro_opendata           83    90   90   90   90   0.0\n"
-     ]
-    }
-   ],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "print(\"═\" * 60)\n",
-    "print(\"  PAQA PER FONTE\")\n",
-    "print(\"═\" * 60)\n",
-    "\n",
-    "src_paqa = (\n",
-    "    df_scr[df_scr[\"paqa_score\"].notna()]\n",
-    "    .groupby(\"source_id\")\n",
-    "    .agg(\n",
-    "        items=(\"paqa_score\", \"count\"),\n",
-    "        avg_score=(\"paqa_score\", \"mean\"),\n",
-    "        med_score=(\"paqa_score\", \"median\"),\n",
-    "        min_score=(\"paqa_score\", \"min\"),\n",
-    "        max_score=(\"paqa_score\", \"max\"),\n",
-    "        std_score=(\"paqa_score\", \"std\"),\n",
-    "    )\n",
-    "    .reset_index()\n",
-    ")\n",
-    "src_paqa = src_paqa.sort_values(\"avg_score\", ascending=False)\n",
-    "\n",
-    "print(f\"{'Fonte':22s} {'Item':>5s} {'Avg':>5s} {'Med':>4s} {'Min':>4s} {'Max':>4s} {'Std':>5s}\")\n",
-    "print(\"-\" * 52)\n",
-    "for _, r in src_paqa.iterrows():\n",
-    "    std_str = f\"{r['std_score']:.1f}\" if pd.notna(r[\"std_score\"]) else \"N/A\"\n",
-    "    print(\n",
-    "        f\"{r['source_id']:22s} {r['items']:5.0f} {r['avg_score']:5.0f} {r['med_score']:4.0f} {r['min_score']:4.0f} {r['max_score']:4.0f} {std_str:>5s}\"\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:11.973794Z",
-     "iopub.status.busy": "2026-06-14T10:33:11.973217Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.016571Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.013795Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "════════════════════════════════════════════════════════════\n",
-      "  PAQA — FLAG\n",
-      "════════════════════════════════════════════════════════════\n",
-      "Flag combo                                               Item      %\n",
-      "--------------------------------------------------------------------\n",
-      "  [non_iso_dates                                     ]   378  ( 44.6%)\n",
-      "  [column_naming                                     ]   292  ( 34.5%)\n",
-      "  [inconsistent_columns, column_naming               ]    87  ( 10.3%)\n",
-      "  [column_naming, non_iso_dates                      ]    44  (  5.2%)\n",
-      "  [duplicate_columns, column_naming                  ]    15  (  1.8%)\n",
-      "  [encoding_issues, non_iso_dates                    ]    11  (  1.3%)\n",
-      "  [duplicate_columns, high_missing_rate, column_naming]     4  (  0.5%)\n",
-      "  [high_missing_rate                                 ]     3  (  0.4%)\n",
-      "  [duplicate_columns, column_naming, non_iso_dates   ]     2  (  0.2%)\n",
-      "  [high_missing_rate, column_naming                  ]     2  (  0.2%)\n",
-      "  [encoding_issues                                   ]     2  (  0.2%)\n",
-      "  [inconsistent_columns, non_iso_dates               ]     2  (  0.2%)\n",
-      "  [encoding_issues, column_naming                    ]     2  (  0.2%)\n",
-      "  [duplicate_columns, high_missing_rate, column_naming, non_iso_dates]     1  (  0.1%)\n",
-      "  [duplicate_columns                                 ]     1  (  0.1%)\n",
-      "  ... e altre 1 combinazioni\n"
-     ]
-    }
-   ],
-   "source": [
-    "import ast\n",
-    "\n",
-    "print(\"═\" * 60)\n",
-    "print(\"  PAQA — FLAG\")\n",
-    "print(\"═\" * 60)\n",
-    "\n",
-    "flags_series = df_scr[\n",
-    "    df_scr[\"paqa_flags\"].notna() & (df_scr[\"paqa_flags\"] != \"[]\") & (df_scr[\"paqa_flags\"] != \"\")\n",
-    "]\n",
-    "\n",
-    "# Parse e conta flag (ogni riga può avere multipli flag in formato JSON array string)\n",
-    "\n",
-    "flag_counter = {}\n",
-    "for raw in flags_series[\"paqa_flags\"]:\n",
-    "    try:\n",
-    "        flags = ast.literal_eval(raw) if isinstance(raw, str) else raw\n",
-    "    except Exception:\n",
-    "        flags = []\n",
-    "    key = \", \".join(flags) if flags else \"empty\"\n",
-    "    flag_counter[key] = flag_counter.get(key, 0) + 1\n",
-    "\n",
-    "sorted_flags = sorted(flag_counter.items(), key=lambda x: -x[1])\n",
-    "print(f\"{'Flag combo':55s} {'Item':>5s} {'%':>6s}\")\n",
-    "print(\"-\" * 68)\n",
-    "for combo, cnt in sorted_flags[:15]:\n",
-    "    print(f\"  [{combo:50s}] {cnt:5d}  ({cnt / flags_series.shape[0] * 100:5.1f}%)\")\n",
-    "\n",
-    "if len(sorted_flags) > 15:\n",
-    "    print(f\"  ... e altre {len(sorted_flags) - 15} combinazioni\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.020895Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.020464Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.094355Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.091413Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "════════════════════════════════════════════════════════════\n",
-      "  PAQA — ONTOLOGIE RILEVATE\n",
-      "════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ontologia/e                                              Item\n",
-      "--------------------------------------------------------------\n",
-      "  TI                                                        172\n",
-      "  CPV, TI                                                   167\n",
-      "  ISTAT, TI                                                 121\n",
-      "  CLV, ISTAT, TI                                             80\n",
-      "  CLV, COV, ISTAT, TI                                        67\n",
-      "  CLV, ISTAT                                                 59\n",
-      "  CLV                                                        41\n",
-      "  CPV, QB, TI                                                32\n",
-      "  QB, TI                                                     23\n",
-      "  QB                                                         20\n",
-      "  COV, TI                                                    16\n",
-      "  CLV, ISTAT, QB                                             11\n",
-      "  ... e altre 28 combinazioni\n",
-      "\n",
-      "Item con ontologia/e: 890\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"═\" * 60)\n",
-    "print(\"  PAQA — ONTOLOGIE RILEVATE\")\n",
-    "print(\"═\" * 60)\n",
-    "\n",
-    "onto_series = df_scr[\n",
-    "    df_scr[\"paqa_ontologies\"].notna()\n",
-    "    & (df_scr[\"paqa_ontologies\"] != \"{}\")\n",
-    "    & (df_scr[\"paqa_ontologies\"] != \"\")\n",
-    "]\n",
-    "\n",
-    "onto_counter = {}\n",
-    "for raw in onto_series[\"paqa_ontologies\"]:\n",
-    "    try:\n",
-    "        onto = ast.literal_eval(raw) if isinstance(raw, str) else raw\n",
-    "    except Exception:\n",
-    "        onto = {}\n",
-    "    # Extract ontology codes\n",
-    "    codes = sorted(onto.keys()) if onto else [\"empty\"]\n",
-    "    key = \", \".join(codes)\n",
-    "    onto_counter[key] = onto_counter.get(key, 0) + 1\n",
-    "\n",
-    "sorted_onto = sorted(onto_counter.items(), key=lambda x: -x[1])\n",
-    "print(f\"{'Ontologia/e':55s} {'Item':>5s}\")\n",
-    "print(\"-\" * 62)\n",
-    "for combo, cnt in sorted_onto[:12]:\n",
-    "    print(f\"  {combo:55s} {cnt:5d}\")\n",
-    "\n",
-    "if len(sorted_onto) > 12:\n",
-    "    print(f\"  ... e altre {len(sorted_onto) - 12} combinazioni\")\n",
-    "\n",
-    "print(f\"\\nItem con ontologia/e: {onto_series.shape[0]}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.098723Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.098247Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.167977Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.164251Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "════════════════════════════════════════════════════════════\n",
-      "  PAQA vs INTAKE SCORE\n",
-      "════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Correlazione PAQA ↔ Intake: 0.285\n",
-      "(su 1132 item con entrambi gli score)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "  Fascia PAQA      N Avg Intake\n",
-      "  ------------------------------\n",
-      "  70-90          188       53.6\n",
-      "  90-100         944       67.4\n",
-      "\n",
-      "  Top 5 per intake_score (con PAQA):\n",
-      "    unioncamere     intake=100 paqa=95  Vicenza - Imprese Femminili della provincia, storico iscrizi\n",
-      "    unioncamere     intake=100 paqa=98  Modena - esportazioni settore ceramico provincia di Modena d\n",
-      "    unioncamere     intake=100 paqa=98  Modena - esportazioni mezzi di trasporto provincia di Modena\n",
-      "    unioncamere     intake=100 paqa=98  Modena - esportazioni macchine e apparecchiature meccaniche \n",
-      "    unioncamere     intake=100 paqa=98  Modena - esportazioni settore biomedicale provincia di Moden\n"
-     ]
-    }
-   ],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "print(\"═\" * 60)\n",
-    "print(\"  PAQA vs INTAKE SCORE\")\n",
-    "print(\"═\" * 60)\n",
-    "\n",
-    "both = df_scr[df_scr[\"paqa_score\"].notna() & df_scr[\"intake_score\"].notna()].copy()\n",
-    "if len(both) > 0:\n",
-    "    corr = both[\"paqa_score\"].corr(both[\"intake_score\"])\n",
-    "    print(f\"Correlazione PAQA ↔ Intake: {corr:.3f}\")\n",
-    "    print(f\"(su {len(both)} item con entrambi gli score)\")\n",
-    "\n",
-    "    incrocio = (\n",
-    "        both.groupby(\n",
-    "            pd.cut(both[\"paqa_score\"], bins=[0, 70, 90, 100], labels=[\"<70\", \"70-90\", \"90-100\"])\n",
-    "        )\n",
-    "        .agg(n=(\"intake_score\", \"count\"), avg_intake=(\"intake_score\", \"mean\"))\n",
-    "        .reset_index()\n",
-    "    )\n",
-    "    print(f\"\\n  {'Fascia PAQA':12s} {'N':>5s} {'Avg Intake':>10s}\")\n",
-    "    print(\"  \" + \"-\" * 30)\n",
-    "    for _, r in incrocio.iterrows():\n",
-    "        print(f\"  {str(r['paqa_score']):12s} {r['n']:5.0f} {r['avg_intake']:10.1f}\")\n",
-    "\n",
-    "    # Top item: alto PAQA + alto intake\n",
-    "    top = both.nlargest(5, \"intake_score\")[[\"source_id\", \"title\", \"intake_score\", \"paqa_score\"]]\n",
-    "    print(\"\\n  Top 5 per intake_score (con PAQA):\")\n",
-    "    for _, r in top.iterrows():\n",
-    "        print(\n",
-    "            f\"    {r['source_id']:<15s} intake={r['intake_score']:.0f} paqa={r['paqa_score']:.0f}  {str(r.get('title', ''))[:60]}\"\n",
-    "        )\n",
-    "else:\n",
-    "    print(\"Nessun item con entrambi gli score disponibile\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.172625Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.172023Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.210480Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.207693Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "════════════════════════════════════════════════════════════\n",
-      "  SAMPLED — PREVIEW TRONCA\n",
-      "════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sampled (preview tronca, check S6/S12 disabilitati): 233\n",
-      "Full preview:                                         899\n",
-      "Score medio sampled:   91.3\n",
-      "Score medio full:      93.7\n",
-      "Differenza:            +2.4\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"═\" * 60)\n",
-    "print(\"  SAMPLED — PREVIEW TRONCA\")\n",
-    "print(\"═\" * 60)\n",
-    "\n",
-    "sampled_true = df_scr[df_scr[\"paqa_sampled\"]]\n",
-    "sampled_false = df_scr[~df_scr[\"paqa_sampled\"]]\n",
-    "print(f\"Sampled (preview tronca, check S6/S12 disabilitati): {len(sampled_true)}\")\n",
-    "print(f\"Full preview:                                         {len(sampled_false)}\")\n",
-    "\n",
-    "if len(sampled_true) > 0 and len(sampled_false) > 0:\n",
-    "    score_sampled = sampled_true[\"paqa_score\"].mean()\n",
-    "    score_full = sampled_false[\"paqa_score\"].mean()\n",
-    "    print(f\"Score medio sampled:   {score_sampled:.1f}\")\n",
-    "    print(f\"Score medio full:      {score_full:.1f}\")\n",
-    "    print(f\"Differenza:            {score_full - score_sampled:+.1f}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.214912Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.214506Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.256762Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.254181Z"
+     "iopub.execute_input": "2026-06-08T13:28:51.004172Z",
+     "iopub.status.busy": "2026-06-08T13:28:51.003785Z",
+     "iopub.status.idle": "2026-06-08T13:28:51.041663Z",
+     "shell.execute_reply": "2026-06-08T13:28:51.038868Z"
     }
    },
    "outputs": [
@@ -742,47 +298,39 @@
      "text": [
       "════════════════════════════════════════════════════════════\n",
       "  COPERTURA SOURCE-CHECK\n",
-      "════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "════════════════════════════════════════════════════════════\n",
       "Fonte                   Inventory   Scored  Coperto\n",
       "--------------------------------------------------\n",
       "istat_sdmx                   4871     3584    73.6%\n",
       "openbdap                     3817     1918    50.2%\n",
-      "inps                         2323     1427    61.4%\n",
+      "inps                         2323     1426    61.4%\n",
       "opencivitas                   703      384    54.6%\n",
-      "opencoesione                  561      518    92.3%\n",
+      "opencoesione                  561      504    89.8%\n",
       "openga                        436      364    83.5%\n",
-      "mim_opendata                  372      407   109.4%\n",
-      "unioncamere                   371      371   100.0%\n",
+      "mim_opendata                  372      387   104.0%\n",
       "mimit_rna                     370       85    23.0%\n",
+      "unioncamere                   352      349    99.1%\n",
       "dati_cultura                  213      213   100.0%\n",
+      "mef_irpef                     147       80    54.4%\n",
       "dati_camera                   104      104   100.0%\n",
       "dati_senato                    98        0     0.0%\n",
       "lavoro_opendata                83       83   100.0%\n",
-      "mit_opendata                   70       62    88.6%\n",
       "anac                           70       13    18.6%\n",
+      "mit_opendata                   70       62    88.6%\n",
       "mur_ustat                      69       69   100.0%\n",
-      "ispra_linked_data              69        0     0.0%\n",
+      "ispra_linked_data              67        0     0.0%\n",
       "agcm                           53        4     7.5%\n",
       "ministero_salute               51       48    94.1%\n",
       "aifa                           42       20    47.6%\n",
       "agid                           40        8    20.0%\n",
       "ministero_interno              38       38   100.0%\n",
-      "aci                            35        4    11.4%\n",
       "cortecostituzionale            33       13    39.4%\n",
       "consip_open_data               16       10    62.5%\n",
-      "giustizia_statistiche           9        4    44.4%\n",
-      "pagopa                          8        8   100.0%\n",
-      "mef_irpef                       0       80  8000.0%\n",
+      "giustizia_statistiche           8        4    50.0%\n",
       "\n",
-      "Totale inventory: 14925\n",
-      "Totale scored:    9839\n",
-      "Copertura media:  65.9%\n"
+      "Totale inventory: 15007\n",
+      "Totale scored:    9770\n",
+      "Copertura media:  65.1%\n"
      ]
     }
    ],
@@ -816,13 +364,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.263049Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.262405Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.281164Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.278403Z"
+     "iopub.execute_input": "2026-06-08T13:28:51.045283Z",
+     "iopub.status.busy": "2026-06-08T13:28:51.044911Z",
+     "iopub.status.idle": "2026-06-08T13:28:51.063153Z",
+     "shell.execute_reply": "2026-06-08T13:28:51.060975Z"
     }
    },
    "outputs": [
@@ -833,14 +381,20 @@
       "════════════════════════════════════════════════════════════\n",
       "  QUALITA' DATASET\n",
       "════════════════════════════════════════════════════════════\n",
-      "Item totali:              9840\n",
-      "Candidati intake:         1422 (14%)\n",
-      "Needs review:             7942 (81%)\n",
-      "Reachable:                2923 (30%)\n",
-      "Con colonne profilate:    2172 (22%)\n",
-      "Con join_keys:            1132 (12%)\n",
-      "Intake score medio:       26.5\n",
-      "Joinability score medio:    5.8\n"
+      "Item totali:              9771\n",
+      "Candidati intake:         1271 (13%)\n",
+      "Needs review:             7946 (81%)\n",
+      "Reachable:                2853 (29%)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Con colonne profilate:    2118 (22%)\n",
+      "Con join_keys:            1009 (10%)\n",
+      "Intake score medio:       26.0\n",
+      "Joinability score medio:    5.1\n"
      ]
     }
    ],
@@ -873,13 +427,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.285597Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.285135Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.302998Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.298938Z"
+     "iopub.execute_input": "2026-06-08T13:28:51.068025Z",
+     "iopub.status.busy": "2026-06-08T13:28:51.067611Z",
+     "iopub.status.idle": "2026-06-08T13:28:51.081624Z",
+     "shell.execute_reply": "2026-06-08T13:28:51.079069Z"
     }
    },
    "outputs": [
@@ -889,30 +443,24 @@
      "text": [
       "════════════════════════════════════════════════════════════\n",
       "  GRANULARITA'\n",
-      "════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  non_determinato       6811 (69%)\n",
-      "  regione               1608 (16%)\n",
-      "  provincia              474 (5%)\n",
-      "  comune                 374 (4%)\n",
-      "  nazionale              346 (4%)\n",
-      "  europeo                108 (1%)\n",
+      "════════════════════════════════════════════════════════════\n",
+      "  non_determinato       6713 (69%)\n",
+      "  regione               1607 (16%)\n",
+      "  comune                 446 (5%)\n",
+      "  provincia              372 (4%)\n",
+      "  nazionale              345 (4%)\n",
+      "  europeo                 99 (1%)\n",
       "  mondiale                 2 (0%)\n",
       "\n",
       "  FORMATI\n",
-      "  CSV         4527 (46%)\n",
-      "  SDMX        3584 (36%)\n",
-      "  XLS          700 (7%)\n",
+      "  CSV         4455 (46%)\n",
+      "  SDMX        3584 (37%)\n",
+      "  XLS          640 (7%)\n",
       "  ZIP          437 (4%)\n",
       "               317 (3%)\n",
       "  XML          130 (1%)\n",
       "  JSON          12 (0%)\n",
-      "  XLSX           9 (0%)\n"
+      "  PDF            7 (0%)\n"
      ]
     }
    ],
@@ -941,19 +489,18 @@
     "- Fonti non inventariate → valutare se aggiungere a catalog-watch\n",
     "- Fonti con segnali di drift → verificare\n",
     "- Source_check da completare su fonti a bassa copertura\n",
-    "- Dataset con intake_score alto ma senza join_keys → potenziali falsi negativi\n",
-    "- Fonti con PAQA basso (< 85) → verificare quality check\n"
+    "- Dataset con intake_score alto ma senza join_keys → potenziali falsi negativi"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.308022Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.307587Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.370211Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.367165Z"
+     "iopub.execute_input": "2026-06-08T13:28:51.085735Z",
+     "iopub.status.busy": "2026-06-08T13:28:51.085271Z",
+     "iopub.status.idle": "2026-06-08T13:28:51.131665Z",
+     "shell.execute_reply": "2026-06-08T13:28:51.129397Z"
     }
    },
    "outputs": [
@@ -965,9 +512,9 @@
       "  COSE DA FARE\n",
       "════════════════════════════════════════════════════════════\n",
       "\n",
-      "📋 Fonti da inventariare: dait, inail_opendata, mef_irpef, noipa_sparql, terna_opendata\n",
+      "📋 Fonti da inventariare: dait, inail_opendata, noipa_sparql, terna_opendata\n",
       "\n",
-      "📋 Fonti con segnali attivi (8):\n",
+      "📋 Fonti con segnali attivi (7):\n",
       "     mim_opendata           csv_magnet           catalog-watch-ready\n",
       "     ispra_linked_data      inventory change     verificare se variazione attesa; avviare inventory-triage se\n",
       "     mef_irpef              csv_magnet           verificare raggiungibilità del portale\n",
@@ -975,38 +522,23 @@
       "     aifa                   csv_magnet           catalog-watch-ready\n",
       "     giustizia_statistiche  csv_magnet           low signal\n",
       "     cortecostituzionale    csv_magnet           catalog-watch-ready\n",
-      "     unioncamere            inventory change     verificare se variazione attesa; avviare inventory-triage se\n",
       "\n",
-      "📋 Fonti con copertura < 50% (10):\n",
+      "📋 Fonti con copertura < 50% (8):\n",
       "     dati_senato            0% (0/98)\n",
-      "     ispra_linked_data      0% (0/69)\n",
+      "     ispra_linked_data      0% (0/67)\n",
       "     agcm                   8% (4/53)\n",
-      "     aci                    11% (4/35)\n",
       "     anac                   19% (13/70)\n",
       "     agid                   20% (8/40)\n",
       "     mimit_rna              23% (85/370)\n",
       "     cortecostituzionale    39% (13/33)\n",
-      "     giustizia_statistiche  44% (4/9)\n",
-      "     aifa                   48% (20/42)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "     aifa                   48% (20/42)\n",
       "\n",
-      "📋 Dataset con intake >= 50 MA senza join_keys (859):\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n",
-      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n",
-      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n",
-      "     unioncamere     score=100 Modena - Unita locali attive per settori in provin\n",
-      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n"
+      "📋 Dataset con intake >= 50 MA senza join_keys (927):\n",
+      "     unioncamere     score=100 Modena - esportazioni per settore provincia di Mod\n",
+      "     unioncamere     score=100 Modena - Demografia delle imprese della provincia \n",
+      "     unioncamere     score=100 Modena - esportazioni mezzi di trasporto provincia\n",
+      "     unioncamere     score=100 Modena - esportazioni settore biomedicale provinci\n",
+      "     unioncamere     score=100 Modena - esportazioni settore agroalimentare provi\n"
      ]
     }
    ],

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -709,6 +709,8 @@ def _check_row(
         "sparql_triple_count": enrich.get("sparql_triple_count"),
         # Protocol — propagato dal catalogo per il grouping SDMX
         "protocol": row.get("protocol"),
+        # Distribution URL — usata internamente per preview/HEAD, propagata per tracciabilità
+        "distribution_url": row.get("distribution_url"),
     }
 
 

--- a/scripts/collectors/sdmx.py
+++ b/scripts/collectors/sdmx.py
@@ -26,7 +26,7 @@ def _sdmx_api_base(url: str) -> str | None:
 
 def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> CollectorResult:
     endpoint = source_cfg["base_url"]
-    client = HttpClient(timeout=300, max_retries=3)
+    client = HttpClient(timeout=600, max_retries=3)
     result = client.get(endpoint)
 
     if result.is_error:

--- a/scripts/collectors/sdmx.py
+++ b/scripts/collectors/sdmx.py
@@ -26,7 +26,7 @@ def _sdmx_api_base(url: str) -> str | None:
 
 def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> CollectorResult:
     endpoint = source_cfg["base_url"]
-    client = HttpClient(timeout=600, max_retries=3)
+    client = HttpClient(timeout=330, max_retries=1)
     result = client.get(endpoint)
 
     if result.is_error:

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -1514,6 +1514,10 @@ class TestSdmxPaqaFlow:
         assert result.get("paqa_score") == 92, f"paqa_score: {result.get('paqa_score')}"
         assert result.get("paqa_verdict") == "buona"
         assert result.get("paqa_sampled") is True
+        # Verifica che distribution_url sia propagato nel risultato (contratto)
+        assert result.get("distribution_url") == row.get("distribution_url"), (
+            f"distribution_url non propagato: {result.get('distribution_url')}"
+        )
 
 
 pytestmark = pytest.mark.contract


### PR DESCRIPTION
## Root cause

`istat_sdmx` timeout a 300s durante inventory build perché l'endpoint `esploradati.istat.it/SDMXWS/rest/dataflow/IT1` impiega ~290s a generare l'XML con 4871 dataflow. Il per-source timeout di 300s race-conditionava col client HTTP a 300s, killando il task appena prima del completamento → inventory usava snapshot precedente (senza `distribution_url`, pre-PR #356).

## Fix

| # | Cosa | Dettaglio |
|---|---|---|
| 1 | **Budget coerente** | `HttpClient(timeout=330, max_retries=1)` + per-source `timeout:600`. Primo tentativo ha 330s, ISTAT risponde in ~290s. Niente retry fantasma in background. |
| 2 | **distribution_url propagato** | Aggiunto campo al return dict di `_check_row`. |
| 3 | **Contract test** | Assert che `distribution_url` sia presente nel risultato di `_check_row` per SDMX. |

## Test

```bash
pytest tests/test_sdmx_collector.py tests/test_bulk_source_check.py -v
# 109 passed
```

## Changelog

- `scripts/collectors/sdmx.py:29`: timeout 300→330, max_retries 3→1
- `data/radar/sources_registry.yaml:7`: inventory.timeout 300→600
- `scripts/bulk_source_check.py:712`: +distribution_url nel return dict
- `tests/test_bulk_source_check.py:1517`: +contract assert distribution_url

Notebook PAQA separato in PR #358.