### PR TITLE
feat: sezioni PAQA nel notebook diagnostico

### DIFF
--- a/notebooks/00_quality_diagnostic.ipynb
+++ b/notebooks/00_quality_diagnostic.ipynb
@@ -12,7 +12,7 @@
     "- **Dataset**: copertura source_check, intake score, reachability, granularità\n",
     "- **Copertura**: % inventario processato, gap\n",
     "\n",
-    "**Data**: 2026-06-08"
+    "**Data**: 2026-06-14"
    ]
   },
   {
@@ -20,10 +20,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:43.863715Z",
-     "iopub.status.busy": "2026-06-08T13:28:43.863237Z",
-     "iopub.status.idle": "2026-06-08T13:28:50.861768Z",
-     "shell.execute_reply": "2026-06-08T13:28:50.859681Z"
+     "iopub.execute_input": "2026-06-14T10:33:06.524077Z",
+     "iopub.status.busy": "2026-06-14T10:33:06.523605Z",
+     "iopub.status.idle": "2026-06-14T10:33:11.741989Z",
+     "shell.execute_reply": "2026-06-14T10:33:11.738590Z"
     }
    },
    "outputs": [
@@ -31,10 +31,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Radar: 30 fonti\n",
-      "Inventory: 15007 rows, 26 fonti\n",
-      "Source-check: 9771 rows, 24 fonti\n",
-      "Signals: 26 fonti controllate\n"
+      "Radar: 32 fonti\n",
+      "Inventory: 14925 rows, 27 fonti\n",
+      "Source-check: 9840 rows, 26 fonti\n",
+      "Signals: 28 fonti controllate\n"
      ]
     }
    ],
@@ -80,10 +80,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:50.944172Z",
-     "iopub.status.busy": "2026-06-08T13:28:50.943532Z",
-     "iopub.status.idle": "2026-06-08T13:28:50.959883Z",
-     "shell.execute_reply": "2026-06-08T13:28:50.957906Z"
+     "iopub.execute_input": "2026-06-14T10:33:11.825136Z",
+     "iopub.status.busy": "2026-06-14T10:33:11.824384Z",
+     "iopub.status.idle": "2026-06-14T10:33:11.841403Z",
+     "shell.execute_reply": "2026-06-14T10:33:11.838490Z"
     }
    },
    "outputs": [
@@ -95,16 +95,21 @@
       "  RADAR HEALTH\n",
       "════════════════════════════════════════════════════════════\n",
       "\n",
-      "GREEN:  30\n",
-      "YELLOW: 0\n",
+      "GREEN:  28\n",
+      "YELLOW: 4\n",
       "RED:    0\n",
       "Persistent RED: 0\n",
       "\n",
       "Fonti non VERDI:\n",
+      "  🔴 istat_sdmx                YELLOW   Timeout (ConnectTimeout)\n",
+      "  🔴 openbdap                  YELLOW   Retry timeout/connection: Timeout (ConnectTimeout)\n",
+      "  🔴 consip_open_data          YELLOW   Retry timeout/connection: Timeout (ConnectTimeout)\n",
+      "  🔴 mef_irpef                 YELLOW   Retry timeout/connection: Timeout (ConnectTimeout)\n",
       "\n",
-      "Fonti non inventariate (4):\n",
+      "Fonti non inventariate (5):\n",
       "  dait                      protocol=html      \n",
       "  inail_opendata            protocol=aem       \n",
+      "  mef_irpef                 protocol=html      \n",
       "  noipa_sparql              protocol=sparql    \n",
       "  terna_opendata            protocol=rest      \n"
      ]
@@ -152,10 +157,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:50.964392Z",
-     "iopub.status.busy": "2026-06-08T13:28:50.963920Z",
-     "iopub.status.idle": "2026-06-08T13:28:50.987791Z",
-     "shell.execute_reply": "2026-06-08T13:28:50.985630Z"
+     "iopub.execute_input": "2026-06-14T10:33:11.846167Z",
+     "iopub.status.busy": "2026-06-14T10:33:11.845781Z",
+     "iopub.status.idle": "2026-06-14T10:33:11.871263Z",
+     "shell.execute_reply": "2026-06-14T10:33:11.867551Z"
     }
    },
    "outputs": [
@@ -174,27 +179,28 @@
       "         opencoesione     ckan    561\n",
       "               openga     ckan    436\n",
       "         mim_opendata     html    372\n",
+      "          unioncamere     ckan    371\n",
       "            mimit_rna     ckan    370\n",
-      "          unioncamere     ckan    352\n",
       "         dati_cultura   sparql    213\n",
-      "            mef_irpef     html    147\n",
       "          dati_camera   sparql    104\n",
       "          dati_senato   sparql     98\n",
       "      lavoro_opendata     ckan     83\n",
-      "                 anac     ckan     70\n",
       "         mit_opendata     ckan     70\n",
+      "                 anac     ckan     70\n",
       "            mur_ustat     ckan     69\n",
-      "    ispra_linked_data   sparql     67\n",
+      "    ispra_linked_data   sparql     69\n",
       "                 agcm     ckan     53\n",
       "     ministero_salute     ckan     51\n",
       "                 aifa     html     42\n",
       "                 agid     ckan     40\n",
       "    ministero_interno     ckan     38\n",
+      "                  aci     ckan     35\n",
       "  cortecostituzionale     html     33\n",
       "     consip_open_data     ckan     16\n",
-      "giustizia_statistiche     html      8\n",
+      "giustizia_statistiche     html      9\n",
+      "               pagopa     ckan      8\n",
       "\n",
-      "Totale item inventario: 15007\n"
+      "Totale item inventario: 14925\n"
      ]
     }
    ],
@@ -215,10 +221,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:50.991354Z",
-     "iopub.status.busy": "2026-06-08T13:28:50.991014Z",
-     "iopub.status.idle": "2026-06-08T13:28:51.000073Z",
-     "shell.execute_reply": "2026-06-08T13:28:50.997393Z"
+     "iopub.execute_input": "2026-06-14T10:33:11.876049Z",
+     "iopub.status.busy": "2026-06-14T10:33:11.875487Z",
+     "iopub.status.idle": "2026-06-14T10:33:11.885824Z",
+     "shell.execute_reply": "2026-06-14T10:33:11.883187Z"
     }
    },
    "outputs": [
@@ -235,7 +241,7 @@
       "    azione: catalog-watch-ready\n",
       "\n",
       "ispra_linked_data      inventory change    \n",
-      "    67 item (sparql_query), delta +1 rispetto al run precedente (66).\n",
+      "    69 item (sparql_query), delta +2 rispetto al run precedente (67).\n",
       "    azione: verificare se variazione attesa; avviare inventory-triage se nuovi dataset\n",
       "\n",
       "mef_irpef              csv_magnet          \n",
@@ -251,12 +257,16 @@
       "    azione: catalog-watch-ready\n",
       "\n",
       "giustizia_statistiche  csv_magnet          \n",
-      "    8 link data (XLS 8), years 2014-2025 — top prefixes: Indicatori=2, Durata=2, Civile=1, Sorveg=1, Interc=1\n",
+      "    9 link data (XLS 9), years 2014-2025 — top prefixes: Indicatori=2, Durata=2, Civile=1, Sorveg=1, Sorveglianza=1\n",
       "    azione: low signal\n",
       "\n",
       "cortecostituzionale    csv_magnet          \n",
       "    33 link data (ZIP 33)\n",
-      "    azione: catalog-watch-ready\n"
+      "    azione: catalog-watch-ready\n",
+      "\n",
+      "unioncamere            inventory change    \n",
+      "    371 item (package_search), delta +19 rispetto al run precedente (352).\n",
+      "    azione: verificare se variazione attesa; avviare inventory-triage se nuovi dataset\n"
      ]
     }
    ],
@@ -281,14 +291,448 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2b. PAQA — Public Administration Quality Assessment\n",
+    "\n",
+    "Quality scores strutturali e semantici per ogni CSV profilato.\n",
+    "Disponibile da Giugno 2026 (toolkit v1.36.0+).\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:51.004172Z",
-     "iopub.status.busy": "2026-06-08T13:28:51.003785Z",
-     "iopub.status.idle": "2026-06-08T13:28:51.041663Z",
-     "shell.execute_reply": "2026-06-08T13:28:51.038868Z"
+     "iopub.execute_input": "2026-06-14T10:33:11.890118Z",
+     "iopub.status.busy": "2026-06-14T10:33:11.889723Z",
+     "iopub.status.idle": "2026-06-14T10:33:11.915143Z",
+     "shell.execute_reply": "2026-06-14T10:33:11.912259Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PANORAMICA PAQA\n",
+      "════════════════════════════════════════════════════════════\n",
+      "Item con PAQA score:   1132  (11.5%)\n",
+      "Item senza PAQA:       8708  (88.5%)\n",
+      "Score medio:           93.2\n",
+      "Score mediano:           94\n",
+      "Dev std:                3.2\n",
+      "Min:                     78\n",
+      "Max:                     98\n",
+      "\n",
+      "  VERDETTI\n",
+      "    buona             996  (88.0%)\n",
+      "    scarsa             90  (8.0%)\n",
+      "    accettabile        46  (4.1%)\n",
+      "\n",
+      "  ITEM CON FLAG:      847\n",
+      "  ITEM CON ONTOLOGIE:   890\n",
+      "  SAMPLED:              233\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  PANORAMICA PAQA\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "total = len(df_scr)\n",
+    "with_paqa = df_scr[\"paqa_score\"].notna().sum()\n",
+    "without_paqa = total - with_paqa\n",
+    "print(f\"Item con PAQA score:  {with_paqa:>5}  ({with_paqa / total * 100:.1f}%)\")\n",
+    "print(f\"Item senza PAQA:      {without_paqa:>5}  ({without_paqa / total * 100:.1f}%)\")\n",
+    "\n",
+    "if with_paqa > 0:\n",
+    "    print(f\"Score medio:          {df_scr['paqa_score'].mean():>5.1f}\")\n",
+    "    print(f\"Score mediano:        {df_scr['paqa_score'].median():>5.0f}\")\n",
+    "    print(f\"Dev std:              {df_scr['paqa_score'].std():>5.1f}\")\n",
+    "    print(f\"Min:                  {df_scr['paqa_score'].min():>5.0f}\")\n",
+    "    print(f\"Max:                  {df_scr['paqa_score'].max():>5.0f}\")\n",
+    "\n",
+    "    print(\"\\n  VERDETTI\")\n",
+    "    verdicts = df_scr[\"paqa_verdict\"].value_counts()\n",
+    "    for v, c in verdicts.items():\n",
+    "        print(f\"    {str(v):<15s} {c:>5}  ({c / with_paqa * 100:.1f}%)\")\n",
+    "\n",
+    "    print(f\"\\n  ITEM CON FLAG:    {df_scr['paqa_flags'].notna().sum():>5}\")\n",
+    "    print(f\"  ITEM CON ONTOLOGIE: {df_scr['paqa_ontologies'].notna().sum():>5}\")\n",
+    "    print(f\"  SAMPLED:            {df_scr['paqa_sampled'].sum():>5}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T10:33:11.919768Z",
+     "iopub.status.busy": "2026-06-14T10:33:11.919315Z",
+     "iopub.status.idle": "2026-06-14T10:33:11.967786Z",
+     "shell.execute_reply": "2026-06-14T10:33:11.964731Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PAQA PER FONTE\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonte                   Item   Avg  Med  Min  Max   Std\n",
+      "----------------------------------------------------\n",
+      "openga                   200    96   95   90   98   1.5\n",
+      "inps                      41    96   95   90   98   2.1\n",
+      "pagopa                     8    95   95   92   98   2.5\n",
+      "ministero_salute           2    95   95   95   95   0.0\n",
+      "ministero_interno         38    94   95   88   98   3.4\n",
+      "aci                        4    94   94   94   94   0.0\n",
+      "unioncamere              353    94   95   78   98   3.3\n",
+      "mit_opendata              32    92   93   80   98   4.8\n",
+      "mim_opendata             371    92   92   81   95   2.5\n",
+      "lavoro_opendata           83    90   90   90   90   0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "print(\"═\" * 60)\n",
+    "print(\"  PAQA PER FONTE\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "src_paqa = (\n",
+    "    df_scr[df_scr[\"paqa_score\"].notna()]\n",
+    "    .groupby(\"source_id\")\n",
+    "    .agg(\n",
+    "        items=(\"paqa_score\", \"count\"),\n",
+    "        avg_score=(\"paqa_score\", \"mean\"),\n",
+    "        med_score=(\"paqa_score\", \"median\"),\n",
+    "        min_score=(\"paqa_score\", \"min\"),\n",
+    "        max_score=(\"paqa_score\", \"max\"),\n",
+    "        std_score=(\"paqa_score\", \"std\"),\n",
+    "    )\n",
+    "    .reset_index()\n",
+    ")\n",
+    "src_paqa = src_paqa.sort_values(\"avg_score\", ascending=False)\n",
+    "\n",
+    "print(f\"{'Fonte':22s} {'Item':>5s} {'Avg':>5s} {'Med':>4s} {'Min':>4s} {'Max':>4s} {'Std':>5s}\")\n",
+    "print(\"-\" * 52)\n",
+    "for _, r in src_paqa.iterrows():\n",
+    "    std_str = f\"{r['std_score']:.1f}\" if pd.notna(r[\"std_score\"]) else \"N/A\"\n",
+    "    print(\n",
+    "        f\"{r['source_id']:22s} {r['items']:5.0f} {r['avg_score']:5.0f} {r['med_score']:4.0f} {r['min_score']:4.0f} {r['max_score']:4.0f} {std_str:>5s}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T10:33:11.973794Z",
+     "iopub.status.busy": "2026-06-14T10:33:11.973217Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.016571Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.013795Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PAQA — FLAG\n",
+      "════════════════════════════════════════════════════════════\n",
+      "Flag combo                                               Item      %\n",
+      "--------------------------------------------------------------------\n",
+      "  [non_iso_dates                                     ]   378  ( 44.6%)\n",
+      "  [column_naming                                     ]   292  ( 34.5%)\n",
+      "  [inconsistent_columns, column_naming               ]    87  ( 10.3%)\n",
+      "  [column_naming, non_iso_dates                      ]    44  (  5.2%)\n",
+      "  [duplicate_columns, column_naming                  ]    15  (  1.8%)\n",
+      "  [encoding_issues, non_iso_dates                    ]    11  (  1.3%)\n",
+      "  [duplicate_columns, high_missing_rate, column_naming]     4  (  0.5%)\n",
+      "  [high_missing_rate                                 ]     3  (  0.4%)\n",
+      "  [duplicate_columns, column_naming, non_iso_dates   ]     2  (  0.2%)\n",
+      "  [high_missing_rate, column_naming                  ]     2  (  0.2%)\n",
+      "  [encoding_issues                                   ]     2  (  0.2%)\n",
+      "  [inconsistent_columns, non_iso_dates               ]     2  (  0.2%)\n",
+      "  [encoding_issues, column_naming                    ]     2  (  0.2%)\n",
+      "  [duplicate_columns, high_missing_rate, column_naming, non_iso_dates]     1  (  0.1%)\n",
+      "  [duplicate_columns                                 ]     1  (  0.1%)\n",
+      "  ... e altre 1 combinazioni\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ast\n",
+    "\n",
+    "print(\"═\" * 60)\n",
+    "print(\"  PAQA — FLAG\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "flags_series = df_scr[\n",
+    "    df_scr[\"paqa_flags\"].notna() & (df_scr[\"paqa_flags\"] != \"[]\") & (df_scr[\"paqa_flags\"] != \"\")\n",
+    "]\n",
+    "\n",
+    "# Parse e conta flag (ogni riga può avere multipli flag in formato JSON array string)\n",
+    "\n",
+    "flag_counter = {}\n",
+    "for raw in flags_series[\"paqa_flags\"]:\n",
+    "    try:\n",
+    "        flags = ast.literal_eval(raw) if isinstance(raw, str) else raw\n",
+    "    except Exception:\n",
+    "        flags = []\n",
+    "    key = \", \".join(flags) if flags else \"empty\"\n",
+    "    flag_counter[key] = flag_counter.get(key, 0) + 1\n",
+    "\n",
+    "sorted_flags = sorted(flag_counter.items(), key=lambda x: -x[1])\n",
+    "print(f\"{'Flag combo':55s} {'Item':>5s} {'%':>6s}\")\n",
+    "print(\"-\" * 68)\n",
+    "for combo, cnt in sorted_flags[:15]:\n",
+    "    print(f\"  [{combo:50s}] {cnt:5d}  ({cnt / flags_series.shape[0] * 100:5.1f}%)\")\n",
+    "\n",
+    "if len(sorted_flags) > 15:\n",
+    "    print(f\"  ... e altre {len(sorted_flags) - 15} combinazioni\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T10:33:12.020895Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.020464Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.094355Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.091413Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PAQA — ONTOLOGIE RILEVATE\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ontologia/e                                              Item\n",
+      "--------------------------------------------------------------\n",
+      "  TI                                                        172\n",
+      "  CPV, TI                                                   167\n",
+      "  ISTAT, TI                                                 121\n",
+      "  CLV, ISTAT, TI                                             80\n",
+      "  CLV, COV, ISTAT, TI                                        67\n",
+      "  CLV, ISTAT                                                 59\n",
+      "  CLV                                                        41\n",
+      "  CPV, QB, TI                                                32\n",
+      "  QB, TI                                                     23\n",
+      "  QB                                                         20\n",
+      "  COV, TI                                                    16\n",
+      "  CLV, ISTAT, QB                                             11\n",
+      "  ... e altre 28 combinazioni\n",
+      "\n",
+      "Item con ontologia/e: 890\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  PAQA — ONTOLOGIE RILEVATE\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "onto_series = df_scr[\n",
+    "    df_scr[\"paqa_ontologies\"].notna()\n",
+    "    & (df_scr[\"paqa_ontologies\"] != \"{}\")\n",
+    "    & (df_scr[\"paqa_ontologies\"] != \"\")\n",
+    "]\n",
+    "\n",
+    "onto_counter = {}\n",
+    "for raw in onto_series[\"paqa_ontologies\"]:\n",
+    "    try:\n",
+    "        onto = ast.literal_eval(raw) if isinstance(raw, str) else raw\n",
+    "    except Exception:\n",
+    "        onto = {}\n",
+    "    # Extract ontology codes\n",
+    "    codes = sorted(onto.keys()) if onto else [\"empty\"]\n",
+    "    key = \", \".join(codes)\n",
+    "    onto_counter[key] = onto_counter.get(key, 0) + 1\n",
+    "\n",
+    "sorted_onto = sorted(onto_counter.items(), key=lambda x: -x[1])\n",
+    "print(f\"{'Ontologia/e':55s} {'Item':>5s}\")\n",
+    "print(\"-\" * 62)\n",
+    "for combo, cnt in sorted_onto[:12]:\n",
+    "    print(f\"  {combo:55s} {cnt:5d}\")\n",
+    "\n",
+    "if len(sorted_onto) > 12:\n",
+    "    print(f\"  ... e altre {len(sorted_onto) - 12} combinazioni\")\n",
+    "\n",
+    "print(f\"\\nItem con ontologia/e: {onto_series.shape[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T10:33:12.098723Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.098247Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.167977Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.164251Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PAQA vs INTAKE SCORE\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correlazione PAQA ↔ Intake: 0.285\n",
+      "(su 1132 item con entrambi gli score)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fascia PAQA      N Avg Intake\n",
+      "  ------------------------------\n",
+      "  70-90          188       53.6\n",
+      "  90-100         944       67.4\n",
+      "\n",
+      "  Top 5 per intake_score (con PAQA):\n",
+      "    unioncamere     intake=100 paqa=95  Vicenza - Imprese Femminili della provincia, storico iscrizi\n",
+      "    unioncamere     intake=100 paqa=98  Modena - esportazioni settore ceramico provincia di Modena d\n",
+      "    unioncamere     intake=100 paqa=98  Modena - esportazioni mezzi di trasporto provincia di Modena\n",
+      "    unioncamere     intake=100 paqa=98  Modena - esportazioni macchine e apparecchiature meccaniche \n",
+      "    unioncamere     intake=100 paqa=98  Modena - esportazioni settore biomedicale provincia di Moden\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "print(\"═\" * 60)\n",
+    "print(\"  PAQA vs INTAKE SCORE\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "both = df_scr[df_scr[\"paqa_score\"].notna() & df_scr[\"intake_score\"].notna()].copy()\n",
+    "if len(both) > 0:\n",
+    "    corr = both[\"paqa_score\"].corr(both[\"intake_score\"])\n",
+    "    print(f\"Correlazione PAQA ↔ Intake: {corr:.3f}\")\n",
+    "    print(f\"(su {len(both)} item con entrambi gli score)\")\n",
+    "\n",
+    "    incrocio = (\n",
+    "        both.groupby(\n",
+    "            pd.cut(both[\"paqa_score\"], bins=[0, 70, 90, 100], labels=[\"<70\", \"70-90\", \"90-100\"])\n",
+    "        )\n",
+    "        .agg(n=(\"intake_score\", \"count\"), avg_intake=(\"intake_score\", \"mean\"))\n",
+    "        .reset_index()\n",
+    "    )\n",
+    "    print(f\"\\n  {'Fascia PAQA':12s} {'N':>5s} {'Avg Intake':>10s}\")\n",
+    "    print(\"  \" + \"-\" * 30)\n",
+    "    for _, r in incrocio.iterrows():\n",
+    "        print(f\"  {str(r['paqa_score']):12s} {r['n']:5.0f} {r['avg_intake']:10.1f}\")\n",
+    "\n",
+    "    # Top item: alto PAQA + alto intake\n",
+    "    top = both.nlargest(5, \"intake_score\")[[\"source_id\", \"title\", \"intake_score\", \"paqa_score\"]]\n",
+    "    print(\"\\n  Top 5 per intake_score (con PAQA):\")\n",
+    "    for _, r in top.iterrows():\n",
+    "        print(\n",
+    "            f\"    {r['source_id']:<15s} intake={r['intake_score']:.0f} paqa={r['paqa_score']:.0f}  {str(r.get('title', ''))[:60]}\"\n",
+    "        )\n",
+    "else:\n",
+    "    print(\"Nessun item con entrambi gli score disponibile\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T10:33:12.172625Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.172023Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.210480Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.207693Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  SAMPLED — PREVIEW TRONCA\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sampled (preview tronca, check S6/S12 disabilitati): 233\n",
+      "Full preview:                                         899\n",
+      "Score medio sampled:   91.3\n",
+      "Score medio full:      93.7\n",
+      "Differenza:            +2.4\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  SAMPLED — PREVIEW TRONCA\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "sampled_true = df_scr[df_scr[\"paqa_sampled\"]]\n",
+    "sampled_false = df_scr[~df_scr[\"paqa_sampled\"]]\n",
+    "print(f\"Sampled (preview tronca, check S6/S12 disabilitati): {len(sampled_true)}\")\n",
+    "print(f\"Full preview:                                         {len(sampled_false)}\")\n",
+    "\n",
+    "if len(sampled_true) > 0 and len(sampled_false) > 0:\n",
+    "    score_sampled = sampled_true[\"paqa_score\"].mean()\n",
+    "    score_full = sampled_false[\"paqa_score\"].mean()\n",
+    "    print(f\"Score medio sampled:   {score_sampled:.1f}\")\n",
+    "    print(f\"Score medio full:      {score_full:.1f}\")\n",
+    "    print(f\"Differenza:            {score_full - score_sampled:+.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T10:33:12.214912Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.214506Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.256762Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.254181Z"
     }
    },
    "outputs": [
@@ -298,39 +742,47 @@
      "text": [
       "════════════════════════════════════════════════════════════\n",
       "  COPERTURA SOURCE-CHECK\n",
-      "════════════════════════════════════════════════════════════\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Fonte                   Inventory   Scored  Coperto\n",
       "--------------------------------------------------\n",
       "istat_sdmx                   4871     3584    73.6%\n",
       "openbdap                     3817     1918    50.2%\n",
-      "inps                         2323     1426    61.4%\n",
+      "inps                         2323     1427    61.4%\n",
       "opencivitas                   703      384    54.6%\n",
-      "opencoesione                  561      504    89.8%\n",
+      "opencoesione                  561      518    92.3%\n",
       "openga                        436      364    83.5%\n",
-      "mim_opendata                  372      387   104.0%\n",
+      "mim_opendata                  372      407   109.4%\n",
+      "unioncamere                   371      371   100.0%\n",
       "mimit_rna                     370       85    23.0%\n",
-      "unioncamere                   352      349    99.1%\n",
       "dati_cultura                  213      213   100.0%\n",
-      "mef_irpef                     147       80    54.4%\n",
       "dati_camera                   104      104   100.0%\n",
       "dati_senato                    98        0     0.0%\n",
       "lavoro_opendata                83       83   100.0%\n",
-      "anac                           70       13    18.6%\n",
       "mit_opendata                   70       62    88.6%\n",
+      "anac                           70       13    18.6%\n",
       "mur_ustat                      69       69   100.0%\n",
-      "ispra_linked_data              67        0     0.0%\n",
+      "ispra_linked_data              69        0     0.0%\n",
       "agcm                           53        4     7.5%\n",
       "ministero_salute               51       48    94.1%\n",
       "aifa                           42       20    47.6%\n",
       "agid                           40        8    20.0%\n",
       "ministero_interno              38       38   100.0%\n",
+      "aci                            35        4    11.4%\n",
       "cortecostituzionale            33       13    39.4%\n",
       "consip_open_data               16       10    62.5%\n",
-      "giustizia_statistiche           8        4    50.0%\n",
+      "giustizia_statistiche           9        4    44.4%\n",
+      "pagopa                          8        8   100.0%\n",
+      "mef_irpef                       0       80  8000.0%\n",
       "\n",
-      "Totale inventory: 15007\n",
-      "Totale scored:    9770\n",
-      "Copertura media:  65.1%\n"
+      "Totale inventory: 14925\n",
+      "Totale scored:    9839\n",
+      "Copertura media:  65.9%\n"
      ]
     }
    ],
@@ -364,13 +816,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:51.045283Z",
-     "iopub.status.busy": "2026-06-08T13:28:51.044911Z",
-     "iopub.status.idle": "2026-06-08T13:28:51.063153Z",
-     "shell.execute_reply": "2026-06-08T13:28:51.060975Z"
+     "iopub.execute_input": "2026-06-14T10:33:12.263049Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.262405Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.281164Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.278403Z"
     }
    },
    "outputs": [
@@ -381,20 +833,14 @@
       "════════════════════════════════════════════════════════════\n",
       "  QUALITA' DATASET\n",
       "════════════════════════════════════════════════════════════\n",
-      "Item totali:              9771\n",
-      "Candidati intake:         1271 (13%)\n",
-      "Needs review:             7946 (81%)\n",
-      "Reachable:                2853 (29%)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Con colonne profilate:    2118 (22%)\n",
-      "Con join_keys:            1009 (10%)\n",
-      "Intake score medio:       26.0\n",
-      "Joinability score medio:    5.1\n"
+      "Item totali:              9840\n",
+      "Candidati intake:         1422 (14%)\n",
+      "Needs review:             7942 (81%)\n",
+      "Reachable:                2923 (30%)\n",
+      "Con colonne profilate:    2172 (22%)\n",
+      "Con join_keys:            1132 (12%)\n",
+      "Intake score medio:       26.5\n",
+      "Joinability score medio:    5.8\n"
      ]
     }
    ],
@@ -427,13 +873,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:51.068025Z",
-     "iopub.status.busy": "2026-06-08T13:28:51.067611Z",
-     "iopub.status.idle": "2026-06-08T13:28:51.081624Z",
-     "shell.execute_reply": "2026-06-08T13:28:51.079069Z"
+     "iopub.execute_input": "2026-06-14T10:33:12.285597Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.285135Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.302998Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.298938Z"
     }
    },
    "outputs": [
@@ -443,24 +889,30 @@
      "text": [
       "════════════════════════════════════════════════════════════\n",
       "  GRANULARITA'\n",
-      "════════════════════════════════════════════════════════════\n",
-      "  non_determinato       6713 (69%)\n",
-      "  regione               1607 (16%)\n",
-      "  comune                 446 (5%)\n",
-      "  provincia              372 (4%)\n",
-      "  nazionale              345 (4%)\n",
-      "  europeo                 99 (1%)\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  non_determinato       6811 (69%)\n",
+      "  regione               1608 (16%)\n",
+      "  provincia              474 (5%)\n",
+      "  comune                 374 (4%)\n",
+      "  nazionale              346 (4%)\n",
+      "  europeo                108 (1%)\n",
       "  mondiale                 2 (0%)\n",
       "\n",
       "  FORMATI\n",
-      "  CSV         4455 (46%)\n",
-      "  SDMX        3584 (37%)\n",
-      "  XLS          640 (7%)\n",
+      "  CSV         4527 (46%)\n",
+      "  SDMX        3584 (36%)\n",
+      "  XLS          700 (7%)\n",
       "  ZIP          437 (4%)\n",
       "               317 (3%)\n",
       "  XML          130 (1%)\n",
       "  JSON          12 (0%)\n",
-      "  PDF            7 (0%)\n"
+      "  XLSX           9 (0%)\n"
      ]
     }
    ],
@@ -489,18 +941,19 @@
     "- Fonti non inventariate → valutare se aggiungere a catalog-watch\n",
     "- Fonti con segnali di drift → verificare\n",
     "- Source_check da completare su fonti a bassa copertura\n",
-    "- Dataset con intake_score alto ma senza join_keys → potenziali falsi negativi"
+    "- Dataset con intake_score alto ma senza join_keys → potenziali falsi negativi\n",
+    "- Fonti con PAQA basso (< 85) → verificare quality check\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T13:28:51.085735Z",
-     "iopub.status.busy": "2026-06-08T13:28:51.085271Z",
-     "iopub.status.idle": "2026-06-08T13:28:51.131665Z",
-     "shell.execute_reply": "2026-06-08T13:28:51.129397Z"
+     "iopub.execute_input": "2026-06-14T10:33:12.308022Z",
+     "iopub.status.busy": "2026-06-14T10:33:12.307587Z",
+     "iopub.status.idle": "2026-06-14T10:33:12.370211Z",
+     "shell.execute_reply": "2026-06-14T10:33:12.367165Z"
     }
    },
    "outputs": [
@@ -512,9 +965,9 @@
       "  COSE DA FARE\n",
       "════════════════════════════════════════════════════════════\n",
       "\n",
-      "📋 Fonti da inventariare: dait, inail_opendata, noipa_sparql, terna_opendata\n",
+      "📋 Fonti da inventariare: dait, inail_opendata, mef_irpef, noipa_sparql, terna_opendata\n",
       "\n",
-      "📋 Fonti con segnali attivi (7):\n",
+      "📋 Fonti con segnali attivi (8):\n",
       "     mim_opendata           csv_magnet           catalog-watch-ready\n",
       "     ispra_linked_data      inventory change     verificare se variazione attesa; avviare inventory-triage se\n",
       "     mef_irpef              csv_magnet           verificare raggiungibilità del portale\n",
@@ -522,23 +975,38 @@
       "     aifa                   csv_magnet           catalog-watch-ready\n",
       "     giustizia_statistiche  csv_magnet           low signal\n",
       "     cortecostituzionale    csv_magnet           catalog-watch-ready\n",
+      "     unioncamere            inventory change     verificare se variazione attesa; avviare inventory-triage se\n",
       "\n",
-      "📋 Fonti con copertura < 50% (8):\n",
+      "📋 Fonti con copertura < 50% (10):\n",
       "     dati_senato            0% (0/98)\n",
-      "     ispra_linked_data      0% (0/67)\n",
+      "     ispra_linked_data      0% (0/69)\n",
       "     agcm                   8% (4/53)\n",
+      "     aci                    11% (4/35)\n",
       "     anac                   19% (13/70)\n",
       "     agid                   20% (8/40)\n",
       "     mimit_rna              23% (85/370)\n",
       "     cortecostituzionale    39% (13/33)\n",
-      "     aifa                   48% (20/42)\n",
+      "     giustizia_statistiche  44% (4/9)\n",
+      "     aifa                   48% (20/42)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
-      "📋 Dataset con intake >= 50 MA senza join_keys (927):\n",
-      "     unioncamere     score=100 Modena - esportazioni per settore provincia di Mod\n",
-      "     unioncamere     score=100 Modena - Demografia delle imprese della provincia \n",
-      "     unioncamere     score=100 Modena - esportazioni mezzi di trasporto provincia\n",
-      "     unioncamere     score=100 Modena - esportazioni settore biomedicale provinci\n",
-      "     unioncamere     score=100 Modena - esportazioni settore agroalimentare provi\n"
+      "📋 Dataset con intake >= 50 MA senza join_keys (859):\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n",
+      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n",
+      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n",
+      "     unioncamere     score=100 Modena - Unita locali attive per settori in provin\n",
+      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n"
      ]
     }
    ],

--- a/notebooks/00_quality_diagnostic.ipynb
+++ b/notebooks/00_quality_diagnostic.ipynb
@@ -4,12 +4,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Diagnostica — Fonti, Cataloghi, Dataset\n",
+    "# Diagnostica \u2014 Fonti, Cataloghi, Dataset\n",
     "\n",
     "Vista unificata dello stato del Source Observatory:\n",
     "- **Fonti**: radar health, quante monitorate vs inventariate\n",
     "- **Cataloghi**: item count, delta, segnali di drift\n",
-    "- **Dataset**: copertura source_check, intake score, reachability, granularità\n",
+    "- **Dataset**: copertura source_check, intake score, reachability, granularit\u00e0\n",
     "- **Copertura**: % inventario processato, gap\n",
     "\n",
     "**Data**: 2026-06-14"
@@ -20,10 +20,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:06.524077Z",
-     "iopub.status.busy": "2026-06-14T10:33:06.523605Z",
-     "iopub.status.idle": "2026-06-14T10:33:11.741989Z",
-     "shell.execute_reply": "2026-06-14T10:33:11.738590Z"
+     "iopub.execute_input": "2026-06-15T11:34:28.086496Z",
+     "iopub.status.busy": "2026-06-15T11:34:28.086101Z",
+     "iopub.status.idle": "2026-06-15T11:34:33.886396Z",
+     "shell.execute_reply": "2026-06-15T11:34:33.882489Z"
     }
    },
    "outputs": [
@@ -32,8 +32,8 @@
      "output_type": "stream",
      "text": [
       "Radar: 32 fonti\n",
-      "Inventory: 14925 rows, 27 fonti\n",
-      "Source-check: 9840 rows, 26 fonti\n",
+      "Inventory: 15075 rows, 28 fonti\n",
+      "Source-check: 10157 rows, 26 fonti\n",
       "Signals: 28 fonti controllate\n"
      ]
     }
@@ -43,19 +43,19 @@
     "\n",
     "from lab_connectors.duckdb import gcs_connect\n",
     "\n",
-    "# ── Path ──\n",
+    "# \u2500\u2500 Path \u2500\u2500\n",
     "RADAR_PATH = \"../data/radar/radar_summary.json\"\n",
     "SIGNALS_PATH = \"../data/catalog/catalog_signals.json\"\n",
     "S3_INV = \"s3://dataciviclab-clean/catalog_inventory/catalog_inventory_latest.parquet\"\n",
     "S3_SCR = \"s3://dataciviclab-clean/catalog_inventory/source-check/source_check_results.parquet\"\n",
     "\n",
-    "# ── Carica dati locali (git) ──\n",
+    "# \u2500\u2500 Carica dati locali (git) \u2500\u2500\n",
     "with open(RADAR_PATH) as f:\n",
     "    radar = json.load(f)\n",
     "with open(SIGNALS_PATH) as f:\n",
     "    signals = json.load(f)\n",
     "\n",
-    "# ── Carica dati da S3 ──\n",
+    "# \u2500\u2500 Carica dati da S3 \u2500\u2500\n",
     "with gcs_connect(S3_INV) as con:\n",
     "    df_inv = con.execute(\"SELECT * FROM read_parquet(?)\", [S3_INV]).fetchdf()\n",
     "with gcs_connect(S3_SCR) as con:\n",
@@ -72,7 +72,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 1. Fonti — Radar Health"
+    "## 1. Fonti \u2014 Radar Health"
    ]
   },
   {
@@ -80,10 +80,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:11.825136Z",
-     "iopub.status.busy": "2026-06-14T10:33:11.824384Z",
-     "iopub.status.idle": "2026-06-14T10:33:11.841403Z",
-     "shell.execute_reply": "2026-06-14T10:33:11.838490Z"
+     "iopub.execute_input": "2026-06-15T11:34:33.981789Z",
+     "iopub.status.busy": "2026-06-15T11:34:33.981013Z",
+     "iopub.status.idle": "2026-06-15T11:34:33.997559Z",
+     "shell.execute_reply": "2026-06-15T11:34:33.994762Z"
     }
    },
    "outputs": [
@@ -91,34 +91,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "  RADAR HEALTH\n",
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "\n",
-      "GREEN:  28\n",
-      "YELLOW: 4\n",
+      "GREEN:  31\n",
+      "YELLOW: 1\n",
       "RED:    0\n",
       "Persistent RED: 0\n",
       "\n",
       "Fonti non VERDI:\n",
-      "  🔴 istat_sdmx                YELLOW   Timeout (ConnectTimeout)\n",
-      "  🔴 openbdap                  YELLOW   Retry timeout/connection: Timeout (ConnectTimeout)\n",
-      "  🔴 consip_open_data          YELLOW   Retry timeout/connection: Timeout (ConnectTimeout)\n",
-      "  🔴 mef_irpef                 YELLOW   Retry timeout/connection: Timeout (ConnectTimeout)\n",
+      "  \ud83d\udd34 istat_sdmx                YELLOW   Timeout (ReadTimeout)\n",
       "\n",
-      "Fonti non inventariate (5):\n",
+      "Fonti non inventariate (4):\n",
       "  dait                      protocol=html      \n",
       "  inail_opendata            protocol=aem       \n",
-      "  mef_irpef                 protocol=html      \n",
       "  noipa_sparql              protocol=sparql    \n",
       "  terna_opendata            protocol=rest      \n"
      ]
     }
    ],
    "source": [
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "print(\"  RADAR HEALTH\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "print(f\"\\nGREEN:  {radar['status_counts'].get('GREEN', 0)}\")\n",
     "print(f\"YELLOW: {radar['status_counts'].get('YELLOW', 0)}\")\n",
     "print(f\"RED:    {radar['status_counts'].get('RED', 0)}\")\n",
@@ -127,7 +123,7 @@
     "print(\"Fonti non VERDI:\")\n",
     "for s in radar[\"sources\"]:\n",
     "    if s[\"status\"] != \"GREEN\":\n",
-    "        print(f\"  🔴 {s['id']:<25s} {s['status']:<8s} {s.get('note', '')[:80]}\")\n",
+    "        print(f\"  \ud83d\udd34 {s['id']:<25s} {s['status']:<8s} {s.get('note', '')[:80]}\")\n",
     "\n",
     "# Fonti radar MA non in inventory\n",
     "radar_ids = {s[\"id\"] for s in radar[\"sources\"]}\n",
@@ -149,7 +145,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 2. Cataloghi — Item count e segnali"
+    "## 2. Cataloghi \u2014 Item count e segnali"
    ]
   },
   {
@@ -157,10 +153,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:11.846167Z",
-     "iopub.status.busy": "2026-06-14T10:33:11.845781Z",
-     "iopub.status.idle": "2026-06-14T10:33:11.871263Z",
-     "shell.execute_reply": "2026-06-14T10:33:11.867551Z"
+     "iopub.execute_input": "2026-06-15T11:34:34.002096Z",
+     "iopub.status.busy": "2026-06-15T11:34:34.001667Z",
+     "iopub.status.idle": "2026-06-15T11:34:34.048867Z",
+     "shell.execute_reply": "2026-06-15T11:34:34.046154Z"
     }
    },
    "outputs": [
@@ -168,11 +164,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
-      "  CATALOGHI — Item per fonte\n",
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "  CATALOGHI \u2014 Item per fonte\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "            source_id protocol  items\n",
-      "           istat_sdmx     sdmx   4871\n",
+      "           istat_sdmx     sdmx   4874\n",
       "             openbdap     ckan   3817\n",
       "                 inps     ckan   2323\n",
       "          opencivitas     html    703\n",
@@ -182,6 +178,7 @@
       "          unioncamere     ckan    371\n",
       "            mimit_rna     ckan    370\n",
       "         dati_cultura   sparql    213\n",
+      "            mef_irpef     html    147\n",
       "          dati_camera   sparql    104\n",
       "          dati_senato   sparql     98\n",
       "      lavoro_opendata     ckan     83\n",
@@ -200,14 +197,14 @@
       "giustizia_statistiche     html      9\n",
       "               pagopa     ckan      8\n",
       "\n",
-      "Totale item inventario: 14925\n"
+      "Totale item inventario: 15075\n"
      ]
     }
    ],
    "source": [
-    "print(\"═\" * 60)\n",
-    "print(\"  CATALOGHI — Item per fonte\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
+    "print(\"  CATALOGHI \u2014 Item per fonte\")\n",
+    "print(\"\u2550\" * 60)\n",
     "\n",
     "src_counts = df_inv.groupby([\"source_id\", \"protocol\"]).size().reset_index(name=\"items\")\n",
     "src_counts = src_counts.sort_values(\"items\", ascending=False)\n",
@@ -221,10 +218,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:11.876049Z",
-     "iopub.status.busy": "2026-06-14T10:33:11.875487Z",
-     "iopub.status.idle": "2026-06-14T10:33:11.885824Z",
-     "shell.execute_reply": "2026-06-14T10:33:11.883187Z"
+     "iopub.execute_input": "2026-06-15T11:34:34.053212Z",
+     "iopub.status.busy": "2026-06-15T11:34:34.052831Z",
+     "iopub.status.idle": "2026-06-15T11:34:34.063786Z",
+     "shell.execute_reply": "2026-06-15T11:34:34.060859Z"
     }
    },
    "outputs": [
@@ -232,48 +229,40 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "  SEGNALI DI DRIFT\n",
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "\n",
       "mim_opendata           csv_magnet          \n",
-      "    1116 link data (CSV 372, JSON 372, XML 372), years 2015-2026 — top prefixes: INFANZIA=192, ALUCORSO=120, SCUANAGR=66, SCUANAAU=66, ALUITAST=60\n",
+      "    1116 link data (CSV 372, JSON 372, XML 372), years 2015-2026 \u2014 top prefixes: INFANZIA=192, ALUCORSO=120, SCUANAGR=66, SCUANAAU=66, ALUITAST=60\n",
       "    azione: catalog-watch-ready\n",
       "\n",
-      "ispra_linked_data      inventory change    \n",
-      "    69 item (sparql_query), delta +2 rispetto al run precedente (67).\n",
-      "    azione: verificare se variazione attesa; avviare inventory-triage se nuovi dataset\n",
-      "\n",
       "mef_irpef              csv_magnet          \n",
-      "    HTTPSConnectionPool(host='www1.finanze.gov.it', port=443): Max retries exceeded with url: /finanze/analisi_stat/public/index.php?opendata=yes (Caused \n",
-      "    azione: verificare raggiungibilità del portale\n",
+      "    147 link data (CSV 81, ZIP 66)\n",
+      "    azione: catalog-watch-ready\n",
       "\n",
       "opencivitas            csv_magnet          \n",
-      "    748 link data (ZIP 748), years 2010-2025 — top prefixes: 2010=90, 2013=72, Metadati=64, 2022=63, 2018=59\n",
+      "    748 link data (ZIP 748), years 2010-2025 \u2014 top prefixes: 2010=90, 2013=72, Metadati=64, 2022=63, 2018=59\n",
       "    azione: catalog-watch-ready\n",
       "\n",
       "aifa                   csv_magnet          \n",
-      "    42 link data (CSV 38, XML 1, ZIP 3), years 2010-2027 — top prefixes: provvedimenti=8, Classe=4, sc=3, elenco=2, Elenco=2\n",
+      "    42 link data (CSV 38, XML 1, ZIP 3), years 2010-2027 \u2014 top prefixes: provvedimenti=8, Classe=4, sc=3, elenco=2, Elenco=2\n",
       "    azione: catalog-watch-ready\n",
       "\n",
       "giustizia_statistiche  csv_magnet          \n",
-      "    9 link data (XLS 9), years 2014-2025 — top prefixes: Indicatori=2, Durata=2, Civile=1, Sorveg=1, Sorveglianza=1\n",
+      "    9 link data (XLS 9), years 2014-2025 \u2014 top prefixes: Indicatori=2, Durata=2, Civile=1, Sorveg=1, Sorveglianza=1\n",
       "    azione: low signal\n",
       "\n",
       "cortecostituzionale    csv_magnet          \n",
       "    33 link data (ZIP 33)\n",
-      "    azione: catalog-watch-ready\n",
-      "\n",
-      "unioncamere            inventory change    \n",
-      "    371 item (package_search), delta +19 rispetto al run precedente (352).\n",
-      "    azione: verificare se variazione attesa; avviare inventory-triage se nuovi dataset\n"
+      "    azione: catalog-watch-ready\n"
      ]
     }
    ],
    "source": [
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "print(\"  SEGNALI DI DRIFT\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "\n",
     "for sig in signals[\"signals\"]:\n",
     "    if sig[\"signal_type\"] != \"no signal\":\n",
@@ -287,7 +276,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 3. Dataset — Source-check coverage"
+    "## 3. Dataset \u2014 Source-check coverage"
    ]
   },
   {
@@ -295,7 +284,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 2b. PAQA — Public Administration Quality Assessment\n",
+    "## 2b. PAQA \u2014 Public Administration Quality Assessment\n",
     "\n",
     "Quality scores strutturali e semantici per ogni CSV profilato.\n",
     "Disponibile da Giugno 2026 (toolkit v1.36.0+).\n"
@@ -306,10 +295,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:11.890118Z",
-     "iopub.status.busy": "2026-06-14T10:33:11.889723Z",
-     "iopub.status.idle": "2026-06-14T10:33:11.915143Z",
-     "shell.execute_reply": "2026-06-14T10:33:11.912259Z"
+     "iopub.execute_input": "2026-06-15T11:34:34.069207Z",
+     "iopub.status.busy": "2026-06-15T11:34:34.068639Z",
+     "iopub.status.idle": "2026-06-15T11:34:34.096242Z",
+     "shell.execute_reply": "2026-06-15T11:34:34.093260Z"
     }
    },
    "outputs": [
@@ -317,32 +306,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "  PANORAMICA PAQA\n",
-      "════════════════════════════════════════════════════════════\n",
-      "Item con PAQA score:   1132  (11.5%)\n",
-      "Item senza PAQA:       8708  (88.5%)\n",
-      "Score medio:           93.2\n",
-      "Score mediano:           94\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "Item con PAQA score:   1112  (10.9%)\n",
+      "Item senza PAQA:       9045  (89.1%)\n",
+      "Score medio:           92.8\n",
+      "Score mediano:           92\n",
       "Dev std:                3.2\n",
       "Min:                     78\n",
       "Max:                     98\n",
       "\n",
       "  VERDETTI\n",
-      "    buona             996  (88.0%)\n",
-      "    scarsa             90  (8.0%)\n",
-      "    accettabile        46  (4.1%)\n",
+      "    buona             974  (87.6%)\n",
+      "    scarsa             90  (8.1%)\n",
+      "    accettabile        48  (4.3%)\n",
       "\n",
-      "  ITEM CON FLAG:      847\n",
-      "  ITEM CON ONTOLOGIE:   890\n",
-      "  SAMPLED:              233\n"
+      "  ITEM CON FLAG:      889\n",
+      "  ITEM CON ONTOLOGIE:   912\n",
+      "  SAMPLED:              248\n"
      ]
     }
    ],
    "source": [
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "print(\"  PANORAMICA PAQA\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "\n",
     "total = len(df_scr)\n",
     "with_paqa = df_scr[\"paqa_score\"].notna().sum()\n",
@@ -372,10 +361,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:11.919768Z",
-     "iopub.status.busy": "2026-06-14T10:33:11.919315Z",
-     "iopub.status.idle": "2026-06-14T10:33:11.967786Z",
-     "shell.execute_reply": "2026-06-14T10:33:11.964731Z"
+     "iopub.execute_input": "2026-06-15T11:34:34.100710Z",
+     "iopub.status.busy": "2026-06-15T11:34:34.100226Z",
+     "iopub.status.idle": "2026-06-15T11:34:34.162088Z",
+     "shell.execute_reply": "2026-06-15T11:34:34.159204Z"
     }
    },
    "outputs": [
@@ -383,26 +372,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "  PAQA PER FONTE\n",
-      "════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "Fonte                   Item   Avg  Med  Min  Max   Std\n",
       "----------------------------------------------------\n",
-      "openga                   200    96   95   90   98   1.5\n",
-      "inps                      41    96   95   90   98   2.1\n",
+      "inps                      43    96   95   90   98   2.1\n",
+      "openga                   159    96   95   90   98   1.5\n",
       "pagopa                     8    95   95   92   98   2.5\n",
       "ministero_salute           2    95   95   95   95   0.0\n",
       "ministero_interno         38    94   95   88   98   3.4\n",
       "aci                        4    94   94   94   94   0.0\n",
-      "unioncamere              353    94   95   78   98   3.3\n",
-      "mit_opendata              32    92   93   80   98   4.8\n",
-      "mim_opendata             371    92   92   81   95   2.5\n",
+      "unioncamere              279    94   95   78   98   3.4\n",
+      "mit_opendata              25    92   92   83   98   4.4\n",
+      "mef_irpef                 79    92   92   88   96   1.7\n",
+      "mim_opendata             392    91   92   81   95   2.9\n",
       "lavoro_opendata           83    90   90   90   90   0.0\n"
      ]
     }
@@ -410,9 +394,9 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "print(\"  PAQA PER FONTE\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "\n",
     "src_paqa = (\n",
     "    df_scr[df_scr[\"paqa_score\"].notna()]\n",
@@ -443,10 +427,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:11.973794Z",
-     "iopub.status.busy": "2026-06-14T10:33:11.973217Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.016571Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.013795Z"
+     "iopub.execute_input": "2026-06-15T11:34:34.167269Z",
+     "iopub.status.busy": "2026-06-15T11:34:34.166238Z",
+     "iopub.status.idle": "2026-06-15T11:34:34.228762Z",
+     "shell.execute_reply": "2026-06-15T11:34:34.225490Z"
     }
    },
    "outputs": [
@@ -454,42 +438,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
-      "  PAQA — FLAG\n",
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "  PAQA \u2014 FLAG\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Flag combo                                               Item      %\n",
       "--------------------------------------------------------------------\n",
-      "  [non_iso_dates                                     ]   378  ( 44.6%)\n",
-      "  [column_naming                                     ]   292  ( 34.5%)\n",
-      "  [inconsistent_columns, column_naming               ]    87  ( 10.3%)\n",
-      "  [column_naming, non_iso_dates                      ]    44  (  5.2%)\n",
-      "  [duplicate_columns, column_naming                  ]    15  (  1.8%)\n",
-      "  [encoding_issues, non_iso_dates                    ]    11  (  1.3%)\n",
-      "  [duplicate_columns, high_missing_rate, column_naming]     4  (  0.5%)\n",
-      "  [high_missing_rate                                 ]     3  (  0.4%)\n",
-      "  [duplicate_columns, column_naming, non_iso_dates   ]     2  (  0.2%)\n",
-      "  [high_missing_rate, column_naming                  ]     2  (  0.2%)\n",
-      "  [encoding_issues                                   ]     2  (  0.2%)\n",
-      "  [inconsistent_columns, non_iso_dates               ]     2  (  0.2%)\n",
+      "  [non_iso_dates                                     ]   390  ( 43.9%)\n",
+      "  [column_naming                                     ]   320  ( 36.0%)\n",
+      "  [inconsistent_columns, column_naming               ]    87  (  9.8%)\n",
+      "  [column_naming, non_iso_dates                      ]    44  (  4.9%)\n",
+      "  [duplicate_columns, column_naming                  ]    16  (  1.8%)\n",
+      "  [encoding_issues, non_iso_dates                    ]    15  (  1.7%)\n",
+      "  [high_missing_rate                                 ]     3  (  0.3%)\n",
+      "  [inconsistent_columns, non_iso_dates               ]     3  (  0.3%)\n",
       "  [encoding_issues, column_naming                    ]     2  (  0.2%)\n",
+      "  [encoding_issues                                   ]     2  (  0.2%)\n",
+      "  [duplicate_columns, high_missing_rate, column_naming]     2  (  0.2%)\n",
+      "  [duplicate_columns, column_naming, non_iso_dates   ]     2  (  0.2%)\n",
       "  [duplicate_columns, high_missing_rate, column_naming, non_iso_dates]     1  (  0.1%)\n",
-      "  [duplicate_columns                                 ]     1  (  0.1%)\n",
-      "  ... e altre 1 combinazioni\n"
+      "  [high_missing_rate, column_naming                  ]     1  (  0.1%)\n",
+      "  [duplicate_columns                                 ]     1  (  0.1%)\n"
      ]
     }
    ],
    "source": [
     "import ast\n",
     "\n",
-    "print(\"═\" * 60)\n",
-    "print(\"  PAQA — FLAG\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
+    "print(\"  PAQA \u2014 FLAG\")\n",
+    "print(\"\u2550\" * 60)\n",
     "\n",
     "flags_series = df_scr[\n",
     "    df_scr[\"paqa_flags\"].notna() & (df_scr[\"paqa_flags\"] != \"[]\") & (df_scr[\"paqa_flags\"] != \"\")\n",
     "]\n",
     "\n",
-    "# Parse e conta flag (ogni riga può avere multipli flag in formato JSON array string)\n",
+    "# Parse e conta flag (ogni riga pu\u00f2 avere multipli flag in formato JSON array string)\n",
     "\n",
     "flag_counter = {}\n",
     "for raw in flags_series[\"paqa_flags\"]:\n",
@@ -515,10 +504,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.020895Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.020464Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.094355Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.091413Z"
+     "iopub.execute_input": "2026-06-15T11:34:34.234105Z",
+     "iopub.status.busy": "2026-06-15T11:34:34.233523Z",
+     "iopub.status.idle": "2026-06-15T11:34:34.305825Z",
+     "shell.execute_reply": "2026-06-15T11:34:34.302776Z"
     }
    },
    "outputs": [
@@ -526,9 +515,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
-      "  PAQA — ONTOLOGIE RILEVATE\n",
-      "════════════════════════════════════════════════════════════\n"
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "  PAQA \u2014 ONTOLOGIE RILEVATE\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n"
      ]
     },
     {
@@ -537,28 +526,28 @@
      "text": [
       "Ontologia/e                                              Item\n",
       "--------------------------------------------------------------\n",
-      "  TI                                                        172\n",
-      "  CPV, TI                                                   167\n",
-      "  ISTAT, TI                                                 121\n",
+      "  TI                                                        195\n",
+      "  CPV, TI                                                   135\n",
+      "  ISTAT, TI                                                 120\n",
       "  CLV, ISTAT, TI                                             80\n",
-      "  CLV, COV, ISTAT, TI                                        67\n",
-      "  CLV, ISTAT                                                 59\n",
-      "  CLV                                                        41\n",
-      "  CPV, QB, TI                                                32\n",
+      "  CLV, COV, ISTAT, TI                                        59\n",
+      "  CLV                                                        58\n",
+      "  CLV, ISTAT                                                 46\n",
+      "  ISTAT                                                      44\n",
+      "  CLV, ISTAT, PC                                             27\n",
       "  QB, TI                                                     23\n",
+      "  CPV, QB, TI                                                22\n",
       "  QB                                                         20\n",
-      "  COV, TI                                                    16\n",
-      "  CLV, ISTAT, QB                                             11\n",
-      "  ... e altre 28 combinazioni\n",
+      "  ... e altre 27 combinazioni\n",
       "\n",
-      "Item con ontologia/e: 890\n"
+      "Item con ontologia/e: 912\n"
      ]
     }
    ],
    "source": [
-    "print(\"═\" * 60)\n",
-    "print(\"  PAQA — ONTOLOGIE RILEVATE\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
+    "print(\"  PAQA \u2014 ONTOLOGIE RILEVATE\")\n",
+    "print(\"\u2550\" * 60)\n",
     "\n",
     "onto_series = df_scr[\n",
     "    df_scr[\"paqa_ontologies\"].notna()\n",
@@ -594,10 +583,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.098723Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.098247Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.167977Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.164251Z"
+     "iopub.execute_input": "2026-06-15T11:34:34.310550Z",
+     "iopub.status.busy": "2026-06-15T11:34:34.310098Z",
+     "iopub.status.idle": "2026-06-15T11:34:34.409773Z",
+     "shell.execute_reply": "2026-06-15T11:34:34.407068Z"
     }
    },
    "outputs": [
@@ -605,17 +594,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "  PAQA vs INTAKE SCORE\n",
-      "════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Correlazione PAQA ↔ Intake: 0.285\n",
-      "(su 1132 item con entrambi gli score)\n"
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "Correlazione PAQA \u2194 Intake: 0.268\n",
+      "(su 1112 item con entrambi gli score)\n"
      ]
     },
     {
@@ -625,29 +608,29 @@
       "\n",
       "  Fascia PAQA      N Avg Intake\n",
       "  ------------------------------\n",
-      "  70-90          188       53.6\n",
-      "  90-100         944       67.4\n",
+      "  70-90          213       53.5\n",
+      "  90-100         899       65.2\n",
       "\n",
       "  Top 5 per intake_score (con PAQA):\n",
-      "    unioncamere     intake=100 paqa=95  Vicenza - Imprese Femminili della provincia, storico iscrizi\n",
-      "    unioncamere     intake=100 paqa=98  Modena - esportazioni settore ceramico provincia di Modena d\n",
-      "    unioncamere     intake=100 paqa=98  Modena - esportazioni mezzi di trasporto provincia di Modena\n",
-      "    unioncamere     intake=100 paqa=98  Modena - esportazioni macchine e apparecchiature meccaniche \n",
-      "    unioncamere     intake=100 paqa=98  Modena - esportazioni settore biomedicale provincia di Moden\n"
+      "    mit_opendata    intake=100 paqa=98  Posti Barca\n",
+      "    mit_opendata    intake=100 paqa=90  Storico interventi previsti dai Contratti di Programma RFI e\n",
+      "    mit_opendata    intake=100 paqa=85  Interventi delle Autorit\u00e0 di Sistema Portuale\n",
+      "    ministero_interno intake=100 paqa=92  Popolazione residente\n",
+      "    mit_opendata    intake=100 paqa=83  Interventi previsti dai Contratti di Programma RFI e ANAS\n"
      ]
     }
    ],
    "source": [
     "import pandas as pd\n",
     "\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "print(\"  PAQA vs INTAKE SCORE\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "\n",
     "both = df_scr[df_scr[\"paqa_score\"].notna() & df_scr[\"intake_score\"].notna()].copy()\n",
     "if len(both) > 0:\n",
     "    corr = both[\"paqa_score\"].corr(both[\"intake_score\"])\n",
-    "    print(f\"Correlazione PAQA ↔ Intake: {corr:.3f}\")\n",
+    "    print(f\"Correlazione PAQA \u2194 Intake: {corr:.3f}\")\n",
     "    print(f\"(su {len(both)} item con entrambi gli score)\")\n",
     "\n",
     "    incrocio = (\n",
@@ -678,10 +661,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.172625Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.172023Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.210480Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.207693Z"
+     "iopub.execute_input": "2026-06-15T11:34:34.414588Z",
+     "iopub.status.busy": "2026-06-15T11:34:34.414139Z",
+     "iopub.status.idle": "2026-06-15T11:34:34.453720Z",
+     "shell.execute_reply": "2026-06-15T11:34:34.450867Z"
     }
    },
    "outputs": [
@@ -689,27 +672,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
-      "  SAMPLED — PREVIEW TRONCA\n",
-      "════════════════════════════════════════════════════════════\n"
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "  SAMPLED \u2014 PREVIEW TRONCA\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sampled (preview tronca, check S6/S12 disabilitati): 233\n",
-      "Full preview:                                         899\n",
-      "Score medio sampled:   91.3\n",
-      "Score medio full:      93.7\n",
-      "Differenza:            +2.4\n"
+      "Sampled (preview tronca, check S6/S12 disabilitati): 248\n",
+      "Full preview:                                         864\n",
+      "Score medio sampled:   90.8\n",
+      "Score medio full:      93.4\n",
+      "Differenza:            +2.6\n"
      ]
     }
    ],
    "source": [
-    "print(\"═\" * 60)\n",
-    "print(\"  SAMPLED — PREVIEW TRONCA\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
+    "print(\"  SAMPLED \u2014 PREVIEW TRONCA\")\n",
+    "print(\"\u2550\" * 60)\n",
     "\n",
     "sampled_true = df_scr[df_scr[\"paqa_sampled\"]]\n",
     "sampled_false = df_scr[~df_scr[\"paqa_sampled\"]]\n",
@@ -729,10 +712,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.214912Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.214506Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.256762Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.254181Z"
+     "iopub.execute_input": "2026-06-15T11:34:34.458115Z",
+     "iopub.status.busy": "2026-06-15T11:34:34.457639Z",
+     "iopub.status.idle": "2026-06-15T11:34:34.500344Z",
+     "shell.execute_reply": "2026-06-15T11:34:34.497857Z"
     }
    },
    "outputs": [
@@ -740,27 +723,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "  COPERTURA SOURCE-CHECK\n",
-      "════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "Fonte                   Inventory   Scored  Coperto\n",
       "--------------------------------------------------\n",
-      "istat_sdmx                   4871     3584    73.6%\n",
-      "openbdap                     3817     1918    50.2%\n",
+      "istat_sdmx                   4874     3833    78.6%\n",
+      "openbdap                     3817     1927    50.5%\n",
       "inps                         2323     1427    61.4%\n",
       "opencivitas                   703      384    54.6%\n",
       "opencoesione                  561      518    92.3%\n",
       "openga                        436      364    83.5%\n",
-      "mim_opendata                  372      407   109.4%\n",
+      "mim_opendata                  372      427   114.8%\n",
       "unioncamere                   371      371   100.0%\n",
       "mimit_rna                     370       85    23.0%\n",
       "dati_cultura                  213      213   100.0%\n",
+      "mef_irpef                     147      119    81.0%\n",
       "dati_camera                   104      104   100.0%\n",
       "dati_senato                    98        0     0.0%\n",
       "lavoro_opendata                83       83   100.0%\n",
@@ -778,18 +756,17 @@
       "consip_open_data               16       10    62.5%\n",
       "giustizia_statistiche           9        4    44.4%\n",
       "pagopa                          8        8   100.0%\n",
-      "mef_irpef                       0       80  8000.0%\n",
       "\n",
-      "Totale inventory: 14925\n",
-      "Totale scored:    9839\n",
-      "Copertura media:  65.9%\n"
+      "Totale inventory: 15075\n",
+      "Totale scored:    10156\n",
+      "Copertura media:  67.4%\n"
      ]
     }
    ],
    "source": [
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "print(\"  COPERTURA SOURCE-CHECK\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "\n",
     "# Merge inventory + source_check\n",
     "inv_count = df_inv.groupby(\"source_id\").size().reset_index(name=\"inventory_items\")\n",
@@ -819,10 +796,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.263049Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.262405Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.281164Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.278403Z"
+     "iopub.execute_input": "2026-06-15T11:34:34.505741Z",
+     "iopub.status.busy": "2026-06-15T11:34:34.505310Z",
+     "iopub.status.idle": "2026-06-15T11:34:34.524636Z",
+     "shell.execute_reply": "2026-06-15T11:34:34.521956Z"
     }
    },
    "outputs": [
@@ -830,24 +807,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "  QUALITA' DATASET\n",
-      "════════════════════════════════════════════════════════════\n",
-      "Item totali:              9840\n",
-      "Candidati intake:         1422 (14%)\n",
-      "Needs review:             7942 (81%)\n",
-      "Reachable:                2923 (30%)\n",
-      "Con colonne profilate:    2172 (22%)\n",
-      "Con join_keys:            1132 (12%)\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "Item totali:             10157\n",
+      "Candidati intake:         1437 (14%)\n",
+      "Needs review:             8247 (81%)\n",
+      "Reachable:                2863 (28%)\n",
+      "Con colonne profilate:    2142 (21%)\n",
+      "Con join_keys:            1275 (13%)\n",
       "Intake score medio:       26.5\n",
-      "Joinability score medio:    5.8\n"
+      "Joinability score medio:    5.2\n"
      ]
     }
    ],
    "source": [
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "print(\"  QUALITA' DATASET\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "\n",
     "total = len(df_scr)\n",
     "print(f\"Item totali:            {total:>6}\")\n",
@@ -876,10 +853,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.285597Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.285135Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.302998Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.298938Z"
+     "iopub.execute_input": "2026-06-15T11:34:34.528751Z",
+     "iopub.status.busy": "2026-06-15T11:34:34.528378Z",
+     "iopub.status.idle": "2026-06-15T11:34:34.542595Z",
+     "shell.execute_reply": "2026-06-15T11:34:34.539771Z"
     }
    },
    "outputs": [
@@ -887,39 +864,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "  GRANULARITA'\n",
-      "════════════════════════════════════════════════════════════\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  non_determinato       6811 (69%)\n",
-      "  regione               1608 (16%)\n",
-      "  provincia              474 (5%)\n",
-      "  comune                 374 (4%)\n",
-      "  nazionale              346 (4%)\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "  non_determinato       7030 (69%)\n",
+      "  regione               1664 (16%)\n",
+      "  provincia              492 (5%)\n",
+      "  comune                 392 (4%)\n",
+      "  nazionale              352 (3%)\n",
       "  europeo                108 (1%)\n",
       "  mondiale                 2 (0%)\n",
       "\n",
       "  FORMATI\n",
-      "  CSV         4527 (46%)\n",
-      "  SDMX        3584 (36%)\n",
-      "  XLS          700 (7%)\n",
+      "  CSV         5162 (51%)\n",
+      "  SDMX        3268 (32%)\n",
+      "  XLS          699 (7%)\n",
       "  ZIP          437 (4%)\n",
       "               317 (3%)\n",
       "  XML          130 (1%)\n",
       "  JSON          12 (0%)\n",
-      "  XLSX           9 (0%)\n"
+      "  XLSX           8 (0%)\n"
      ]
     }
    ],
    "source": [
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "print(\"  GRANULARITA'\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "gran = df_scr[\"granularity\"].value_counts()\n",
     "for g, c in gran.items():\n",
     "    print(f\"  {g:<20s} {c:>5} ({c / total * 100:.0f}%)\")\n",
@@ -938,11 +909,11 @@
     "## 4. Sintesi\n",
     "\n",
     "Cose da fare:\n",
-    "- Fonti non inventariate → valutare se aggiungere a catalog-watch\n",
-    "- Fonti con segnali di drift → verificare\n",
+    "- Fonti non inventariate \u2192 valutare se aggiungere a catalog-watch\n",
+    "- Fonti con segnali di drift \u2192 verificare\n",
     "- Source_check da completare su fonti a bassa copertura\n",
-    "- Dataset con intake_score alto ma senza join_keys → potenziali falsi negativi\n",
-    "- Fonti con PAQA basso (< 85) → verificare quality check\n"
+    "- Dataset con intake_score alto ma senza join_keys \u2192 potenziali falsi negativi\n",
+    "- Fonti con PAQA basso (< 85) \u2192 verificare quality check\n"
    ]
   },
   {
@@ -950,10 +921,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-14T10:33:12.308022Z",
-     "iopub.status.busy": "2026-06-14T10:33:12.307587Z",
-     "iopub.status.idle": "2026-06-14T10:33:12.370211Z",
-     "shell.execute_reply": "2026-06-14T10:33:12.367165Z"
+     "iopub.execute_input": "2026-06-15T11:34:34.546639Z",
+     "iopub.status.busy": "2026-06-15T11:34:34.546197Z",
+     "iopub.status.idle": "2026-06-15T11:34:34.595784Z",
+     "shell.execute_reply": "2026-06-15T11:34:34.593055Z"
     }
    },
    "outputs": [
@@ -961,23 +932,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "  COSE DA FARE\n",
-      "════════════════════════════════════════════════════════════\n",
+      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
       "\n",
-      "📋 Fonti da inventariare: dait, inail_opendata, mef_irpef, noipa_sparql, terna_opendata\n",
+      "\ud83d\udccb Fonti da inventariare: dait, inail_opendata, noipa_sparql, terna_opendata\n",
       "\n",
-      "📋 Fonti con segnali attivi (8):\n",
+      "\ud83d\udccb Fonti con segnali attivi (6):\n",
       "     mim_opendata           csv_magnet           catalog-watch-ready\n",
-      "     ispra_linked_data      inventory change     verificare se variazione attesa; avviare inventory-triage se\n",
-      "     mef_irpef              csv_magnet           verificare raggiungibilità del portale\n",
+      "     mef_irpef              csv_magnet           catalog-watch-ready\n",
       "     opencivitas            csv_magnet           catalog-watch-ready\n",
       "     aifa                   csv_magnet           catalog-watch-ready\n",
       "     giustizia_statistiche  csv_magnet           low signal\n",
       "     cortecostituzionale    csv_magnet           catalog-watch-ready\n",
-      "     unioncamere            inventory change     verificare se variazione attesa; avviare inventory-triage se\n",
       "\n",
-      "📋 Fonti con copertura < 50% (10):\n",
+      "\ud83d\udccb Fonti con copertura < 50% (10):\n",
       "     dati_senato            0% (0/98)\n",
       "     ispra_linked_data      0% (0/69)\n",
       "     agcm                   8% (4/53)\n",
@@ -987,42 +956,30 @@
       "     mimit_rna              23% (85/370)\n",
       "     cortecostituzionale    39% (13/33)\n",
       "     giustizia_statistiche  44% (4/9)\n",
-      "     aifa                   48% (20/42)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "     aifa                   48% (20/42)\n",
       "\n",
-      "📋 Dataset con intake >= 50 MA senza join_keys (859):\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n",
-      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n",
-      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n",
-      "     unioncamere     score=100 Modena - Unita locali attive per settori in provin\n",
-      "     unioncamere     score=100 Modena - Movimentazione e consistenza delle impres\n"
+      "\ud83d\udccb Dataset con intake >= 50 MA senza join_keys (884):\n",
+      "     unioncamere     score=100 Modena - Focus settore Terziario delle imprese nel\n",
+      "     unioncamere     score=100 Modena - Focus settore Grandi Settori delle impres\n",
+      "     unioncamere     score=100 Modena - esportazioni totali della provincia di Mo\n",
+      "     unioncamere     score=100 Modena - Demografia delle imprese della provincia \n",
+      "     unioncamere     score=100 Modena - esportazioni settore agroalimentare provi\n"
      ]
     }
    ],
    "source": [
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "print(\"  COSE DA FARE\")\n",
-    "print(\"═\" * 60)\n",
+    "print(\"\u2550\" * 60)\n",
     "\n",
     "# 1. Fonti non inventariate\n",
     "if not_inventoried:\n",
-    "    print(f\"\\n📋 Fonti da inventariare: {', '.join(sorted(not_inventoried))}\")\n",
+    "    print(f\"\\n\ud83d\udccb Fonti da inventariare: {', '.join(sorted(not_inventoried))}\")\n",
     "\n",
     "# 2. Fonti con segnali\n",
     "signals_active = [s for s in signals[\"signals\"] if s[\"signal_type\"] != \"no signal\"]\n",
     "if signals_active:\n",
-    "    print(f\"\\n📋 Fonti con segnali attivi ({len(signals_active)}):\")\n",
+    "    print(f\"\\n\ud83d\udccb Fonti con segnali attivi ({len(signals_active)}):\")\n",
     "    for s in signals_active:\n",
     "        print(\n",
     "            f\"     {s['source']:<22s} {s['signal_type']:<20s} {s.get('suggested_action', '')[:60]}\"\n",
@@ -1031,7 +988,7 @@
     "# 3. Fonti con bassa copertura source-check\n",
     "low_cov = coverage[coverage[\"pct\"] < 50].sort_values(\"pct\")\n",
     "if not low_cov.empty:\n",
-    "    print(f\"\\n📋 Fonti con copertura < 50% ({len(low_cov)}):\")\n",
+    "    print(f\"\\n\ud83d\udccb Fonti con copertura < 50% ({len(low_cov)}):\")\n",
     "    for _, r in low_cov.iterrows():\n",
     "        print(\n",
     "            f\"     {r['source_id']:<22s} {r['pct']:.0f}% ({r['scored_items']:.0f}/{r['inventory_items']:.0f})\"\n",
@@ -1040,7 +997,7 @@
     "# 4. Intake alto senza join_keys\n",
     "high_intake_no_keys = df_scr[(df_scr[\"intake_score\"] >= 50) & (df_scr[\"join_keys\"].isna())].copy()\n",
     "if len(high_intake_no_keys) > 0:\n",
-    "    print(f\"\\n📋 Dataset con intake >= 50 MA senza join_keys ({len(high_intake_no_keys)}):\")\n",
+    "    print(f\"\\n\ud83d\udccb Dataset con intake >= 50 MA senza join_keys ({len(high_intake_no_keys)}):\")\n",
     "    top = high_intake_no_keys.sort_values(\"intake_score\", ascending=False).head(5)\n",
     "    for _, r in top.iterrows():\n",
     "        print(\n",
@@ -1057,7 +1014,7 @@
     "\n",
     "- I dati radar e signals vengono dal repository git (ultimo commit).\n",
     "- I dati inventory e source_check vengono da S3 (ultimo run CI).\n",
-    "- La diagnostica non modifica nulla — è una vista sola."
+    "- La diagnostica non modifica nulla \u2014 \u00e8 una vista sola."
    ]
   }
  ],

--- a/notebooks/00_quality_diagnostic.ipynb
+++ b/notebooks/00_quality_diagnostic.ipynb
@@ -4,15 +4,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Diagnostica \u2014 Fonti, Cataloghi, Dataset\n",
+    "# Diagnostica — Fonti, Cataloghi, Dataset\n",
     "\n",
     "Vista unificata dello stato del Source Observatory:\n",
     "- **Fonti**: radar health, quante monitorate vs inventariate\n",
     "- **Cataloghi**: item count, delta, segnali di drift\n",
-    "- **Dataset**: copertura source_check, intake score, reachability, granularit\u00e0\n",
-    "- **Copertura**: % inventario processato, gap\n",
+    "- **Dataset**: copertura source_check, intake score, reachability, granularità\n",
+    "- **PAQA**: quality score strutturali e semantici per CSV profilati\n",
     "\n",
-    "**Data**: 2026-06-14"
+    "**Data**: 2026-06-15\n"
    ]
   },
   {
@@ -20,10 +20,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:28.086496Z",
-     "iopub.status.busy": "2026-06-15T11:34:28.086101Z",
-     "iopub.status.idle": "2026-06-15T11:34:33.886396Z",
-     "shell.execute_reply": "2026-06-15T11:34:33.882489Z"
+     "iopub.execute_input": "2026-06-15T16:53:00.624523Z",
+     "iopub.status.busy": "2026-06-15T16:53:00.624085Z",
+     "iopub.status.idle": "2026-06-15T16:53:07.865484Z",
+     "shell.execute_reply": "2026-06-15T16:53:07.863119Z"
     }
    },
    "outputs": [
@@ -43,19 +43,19 @@
     "\n",
     "from lab_connectors.duckdb import gcs_connect\n",
     "\n",
-    "# \u2500\u2500 Path \u2500\u2500\n",
+    "# ── Path ──\n",
     "RADAR_PATH = \"../data/radar/radar_summary.json\"\n",
     "SIGNALS_PATH = \"../data/catalog/catalog_signals.json\"\n",
     "S3_INV = \"s3://dataciviclab-clean/catalog_inventory/catalog_inventory_latest.parquet\"\n",
     "S3_SCR = \"s3://dataciviclab-clean/catalog_inventory/source-check/source_check_results.parquet\"\n",
     "\n",
-    "# \u2500\u2500 Carica dati locali (git) \u2500\u2500\n",
+    "# ── Carica dati locali (git) ──\n",
     "with open(RADAR_PATH) as f:\n",
     "    radar = json.load(f)\n",
     "with open(SIGNALS_PATH) as f:\n",
     "    signals = json.load(f)\n",
     "\n",
-    "# \u2500\u2500 Carica dati da S3 \u2500\u2500\n",
+    "# ── Carica dati da S3 ──\n",
     "with gcs_connect(S3_INV) as con:\n",
     "    df_inv = con.execute(\"SELECT * FROM read_parquet(?)\", [S3_INV]).fetchdf()\n",
     "with gcs_connect(S3_SCR) as con:\n",
@@ -72,7 +72,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 1. Fonti \u2014 Radar Health"
+    "## 1. Radar Health"
    ]
   },
   {
@@ -80,10 +80,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:33.981789Z",
-     "iopub.status.busy": "2026-06-15T11:34:33.981013Z",
-     "iopub.status.idle": "2026-06-15T11:34:33.997559Z",
-     "shell.execute_reply": "2026-06-15T11:34:33.994762Z"
+     "iopub.execute_input": "2026-06-15T16:53:07.936848Z",
+     "iopub.status.busy": "2026-06-15T16:53:07.936230Z",
+     "iopub.status.idle": "2026-06-15T16:53:07.950920Z",
+     "shell.execute_reply": "2026-06-15T16:53:07.948800Z"
     }
    },
    "outputs": [
@@ -91,9 +91,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
       "  RADAR HEALTH\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
       "\n",
       "GREEN:  31\n",
       "YELLOW: 1\n",
@@ -101,7 +101,7 @@
       "Persistent RED: 0\n",
       "\n",
       "Fonti non VERDI:\n",
-      "  \ud83d\udd34 istat_sdmx                YELLOW   Timeout (ReadTimeout)\n",
+      "  🔴 istat_sdmx                YELLOW   Timeout (ReadTimeout)\n",
       "\n",
       "Fonti non inventariate (4):\n",
       "  dait                      protocol=html      \n",
@@ -112,9 +112,9 @@
     }
    ],
    "source": [
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
     "print(\"  RADAR HEALTH\")\n",
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
     "print(f\"\\nGREEN:  {radar['status_counts'].get('GREEN', 0)}\")\n",
     "print(f\"YELLOW: {radar['status_counts'].get('YELLOW', 0)}\")\n",
     "print(f\"RED:    {radar['status_counts'].get('RED', 0)}\")\n",
@@ -123,7 +123,7 @@
     "print(\"Fonti non VERDI:\")\n",
     "for s in radar[\"sources\"]:\n",
     "    if s[\"status\"] != \"GREEN\":\n",
-    "        print(f\"  \ud83d\udd34 {s['id']:<25s} {s['status']:<8s} {s.get('note', '')[:80]}\")\n",
+    "        print(f\"  🔴 {s['id']:<25s} {s['status']:<8s} {s.get('note', '')[:80]}\")\n",
     "\n",
     "# Fonti radar MA non in inventory\n",
     "radar_ids = {s[\"id\"] for s in radar[\"sources\"]}\n",
@@ -145,7 +145,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 2. Cataloghi \u2014 Item count e segnali"
+    "## 2. Cataloghi — Item count e segnali"
    ]
   },
   {
@@ -153,10 +153,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:34.002096Z",
-     "iopub.status.busy": "2026-06-15T11:34:34.001667Z",
-     "iopub.status.idle": "2026-06-15T11:34:34.048867Z",
-     "shell.execute_reply": "2026-06-15T11:34:34.046154Z"
+     "iopub.execute_input": "2026-06-15T16:53:07.954578Z",
+     "iopub.status.busy": "2026-06-15T16:53:07.954220Z",
+     "iopub.status.idle": "2026-06-15T16:53:07.974248Z",
+     "shell.execute_reply": "2026-06-15T16:53:07.971600Z"
     }
    },
    "outputs": [
@@ -164,9 +164,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
-      "  CATALOGHI \u2014 Item per fonte\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
+      "  CATALOGHI — Item per fonte\n",
+      "════════════════════════════════════════════════════════════\n",
       "            source_id protocol  items\n",
       "           istat_sdmx     sdmx   4874\n",
       "             openbdap     ckan   3817\n",
@@ -202,9 +202,9 @@
     }
    ],
    "source": [
-    "print(\"\u2550\" * 60)\n",
-    "print(\"  CATALOGHI \u2014 Item per fonte\")\n",
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
+    "print(\"  CATALOGHI — Item per fonte\")\n",
+    "print(\"═\" * 60)\n",
     "\n",
     "src_counts = df_inv.groupby([\"source_id\", \"protocol\"]).size().reset_index(name=\"items\")\n",
     "src_counts = src_counts.sort_values(\"items\", ascending=False)\n",
@@ -218,10 +218,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:34.053212Z",
-     "iopub.status.busy": "2026-06-15T11:34:34.052831Z",
-     "iopub.status.idle": "2026-06-15T11:34:34.063786Z",
-     "shell.execute_reply": "2026-06-15T11:34:34.060859Z"
+     "iopub.execute_input": "2026-06-15T16:53:07.978590Z",
+     "iopub.status.busy": "2026-06-15T16:53:07.978210Z",
+     "iopub.status.idle": "2026-06-15T16:53:07.986328Z",
+     "shell.execute_reply": "2026-06-15T16:53:07.984425Z"
     }
    },
    "outputs": [
@@ -229,12 +229,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
       "  SEGNALI DI DRIFT\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
       "\n",
       "mim_opendata           csv_magnet          \n",
-      "    1116 link data (CSV 372, JSON 372, XML 372), years 2015-2026 \u2014 top prefixes: INFANZIA=192, ALUCORSO=120, SCUANAGR=66, SCUANAAU=66, ALUITAST=60\n",
+      "    1116 link data (CSV 372, JSON 372, XML 372), years 2015-2026 — top prefixes: INFANZIA=192, ALUCORSO=120, SCUANAGR=66, SCUANAAU=66, ALUITAST=60\n",
       "    azione: catalog-watch-ready\n",
       "\n",
       "mef_irpef              csv_magnet          \n",
@@ -242,15 +242,15 @@
       "    azione: catalog-watch-ready\n",
       "\n",
       "opencivitas            csv_magnet          \n",
-      "    748 link data (ZIP 748), years 2010-2025 \u2014 top prefixes: 2010=90, 2013=72, Metadati=64, 2022=63, 2018=59\n",
+      "    748 link data (ZIP 748), years 2010-2025 — top prefixes: 2010=90, 2013=72, Metadati=64, 2022=63, 2018=59\n",
       "    azione: catalog-watch-ready\n",
       "\n",
       "aifa                   csv_magnet          \n",
-      "    42 link data (CSV 38, XML 1, ZIP 3), years 2010-2027 \u2014 top prefixes: provvedimenti=8, Classe=4, sc=3, elenco=2, Elenco=2\n",
+      "    42 link data (CSV 38, XML 1, ZIP 3), years 2010-2027 — top prefixes: provvedimenti=8, Classe=4, sc=3, elenco=2, Elenco=2\n",
       "    azione: catalog-watch-ready\n",
       "\n",
       "giustizia_statistiche  csv_magnet          \n",
-      "    9 link data (XLS 9), years 2014-2025 \u2014 top prefixes: Indicatori=2, Durata=2, Civile=1, Sorveg=1, Sorveglianza=1\n",
+      "    9 link data (XLS 9), years 2014-2025 — top prefixes: Indicatori=2, Durata=2, Civile=1, Sorveg=1, Sorveglianza=1\n",
       "    azione: low signal\n",
       "\n",
       "cortecostituzionale    csv_magnet          \n",
@@ -260,9 +260,9 @@
     }
    ],
    "source": [
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
     "print(\"  SEGNALI DI DRIFT\")\n",
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
     "\n",
     "for sig in signals[\"signals\"]:\n",
     "    if sig[\"signal_type\"] != \"no signal\":\n",
@@ -276,18 +276,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 3. Dataset \u2014 Source-check coverage"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 2b. PAQA \u2014 Public Administration Quality Assessment\n",
-    "\n",
-    "Quality scores strutturali e semantici per ogni CSV profilato.\n",
-    "Disponibile da Giugno 2026 (toolkit v1.36.0+).\n"
+    "## 3. Source-check coverage"
    ]
   },
   {
@@ -295,10 +284,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:34.069207Z",
-     "iopub.status.busy": "2026-06-15T11:34:34.068639Z",
-     "iopub.status.idle": "2026-06-15T11:34:34.096242Z",
-     "shell.execute_reply": "2026-06-15T11:34:34.093260Z"
+     "iopub.execute_input": "2026-06-15T16:53:07.991041Z",
+     "iopub.status.busy": "2026-06-15T16:53:07.990656Z",
+     "iopub.status.idle": "2026-06-15T16:53:08.025798Z",
+     "shell.execute_reply": "2026-06-15T16:53:08.023420Z"
     }
    },
    "outputs": [
@@ -306,426 +295,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
-      "  PANORAMICA PAQA\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
-      "Item con PAQA score:   1112  (10.9%)\n",
-      "Item senza PAQA:       9045  (89.1%)\n",
-      "Score medio:           92.8\n",
-      "Score mediano:           92\n",
-      "Dev std:                3.2\n",
-      "Min:                     78\n",
-      "Max:                     98\n",
-      "\n",
-      "  VERDETTI\n",
-      "    buona             974  (87.6%)\n",
-      "    scarsa             90  (8.1%)\n",
-      "    accettabile        48  (4.3%)\n",
-      "\n",
-      "  ITEM CON FLAG:      889\n",
-      "  ITEM CON ONTOLOGIE:   912\n",
-      "  SAMPLED:              248\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"\u2550\" * 60)\n",
-    "print(\"  PANORAMICA PAQA\")\n",
-    "print(\"\u2550\" * 60)\n",
-    "\n",
-    "total = len(df_scr)\n",
-    "with_paqa = df_scr[\"paqa_score\"].notna().sum()\n",
-    "without_paqa = total - with_paqa\n",
-    "print(f\"Item con PAQA score:  {with_paqa:>5}  ({with_paqa / total * 100:.1f}%)\")\n",
-    "print(f\"Item senza PAQA:      {without_paqa:>5}  ({without_paqa / total * 100:.1f}%)\")\n",
-    "\n",
-    "if with_paqa > 0:\n",
-    "    print(f\"Score medio:          {df_scr['paqa_score'].mean():>5.1f}\")\n",
-    "    print(f\"Score mediano:        {df_scr['paqa_score'].median():>5.0f}\")\n",
-    "    print(f\"Dev std:              {df_scr['paqa_score'].std():>5.1f}\")\n",
-    "    print(f\"Min:                  {df_scr['paqa_score'].min():>5.0f}\")\n",
-    "    print(f\"Max:                  {df_scr['paqa_score'].max():>5.0f}\")\n",
-    "\n",
-    "    print(\"\\n  VERDETTI\")\n",
-    "    verdicts = df_scr[\"paqa_verdict\"].value_counts()\n",
-    "    for v, c in verdicts.items():\n",
-    "        print(f\"    {str(v):<15s} {c:>5}  ({c / with_paqa * 100:.1f}%)\")\n",
-    "\n",
-    "    print(f\"\\n  ITEM CON FLAG:    {df_scr['paqa_flags'].notna().sum():>5}\")\n",
-    "    print(f\"  ITEM CON ONTOLOGIE: {df_scr['paqa_ontologies'].notna().sum():>5}\")\n",
-    "    print(f\"  SAMPLED:            {df_scr['paqa_sampled'].sum():>5}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:34.100710Z",
-     "iopub.status.busy": "2026-06-15T11:34:34.100226Z",
-     "iopub.status.idle": "2026-06-15T11:34:34.162088Z",
-     "shell.execute_reply": "2026-06-15T11:34:34.159204Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
-      "  PAQA PER FONTE\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
-      "Fonte                   Item   Avg  Med  Min  Max   Std\n",
-      "----------------------------------------------------\n",
-      "inps                      43    96   95   90   98   2.1\n",
-      "openga                   159    96   95   90   98   1.5\n",
-      "pagopa                     8    95   95   92   98   2.5\n",
-      "ministero_salute           2    95   95   95   95   0.0\n",
-      "ministero_interno         38    94   95   88   98   3.4\n",
-      "aci                        4    94   94   94   94   0.0\n",
-      "unioncamere              279    94   95   78   98   3.4\n",
-      "mit_opendata              25    92   92   83   98   4.4\n",
-      "mef_irpef                 79    92   92   88   96   1.7\n",
-      "mim_opendata             392    91   92   81   95   2.9\n",
-      "lavoro_opendata           83    90   90   90   90   0.0\n"
-     ]
-    }
-   ],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "print(\"\u2550\" * 60)\n",
-    "print(\"  PAQA PER FONTE\")\n",
-    "print(\"\u2550\" * 60)\n",
-    "\n",
-    "src_paqa = (\n",
-    "    df_scr[df_scr[\"paqa_score\"].notna()]\n",
-    "    .groupby(\"source_id\")\n",
-    "    .agg(\n",
-    "        items=(\"paqa_score\", \"count\"),\n",
-    "        avg_score=(\"paqa_score\", \"mean\"),\n",
-    "        med_score=(\"paqa_score\", \"median\"),\n",
-    "        min_score=(\"paqa_score\", \"min\"),\n",
-    "        max_score=(\"paqa_score\", \"max\"),\n",
-    "        std_score=(\"paqa_score\", \"std\"),\n",
-    "    )\n",
-    "    .reset_index()\n",
-    ")\n",
-    "src_paqa = src_paqa.sort_values(\"avg_score\", ascending=False)\n",
-    "\n",
-    "print(f\"{'Fonte':22s} {'Item':>5s} {'Avg':>5s} {'Med':>4s} {'Min':>4s} {'Max':>4s} {'Std':>5s}\")\n",
-    "print(\"-\" * 52)\n",
-    "for _, r in src_paqa.iterrows():\n",
-    "    std_str = f\"{r['std_score']:.1f}\" if pd.notna(r[\"std_score\"]) else \"N/A\"\n",
-    "    print(\n",
-    "        f\"{r['source_id']:22s} {r['items']:5.0f} {r['avg_score']:5.0f} {r['med_score']:4.0f} {r['min_score']:4.0f} {r['max_score']:4.0f} {std_str:>5s}\"\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:34.167269Z",
-     "iopub.status.busy": "2026-06-15T11:34:34.166238Z",
-     "iopub.status.idle": "2026-06-15T11:34:34.228762Z",
-     "shell.execute_reply": "2026-06-15T11:34:34.225490Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
-      "  PAQA \u2014 FLAG\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Flag combo                                               Item      %\n",
-      "--------------------------------------------------------------------\n",
-      "  [non_iso_dates                                     ]   390  ( 43.9%)\n",
-      "  [column_naming                                     ]   320  ( 36.0%)\n",
-      "  [inconsistent_columns, column_naming               ]    87  (  9.8%)\n",
-      "  [column_naming, non_iso_dates                      ]    44  (  4.9%)\n",
-      "  [duplicate_columns, column_naming                  ]    16  (  1.8%)\n",
-      "  [encoding_issues, non_iso_dates                    ]    15  (  1.7%)\n",
-      "  [high_missing_rate                                 ]     3  (  0.3%)\n",
-      "  [inconsistent_columns, non_iso_dates               ]     3  (  0.3%)\n",
-      "  [encoding_issues, column_naming                    ]     2  (  0.2%)\n",
-      "  [encoding_issues                                   ]     2  (  0.2%)\n",
-      "  [duplicate_columns, high_missing_rate, column_naming]     2  (  0.2%)\n",
-      "  [duplicate_columns, column_naming, non_iso_dates   ]     2  (  0.2%)\n",
-      "  [duplicate_columns, high_missing_rate, column_naming, non_iso_dates]     1  (  0.1%)\n",
-      "  [high_missing_rate, column_naming                  ]     1  (  0.1%)\n",
-      "  [duplicate_columns                                 ]     1  (  0.1%)\n"
-     ]
-    }
-   ],
-   "source": [
-    "import ast\n",
-    "\n",
-    "print(\"\u2550\" * 60)\n",
-    "print(\"  PAQA \u2014 FLAG\")\n",
-    "print(\"\u2550\" * 60)\n",
-    "\n",
-    "flags_series = df_scr[\n",
-    "    df_scr[\"paqa_flags\"].notna() & (df_scr[\"paqa_flags\"] != \"[]\") & (df_scr[\"paqa_flags\"] != \"\")\n",
-    "]\n",
-    "\n",
-    "# Parse e conta flag (ogni riga pu\u00f2 avere multipli flag in formato JSON array string)\n",
-    "\n",
-    "flag_counter = {}\n",
-    "for raw in flags_series[\"paqa_flags\"]:\n",
-    "    try:\n",
-    "        flags = ast.literal_eval(raw) if isinstance(raw, str) else raw\n",
-    "    except Exception:\n",
-    "        flags = []\n",
-    "    key = \", \".join(flags) if flags else \"empty\"\n",
-    "    flag_counter[key] = flag_counter.get(key, 0) + 1\n",
-    "\n",
-    "sorted_flags = sorted(flag_counter.items(), key=lambda x: -x[1])\n",
-    "print(f\"{'Flag combo':55s} {'Item':>5s} {'%':>6s}\")\n",
-    "print(\"-\" * 68)\n",
-    "for combo, cnt in sorted_flags[:15]:\n",
-    "    print(f\"  [{combo:50s}] {cnt:5d}  ({cnt / flags_series.shape[0] * 100:5.1f}%)\")\n",
-    "\n",
-    "if len(sorted_flags) > 15:\n",
-    "    print(f\"  ... e altre {len(sorted_flags) - 15} combinazioni\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:34.234105Z",
-     "iopub.status.busy": "2026-06-15T11:34:34.233523Z",
-     "iopub.status.idle": "2026-06-15T11:34:34.305825Z",
-     "shell.execute_reply": "2026-06-15T11:34:34.302776Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
-      "  PAQA \u2014 ONTOLOGIE RILEVATE\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ontologia/e                                              Item\n",
-      "--------------------------------------------------------------\n",
-      "  TI                                                        195\n",
-      "  CPV, TI                                                   135\n",
-      "  ISTAT, TI                                                 120\n",
-      "  CLV, ISTAT, TI                                             80\n",
-      "  CLV, COV, ISTAT, TI                                        59\n",
-      "  CLV                                                        58\n",
-      "  CLV, ISTAT                                                 46\n",
-      "  ISTAT                                                      44\n",
-      "  CLV, ISTAT, PC                                             27\n",
-      "  QB, TI                                                     23\n",
-      "  CPV, QB, TI                                                22\n",
-      "  QB                                                         20\n",
-      "  ... e altre 27 combinazioni\n",
-      "\n",
-      "Item con ontologia/e: 912\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"\u2550\" * 60)\n",
-    "print(\"  PAQA \u2014 ONTOLOGIE RILEVATE\")\n",
-    "print(\"\u2550\" * 60)\n",
-    "\n",
-    "onto_series = df_scr[\n",
-    "    df_scr[\"paqa_ontologies\"].notna()\n",
-    "    & (df_scr[\"paqa_ontologies\"] != \"{}\")\n",
-    "    & (df_scr[\"paqa_ontologies\"] != \"\")\n",
-    "]\n",
-    "\n",
-    "onto_counter = {}\n",
-    "for raw in onto_series[\"paqa_ontologies\"]:\n",
-    "    try:\n",
-    "        onto = ast.literal_eval(raw) if isinstance(raw, str) else raw\n",
-    "    except Exception:\n",
-    "        onto = {}\n",
-    "    # Extract ontology codes\n",
-    "    codes = sorted(onto.keys()) if onto else [\"empty\"]\n",
-    "    key = \", \".join(codes)\n",
-    "    onto_counter[key] = onto_counter.get(key, 0) + 1\n",
-    "\n",
-    "sorted_onto = sorted(onto_counter.items(), key=lambda x: -x[1])\n",
-    "print(f\"{'Ontologia/e':55s} {'Item':>5s}\")\n",
-    "print(\"-\" * 62)\n",
-    "for combo, cnt in sorted_onto[:12]:\n",
-    "    print(f\"  {combo:55s} {cnt:5d}\")\n",
-    "\n",
-    "if len(sorted_onto) > 12:\n",
-    "    print(f\"  ... e altre {len(sorted_onto) - 12} combinazioni\")\n",
-    "\n",
-    "print(f\"\\nItem con ontologia/e: {onto_series.shape[0]}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:34.310550Z",
-     "iopub.status.busy": "2026-06-15T11:34:34.310098Z",
-     "iopub.status.idle": "2026-06-15T11:34:34.409773Z",
-     "shell.execute_reply": "2026-06-15T11:34:34.407068Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
-      "  PAQA vs INTAKE SCORE\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
-      "Correlazione PAQA \u2194 Intake: 0.268\n",
-      "(su 1112 item con entrambi gli score)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "  Fascia PAQA      N Avg Intake\n",
-      "  ------------------------------\n",
-      "  70-90          213       53.5\n",
-      "  90-100         899       65.2\n",
-      "\n",
-      "  Top 5 per intake_score (con PAQA):\n",
-      "    mit_opendata    intake=100 paqa=98  Posti Barca\n",
-      "    mit_opendata    intake=100 paqa=90  Storico interventi previsti dai Contratti di Programma RFI e\n",
-      "    mit_opendata    intake=100 paqa=85  Interventi delle Autorit\u00e0 di Sistema Portuale\n",
-      "    ministero_interno intake=100 paqa=92  Popolazione residente\n",
-      "    mit_opendata    intake=100 paqa=83  Interventi previsti dai Contratti di Programma RFI e ANAS\n"
-     ]
-    }
-   ],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "print(\"\u2550\" * 60)\n",
-    "print(\"  PAQA vs INTAKE SCORE\")\n",
-    "print(\"\u2550\" * 60)\n",
-    "\n",
-    "both = df_scr[df_scr[\"paqa_score\"].notna() & df_scr[\"intake_score\"].notna()].copy()\n",
-    "if len(both) > 0:\n",
-    "    corr = both[\"paqa_score\"].corr(both[\"intake_score\"])\n",
-    "    print(f\"Correlazione PAQA \u2194 Intake: {corr:.3f}\")\n",
-    "    print(f\"(su {len(both)} item con entrambi gli score)\")\n",
-    "\n",
-    "    incrocio = (\n",
-    "        both.groupby(\n",
-    "            pd.cut(both[\"paqa_score\"], bins=[0, 70, 90, 100], labels=[\"<70\", \"70-90\", \"90-100\"])\n",
-    "        )\n",
-    "        .agg(n=(\"intake_score\", \"count\"), avg_intake=(\"intake_score\", \"mean\"))\n",
-    "        .reset_index()\n",
-    "    )\n",
-    "    print(f\"\\n  {'Fascia PAQA':12s} {'N':>5s} {'Avg Intake':>10s}\")\n",
-    "    print(\"  \" + \"-\" * 30)\n",
-    "    for _, r in incrocio.iterrows():\n",
-    "        print(f\"  {str(r['paqa_score']):12s} {r['n']:5.0f} {r['avg_intake']:10.1f}\")\n",
-    "\n",
-    "    # Top item: alto PAQA + alto intake\n",
-    "    top = both.nlargest(5, \"intake_score\")[[\"source_id\", \"title\", \"intake_score\", \"paqa_score\"]]\n",
-    "    print(\"\\n  Top 5 per intake_score (con PAQA):\")\n",
-    "    for _, r in top.iterrows():\n",
-    "        print(\n",
-    "            f\"    {r['source_id']:<15s} intake={r['intake_score']:.0f} paqa={r['paqa_score']:.0f}  {str(r.get('title', ''))[:60]}\"\n",
-    "        )\n",
-    "else:\n",
-    "    print(\"Nessun item con entrambi gli score disponibile\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:34.414588Z",
-     "iopub.status.busy": "2026-06-15T11:34:34.414139Z",
-     "iopub.status.idle": "2026-06-15T11:34:34.453720Z",
-     "shell.execute_reply": "2026-06-15T11:34:34.450867Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
-      "  SAMPLED \u2014 PREVIEW TRONCA\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sampled (preview tronca, check S6/S12 disabilitati): 248\n",
-      "Full preview:                                         864\n",
-      "Score medio sampled:   90.8\n",
-      "Score medio full:      93.4\n",
-      "Differenza:            +2.6\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"\u2550\" * 60)\n",
-    "print(\"  SAMPLED \u2014 PREVIEW TRONCA\")\n",
-    "print(\"\u2550\" * 60)\n",
-    "\n",
-    "sampled_true = df_scr[df_scr[\"paqa_sampled\"]]\n",
-    "sampled_false = df_scr[~df_scr[\"paqa_sampled\"]]\n",
-    "print(f\"Sampled (preview tronca, check S6/S12 disabilitati): {len(sampled_true)}\")\n",
-    "print(f\"Full preview:                                         {len(sampled_false)}\")\n",
-    "\n",
-    "if len(sampled_true) > 0 and len(sampled_false) > 0:\n",
-    "    score_sampled = sampled_true[\"paqa_score\"].mean()\n",
-    "    score_full = sampled_false[\"paqa_score\"].mean()\n",
-    "    print(f\"Score medio sampled:   {score_sampled:.1f}\")\n",
-    "    print(f\"Score medio full:      {score_full:.1f}\")\n",
-    "    print(f\"Differenza:            {score_full - score_sampled:+.1f}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:34.458115Z",
-     "iopub.status.busy": "2026-06-15T11:34:34.457639Z",
-     "iopub.status.idle": "2026-06-15T11:34:34.500344Z",
-     "shell.execute_reply": "2026-06-15T11:34:34.497857Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
       "  COPERTURA SOURCE-CHECK\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
       "Fonte                   Inventory   Scored  Coperto\n",
       "--------------------------------------------------\n",
       "istat_sdmx                   4874     3833    78.6%\n",
@@ -764,9 +336,9 @@
     }
    ],
    "source": [
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
     "print(\"  COPERTURA SOURCE-CHECK\")\n",
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
     "\n",
     "# Merge inventory + source_check\n",
     "inv_count = df_inv.groupby(\"source_id\").size().reset_index(name=\"inventory_items\")\n",
@@ -793,13 +365,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:34.505741Z",
-     "iopub.status.busy": "2026-06-15T11:34:34.505310Z",
-     "iopub.status.idle": "2026-06-15T11:34:34.524636Z",
-     "shell.execute_reply": "2026-06-15T11:34:34.521956Z"
+     "iopub.execute_input": "2026-06-15T16:53:08.030305Z",
+     "iopub.status.busy": "2026-06-15T16:53:08.029951Z",
+     "iopub.status.idle": "2026-06-15T16:53:08.046258Z",
+     "shell.execute_reply": "2026-06-15T16:53:08.044056Z"
     }
    },
    "outputs": [
@@ -807,9 +379,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
       "  QUALITA' DATASET\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
       "Item totali:             10157\n",
       "Candidati intake:         1437 (14%)\n",
       "Needs review:             8247 (81%)\n",
@@ -822,9 +394,9 @@
     }
    ],
    "source": [
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
     "print(\"  QUALITA' DATASET\")\n",
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
     "\n",
     "total = len(df_scr)\n",
     "print(f\"Item totali:            {total:>6}\")\n",
@@ -850,13 +422,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:34.528751Z",
-     "iopub.status.busy": "2026-06-15T11:34:34.528378Z",
-     "iopub.status.idle": "2026-06-15T11:34:34.542595Z",
-     "shell.execute_reply": "2026-06-15T11:34:34.539771Z"
+     "iopub.execute_input": "2026-06-15T16:53:08.049854Z",
+     "iopub.status.busy": "2026-06-15T16:53:08.049478Z",
+     "iopub.status.idle": "2026-06-15T16:53:08.062713Z",
+     "shell.execute_reply": "2026-06-15T16:53:08.060698Z"
     }
    },
    "outputs": [
@@ -864,9 +436,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
       "  GRANULARITA'\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
       "  non_determinato       7030 (69%)\n",
       "  regione               1664 (16%)\n",
       "  provincia              492 (5%)\n",
@@ -888,9 +460,9 @@
     }
    ],
    "source": [
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
     "print(\"  GRANULARITA'\")\n",
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
     "gran = df_scr[\"granularity\"].value_counts()\n",
     "for g, c in gran.items():\n",
     "    print(f\"  {g:<20s} {c:>5} ({c / total * 100:.0f}%)\")\n",
@@ -906,25 +478,30 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 4. Sintesi\n",
+    "## 4. PAQA — Quality Scores\n",
     "\n",
-    "Cose da fare:\n",
-    "- Fonti non inventariate \u2192 valutare se aggiungere a catalog-watch\n",
-    "- Fonti con segnali di drift \u2192 verificare\n",
-    "- Source_check da completare su fonti a bassa copertura\n",
-    "- Dataset con intake_score alto ma senza join_keys \u2192 potenziali falsi negativi\n",
-    "- Fonti con PAQA basso (< 85) \u2192 verificare quality check\n"
+    "Valutazione strutturale e semantica dei CSV profilati dal source-check.\n",
+    "Score calcolati dal toolkit v1.36.0+ su encoding, colonne, date, e matching ontologico.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4a. Panoramica\n",
+    "\n",
+    "Copertura PAQA, score medi e distribuzione verdetti."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T11:34:34.546639Z",
-     "iopub.status.busy": "2026-06-15T11:34:34.546197Z",
-     "iopub.status.idle": "2026-06-15T11:34:34.595784Z",
-     "shell.execute_reply": "2026-06-15T11:34:34.593055Z"
+     "iopub.execute_input": "2026-06-15T16:53:08.066512Z",
+     "iopub.status.busy": "2026-06-15T16:53:08.066128Z",
+     "iopub.status.idle": "2026-06-15T16:53:08.084584Z",
+     "shell.execute_reply": "2026-06-15T16:53:08.082297Z"
     }
    },
    "outputs": [
@@ -932,13 +509,491 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
+      "  PANORAMICA PAQA\n",
+      "════════════════════════════════════════════════════════════\n",
+      "Item con PAQA score:   1112  (10.9%)\n",
+      "Item senza PAQA:       9045  (89.1%)\n",
+      "Score medio:           92.8\n",
+      "Score mediano:           92\n",
+      "Dev std:                3.2\n",
+      "Min:                     78\n",
+      "Max:                     98\n",
+      "\n",
+      "  VERDETTI\n",
+      "    buona             974  (87.6%)\n",
+      "    scarsa             90  (8.1%)\n",
+      "    accettabile        48  (4.3%)\n",
+      "\n",
+      "  ITEM CON FLAG:      889\n",
+      "  ITEM CON ONTOLOGIE:   912\n",
+      "  SAMPLED:              248\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  PANORAMICA PAQA\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "total = len(df_scr)\n",
+    "with_paqa = df_scr[\"paqa_score\"].notna().sum()\n",
+    "without_paqa = total - with_paqa\n",
+    "print(f\"Item con PAQA score:  {with_paqa:>5}  ({with_paqa / total * 100:.1f}%)\")\n",
+    "print(f\"Item senza PAQA:      {without_paqa:>5}  ({without_paqa / total * 100:.1f}%)\")\n",
+    "\n",
+    "if with_paqa > 0:\n",
+    "    print(f\"Score medio:          {df_scr['paqa_score'].mean():>5.1f}\")\n",
+    "    print(f\"Score mediano:        {df_scr['paqa_score'].median():>5.0f}\")\n",
+    "    print(f\"Dev std:              {df_scr['paqa_score'].std():>5.1f}\")\n",
+    "    print(f\"Min:                  {df_scr['paqa_score'].min():>5.0f}\")\n",
+    "    print(f\"Max:                  {df_scr['paqa_score'].max():>5.0f}\")\n",
+    "\n",
+    "    print(\"\\n  VERDETTI\")\n",
+    "    verdicts = df_scr[\"paqa_verdict\"].value_counts()\n",
+    "    for v, c in verdicts.items():\n",
+    "        print(f\"    {str(v):<15s} {c:>5}  ({c / with_paqa * 100:.1f}%)\")\n",
+    "\n",
+    "    print(f\"\\n  ITEM CON FLAG:    {df_scr['paqa_flags'].notna().sum():>5}\")\n",
+    "    print(f\"  ITEM CON ONTOLOGIE: {df_scr['paqa_ontologies'].notna().sum():>5}\")\n",
+    "    print(f\"  SAMPLED:            {df_scr['paqa_sampled'].sum():>5}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4b. Per fonte\n",
+    "\n",
+    "Score PAQA medi per fonte, ordinati per qualità decrescente."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T16:53:08.088615Z",
+     "iopub.status.busy": "2026-06-15T16:53:08.088121Z",
+     "iopub.status.idle": "2026-06-15T16:53:08.131940Z",
+     "shell.execute_reply": "2026-06-15T16:53:08.129682Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PAQA PER FONTE\n",
+      "════════════════════════════════════════════════════════════\n",
+      "Fonte                   Item   Avg  Med  Min  Max   Std\n",
+      "----------------------------------------------------\n",
+      "inps                      43    96   95   90   98   2.1\n",
+      "openga                   159    96   95   90   98   1.5\n",
+      "pagopa                     8    95   95   92   98   2.5\n",
+      "ministero_salute           2    95   95   95   95   0.0\n",
+      "ministero_interno         38    94   95   88   98   3.4\n",
+      "aci                        4    94   94   94   94   0.0\n",
+      "unioncamere              279    94   95   78   98   3.4\n",
+      "mit_opendata              25    92   92   83   98   4.4\n",
+      "mef_irpef                 79    92   92   88   96   1.7\n",
+      "mim_opendata             392    91   92   81   95   2.9\n",
+      "lavoro_opendata           83    90   90   90   90   0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "print(\"═\" * 60)\n",
+    "print(\"  PAQA PER FONTE\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "src_paqa = (\n",
+    "    df_scr[df_scr[\"paqa_score\"].notna()]\n",
+    "    .groupby(\"source_id\")\n",
+    "    .agg(\n",
+    "        items=(\"paqa_score\", \"count\"),\n",
+    "        avg_score=(\"paqa_score\", \"mean\"),\n",
+    "        med_score=(\"paqa_score\", \"median\"),\n",
+    "        min_score=(\"paqa_score\", \"min\"),\n",
+    "        max_score=(\"paqa_score\", \"max\"),\n",
+    "        std_score=(\"paqa_score\", \"std\"),\n",
+    "    )\n",
+    "    .reset_index()\n",
+    ")\n",
+    "src_paqa = src_paqa.sort_values(\"avg_score\", ascending=False)\n",
+    "\n",
+    "print(f\"{'Fonte':22s} {'Item':>5s} {'Avg':>5s} {'Med':>4s} {'Min':>4s} {'Max':>4s} {'Std':>5s}\")\n",
+    "print(\"-\" * 52)\n",
+    "for _, r in src_paqa.iterrows():\n",
+    "    std_str = f\"{r['std_score']:.1f}\" if pd.notna(r[\"std_score\"]) else \"N/A\"\n",
+    "    print(\n",
+    "        f\"{r['source_id']:22s} {r['items']:5.0f} {r['avg_score']:5.0f} {r['med_score']:4.0f} {r['min_score']:4.0f} {r['max_score']:4.0f} {std_str:>5s}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4c. Flag\n",
+    "\n",
+    "Combinazioni di flag PAQA più frequenti (non_iso_dates, column_naming, ecc.)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T16:53:08.135741Z",
+     "iopub.status.busy": "2026-06-15T16:53:08.135371Z",
+     "iopub.status.idle": "2026-06-15T16:53:08.183263Z",
+     "shell.execute_reply": "2026-06-15T16:53:08.181006Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PAQA — FLAG\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Flag combo                                               Item      %\n",
+      "--------------------------------------------------------------------\n",
+      "  [non_iso_dates                                     ]   390  ( 43.9%)\n",
+      "  [column_naming                                     ]   320  ( 36.0%)\n",
+      "  [inconsistent_columns, column_naming               ]    87  (  9.8%)\n",
+      "  [column_naming, non_iso_dates                      ]    44  (  4.9%)\n",
+      "  [duplicate_columns, column_naming                  ]    16  (  1.8%)\n",
+      "  [encoding_issues, non_iso_dates                    ]    15  (  1.7%)\n",
+      "  [high_missing_rate                                 ]     3  (  0.3%)\n",
+      "  [inconsistent_columns, non_iso_dates               ]     3  (  0.3%)\n",
+      "  [encoding_issues, column_naming                    ]     2  (  0.2%)\n",
+      "  [encoding_issues                                   ]     2  (  0.2%)\n",
+      "  [duplicate_columns, high_missing_rate, column_naming]     2  (  0.2%)\n",
+      "  [duplicate_columns, column_naming, non_iso_dates   ]     2  (  0.2%)\n",
+      "  [duplicate_columns, high_missing_rate, column_naming, non_iso_dates]     1  (  0.1%)\n",
+      "  [high_missing_rate, column_naming                  ]     1  (  0.1%)\n",
+      "  [duplicate_columns                                 ]     1  (  0.1%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ast\n",
+    "\n",
+    "print(\"═\" * 60)\n",
+    "print(\"  PAQA — FLAG\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "flags_series = df_scr[\n",
+    "    df_scr[\"paqa_flags\"].notna() & (df_scr[\"paqa_flags\"] != \"[]\") & (df_scr[\"paqa_flags\"] != \"\")\n",
+    "]\n",
+    "\n",
+    "# Parse e conta flag (ogni riga può avere multipli flag in formato JSON array string)\n",
+    "\n",
+    "flag_counter = {}\n",
+    "for raw in flags_series[\"paqa_flags\"]:\n",
+    "    try:\n",
+    "        flags = ast.literal_eval(raw) if isinstance(raw, str) else raw\n",
+    "    except Exception:\n",
+    "        flags = []\n",
+    "    key = \", \".join(flags) if flags else \"empty\"\n",
+    "    flag_counter[key] = flag_counter.get(key, 0) + 1\n",
+    "\n",
+    "sorted_flags = sorted(flag_counter.items(), key=lambda x: -x[1])\n",
+    "print(f\"{'Flag combo':55s} {'Item':>5s} {'%':>6s}\")\n",
+    "print(\"-\" * 68)\n",
+    "for combo, cnt in sorted_flags[:15]:\n",
+    "    print(f\"  [{combo:50s}] {cnt:5d}  ({cnt / flags_series.shape[0] * 100:5.1f}%)\")\n",
+    "\n",
+    "if len(sorted_flags) > 15:\n",
+    "    print(f\"  ... e altre {len(sorted_flags) - 15} combinazioni\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4d. Ontologie\n",
+    "\n",
+    "Ontologie riconosciute dal column matching (TI, CPV, ISTAT, CLV, COV, QB, PC)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T16:53:08.187344Z",
+     "iopub.status.busy": "2026-06-15T16:53:08.186973Z",
+     "iopub.status.idle": "2026-06-15T16:53:08.241608Z",
+     "shell.execute_reply": "2026-06-15T16:53:08.239178Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PAQA — ONTOLOGIE RILEVATE\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ontologia/e                                              Item\n",
+      "--------------------------------------------------------------\n",
+      "  TI                                                        195\n",
+      "  CPV, TI                                                   135\n",
+      "  ISTAT, TI                                                 120\n",
+      "  CLV, ISTAT, TI                                             80\n",
+      "  CLV, COV, ISTAT, TI                                        59\n",
+      "  CLV                                                        58\n",
+      "  CLV, ISTAT                                                 46\n",
+      "  ISTAT                                                      44\n",
+      "  CLV, ISTAT, PC                                             27\n",
+      "  QB, TI                                                     23\n",
+      "  CPV, QB, TI                                                22\n",
+      "  QB                                                         20\n",
+      "  ... e altre 27 combinazioni\n",
+      "\n",
+      "Item con ontologia/e: 912\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  PAQA — ONTOLOGIE RILEVATE\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "onto_series = df_scr[\n",
+    "    df_scr[\"paqa_ontologies\"].notna()\n",
+    "    & (df_scr[\"paqa_ontologies\"] != \"{}\")\n",
+    "    & (df_scr[\"paqa_ontologies\"] != \"\")\n",
+    "]\n",
+    "\n",
+    "onto_counter = {}\n",
+    "for raw in onto_series[\"paqa_ontologies\"]:\n",
+    "    try:\n",
+    "        onto = ast.literal_eval(raw) if isinstance(raw, str) else raw\n",
+    "    except Exception:\n",
+    "        onto = {}\n",
+    "    # Extract ontology codes\n",
+    "    codes = sorted(onto.keys()) if onto else [\"empty\"]\n",
+    "    key = \", \".join(codes)\n",
+    "    onto_counter[key] = onto_counter.get(key, 0) + 1\n",
+    "\n",
+    "sorted_onto = sorted(onto_counter.items(), key=lambda x: -x[1])\n",
+    "print(f\"{'Ontologia/e':55s} {'Item':>5s}\")\n",
+    "print(\"-\" * 62)\n",
+    "for combo, cnt in sorted_onto[:12]:\n",
+    "    print(f\"  {combo:55s} {cnt:5d}\")\n",
+    "\n",
+    "if len(sorted_onto) > 12:\n",
+    "    print(f\"  ... e altre {len(sorted_onto) - 12} combinazioni\")\n",
+    "\n",
+    "print(f\"\\nItem con ontologia/e: {onto_series.shape[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4e. PAQA vs Intake score\n",
+    "\n",
+    "Correlazione tra qualità strutturale (PAQA) e valore per il Lab (Intake score)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T16:53:08.245195Z",
+     "iopub.status.busy": "2026-06-15T16:53:08.244816Z",
+     "iopub.status.idle": "2026-06-15T16:53:08.309910Z",
+     "shell.execute_reply": "2026-06-15T16:53:08.307603Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  PAQA vs INTAKE SCORE\n",
+      "════════════════════════════════════════════════════════════\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correlazione PAQA ↔ Intake: 0.268\n",
+      "(su 1112 item con entrambi gli score)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fascia PAQA      N Avg Intake\n",
+      "  ------------------------------\n",
+      "  70-90          213       53.5\n",
+      "  90-100         899       65.2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Top 5 per intake_score (con PAQA):\n",
+      "    mit_opendata    intake=100 paqa=98  Posti Barca\n",
+      "    mit_opendata    intake=100 paqa=90  Storico interventi previsti dai Contratti di Programma RFI e\n",
+      "    mit_opendata    intake=100 paqa=85  Interventi delle Autorità di Sistema Portuale\n",
+      "    ministero_interno intake=100 paqa=92  Popolazione residente\n",
+      "    mit_opendata    intake=100 paqa=83  Interventi previsti dai Contratti di Programma RFI e ANAS\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "print(\"═\" * 60)\n",
+    "print(\"  PAQA vs INTAKE SCORE\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "both = df_scr[df_scr[\"paqa_score\"].notna() & df_scr[\"intake_score\"].notna()].copy()\n",
+    "if len(both) > 0:\n",
+    "    corr = both[\"paqa_score\"].corr(both[\"intake_score\"])\n",
+    "    print(f\"Correlazione PAQA ↔ Intake: {corr:.3f}\")\n",
+    "    print(f\"(su {len(both)} item con entrambi gli score)\")\n",
+    "\n",
+    "    incrocio = (\n",
+    "        both.groupby(\n",
+    "            pd.cut(both[\"paqa_score\"], bins=[0, 70, 90, 100], labels=[\"<70\", \"70-90\", \"90-100\"])\n",
+    "        )\n",
+    "        .agg(n=(\"intake_score\", \"count\"), avg_intake=(\"intake_score\", \"mean\"))\n",
+    "        .reset_index()\n",
+    "    )\n",
+    "    print(f\"\\n  {'Fascia PAQA':12s} {'N':>5s} {'Avg Intake':>10s}\")\n",
+    "    print(\"  \" + \"-\" * 30)\n",
+    "    for _, r in incrocio.iterrows():\n",
+    "        print(f\"  {str(r['paqa_score']):12s} {r['n']:5.0f} {r['avg_intake']:10.1f}\")\n",
+    "\n",
+    "    # Top item: alto PAQA + alto intake\n",
+    "    top = both.nlargest(5, \"intake_score\")[[\"source_id\", \"title\", \"intake_score\", \"paqa_score\"]]\n",
+    "    print(\"\\n  Top 5 per intake_score (con PAQA):\")\n",
+    "    for _, r in top.iterrows():\n",
+    "        print(\n",
+    "            f\"    {r['source_id']:<15s} intake={r['intake_score']:.0f} paqa={r['paqa_score']:.0f}  {str(r.get('title', ''))[:60]}\"\n",
+    "        )\n",
+    "else:\n",
+    "    print(\"Nessun item con entrambi gli score disponibile\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4f. Sampled impact\n",
+    "\n",
+    "Differenza di score tra item con preview completa e items con preview tronca (sampled)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T16:53:08.313864Z",
+     "iopub.status.busy": "2026-06-15T16:53:08.313486Z",
+     "iopub.status.idle": "2026-06-15T16:53:08.343373Z",
+     "shell.execute_reply": "2026-06-15T16:53:08.341570Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
+      "  SAMPLED — PREVIEW TRONCA\n",
+      "════════════════════════════════════════════════════════════\n",
+      "Sampled (preview tronca, check S6/S12 disabilitati): 248\n",
+      "Full preview:                                         864\n",
+      "Score medio sampled:   90.8\n",
+      "Score medio full:      93.4\n",
+      "Differenza:            +2.6\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"═\" * 60)\n",
+    "print(\"  SAMPLED — PREVIEW TRONCA\")\n",
+    "print(\"═\" * 60)\n",
+    "\n",
+    "sampled_true = df_scr[df_scr[\"paqa_sampled\"]]\n",
+    "sampled_false = df_scr[~df_scr[\"paqa_sampled\"]]\n",
+    "print(f\"Sampled (preview tronca, check S6/S12 disabilitati): {len(sampled_true)}\")\n",
+    "print(f\"Full preview:                                         {len(sampled_false)}\")\n",
+    "\n",
+    "if len(sampled_true) > 0 and len(sampled_false) > 0:\n",
+    "    score_sampled = sampled_true[\"paqa_score\"].mean()\n",
+    "    score_full = sampled_false[\"paqa_score\"].mean()\n",
+    "    print(f\"Score medio sampled:   {score_sampled:.1f}\")\n",
+    "    print(f\"Score medio full:      {score_full:.1f}\")\n",
+    "    print(f\"Differenza:            {score_full - score_sampled:+.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 5. Cose da fare\n",
+    "\n",
+    "Azioni generate automaticamente dai dati raccolti."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T16:53:08.348302Z",
+     "iopub.status.busy": "2026-06-15T16:53:08.347901Z",
+     "iopub.status.idle": "2026-06-15T16:53:08.395672Z",
+     "shell.execute_reply": "2026-06-15T16:53:08.393009Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "════════════════════════════════════════════════════════════\n",
       "  COSE DA FARE\n",
-      "\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\n",
+      "════════════════════════════════════════════════════════════\n",
       "\n",
-      "\ud83d\udccb Fonti da inventariare: dait, inail_opendata, noipa_sparql, terna_opendata\n",
+      "📋 Fonti da inventariare: dait, inail_opendata, noipa_sparql, terna_opendata\n",
       "\n",
-      "\ud83d\udccb Fonti con segnali attivi (6):\n",
+      "📋 Fonti con segnali attivi (6):\n",
       "     mim_opendata           csv_magnet           catalog-watch-ready\n",
       "     mef_irpef              csv_magnet           catalog-watch-ready\n",
       "     opencivitas            csv_magnet           catalog-watch-ready\n",
@@ -946,7 +1001,7 @@
       "     giustizia_statistiche  csv_magnet           low signal\n",
       "     cortecostituzionale    csv_magnet           catalog-watch-ready\n",
       "\n",
-      "\ud83d\udccb Fonti con copertura < 50% (10):\n",
+      "📋 Fonti con copertura < 50% (10):\n",
       "     dati_senato            0% (0/98)\n",
       "     ispra_linked_data      0% (0/69)\n",
       "     agcm                   8% (4/53)\n",
@@ -958,7 +1013,13 @@
       "     giustizia_statistiche  44% (4/9)\n",
       "     aifa                   48% (20/42)\n",
       "\n",
-      "\ud83d\udccb Dataset con intake >= 50 MA senza join_keys (884):\n",
+      "📋 Dataset con intake >= 50 MA senza join_keys (884):\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "     unioncamere     score=100 Modena - Focus settore Terziario delle imprese nel\n",
       "     unioncamere     score=100 Modena - Focus settore Grandi Settori delle impres\n",
       "     unioncamere     score=100 Modena - esportazioni totali della provincia di Mo\n",
@@ -968,18 +1029,18 @@
     }
    ],
    "source": [
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
     "print(\"  COSE DA FARE\")\n",
-    "print(\"\u2550\" * 60)\n",
+    "print(\"═\" * 60)\n",
     "\n",
     "# 1. Fonti non inventariate\n",
     "if not_inventoried:\n",
-    "    print(f\"\\n\ud83d\udccb Fonti da inventariare: {', '.join(sorted(not_inventoried))}\")\n",
+    "    print(f\"\\n📋 Fonti da inventariare: {', '.join(sorted(not_inventoried))}\")\n",
     "\n",
     "# 2. Fonti con segnali\n",
     "signals_active = [s for s in signals[\"signals\"] if s[\"signal_type\"] != \"no signal\"]\n",
     "if signals_active:\n",
-    "    print(f\"\\n\ud83d\udccb Fonti con segnali attivi ({len(signals_active)}):\")\n",
+    "    print(f\"\\n📋 Fonti con segnali attivi ({len(signals_active)}):\")\n",
     "    for s in signals_active:\n",
     "        print(\n",
     "            f\"     {s['source']:<22s} {s['signal_type']:<20s} {s.get('suggested_action', '')[:60]}\"\n",
@@ -988,7 +1049,7 @@
     "# 3. Fonti con bassa copertura source-check\n",
     "low_cov = coverage[coverage[\"pct\"] < 50].sort_values(\"pct\")\n",
     "if not low_cov.empty:\n",
-    "    print(f\"\\n\ud83d\udccb Fonti con copertura < 50% ({len(low_cov)}):\")\n",
+    "    print(f\"\\n📋 Fonti con copertura < 50% ({len(low_cov)}):\")\n",
     "    for _, r in low_cov.iterrows():\n",
     "        print(\n",
     "            f\"     {r['source_id']:<22s} {r['pct']:.0f}% ({r['scored_items']:.0f}/{r['inventory_items']:.0f})\"\n",
@@ -997,24 +1058,12 @@
     "# 4. Intake alto senza join_keys\n",
     "high_intake_no_keys = df_scr[(df_scr[\"intake_score\"] >= 50) & (df_scr[\"join_keys\"].isna())].copy()\n",
     "if len(high_intake_no_keys) > 0:\n",
-    "    print(f\"\\n\ud83d\udccb Dataset con intake >= 50 MA senza join_keys ({len(high_intake_no_keys)}):\")\n",
+    "    print(f\"\\n📋 Dataset con intake >= 50 MA senza join_keys ({len(high_intake_no_keys)}):\")\n",
     "    top = high_intake_no_keys.sort_values(\"intake_score\", ascending=False).head(5)\n",
     "    for _, r in top.iterrows():\n",
     "        print(\n",
     "            f\"     {r['source_id']:<15s} score={r['intake_score']:.0f} {str(r.get('title', ''))[:50]}\"\n",
     "        )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 5. Note\n",
-    "\n",
-    "- I dati radar e signals vengono dal repository git (ultimo commit).\n",
-    "- I dati inventory e source_check vengono da S3 (ultimo run CI).\n",
-    "- La diagnostica non modifica nulla \u2014 \u00e8 una vista sola."
    ]
   }
  ],


### PR DESCRIPTION
Notebook `00_quality_diagnostic.ipynb` aggiornato con 7 nuove celle PAQA:

- Panoramica PAQA (copertura, score, verdetti)
- PAQA per fonte
- Flag breakdown
- Ontologie rilevate
- PAQA vs intake score
- Sampled impact

**Data**: aggiornata a 2026-06-14  
**Notebook**: eseguito con dati CI run #27494449757

Separato da PR #357 (fix operativo) per chiarezza di review.