### PR TITLE
fix: proxy HTTPS_PROXY per fonti bloccate (GHA → VM Oracle Frankfurt)

### DIFF
--- a/.github/workflows/observatory.yml
+++ b/.github/workflows/observatory.yml
@@ -65,6 +65,8 @@ jobs:
             data/catalog_inventory/generated/catalog_inventory_latest.parquet || echo "No inventory snapshot yet"
 
       - name: Build catalog inventory
+        env:
+          HTTPS_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
         run: |
           python scripts/build_catalog_inventory.py \
             --out-dir data/catalog_inventory/generated \
@@ -135,6 +137,8 @@ jobs:
             echo "No previous results — starting fresh"
 
       - name: Run bulk source-check
+        env:
+          HTTPS_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
         run: |
           python scripts/bulk_source_check.py \
             --skip-red-sources \

--- a/.github/workflows/radar.yml
+++ b/.github/workflows/radar.yml
@@ -27,6 +27,8 @@ jobs:
         uses: dataciviclab/.github/actions/python-setup@main
 
       - name: Run radar check
+        env:
+          HTTPS_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}
         run: |
           python scripts/radar_check.py
 


### PR DESCRIPTION
## Problema

3 fonti YELLOW nel radar perché GitHub Actions è bloccato da firewall PA:
- `openbdap` (MEF) — ✅ raggiungibile da IP europeo
- `mef_irpef` (MEF) — ✅ raggiungibile da IP europeo  
- `consip_open_data` (Consip) — ❓ da verificare

## Fix

Aggiunge `HTTPS_PROXY: ${{ vars.BLOCKED_SOURCE_PROXY }}` nei due workflow:

| Workflow | Step con proxy |
|---|---|
| `radar.yml` | `Run radar check` |
| `observatory.yml` | `Build catalog inventory` |
| `observatory.yml` | `Run bulk source-check` |

Il proxy è **solo sugli step HTTP**, non su GCS/git/gh CLI.
Se la variabile GitHub `BLOCKED_SOURCE_PROXY` non è impostata,
`HTTPS_PROXY` è vuoto → nessun proxy usato.

## Setup necessario

1. VM Oracle Free Tier Frankfurt con tinyproxy
2. Variabile GitHub: `BLOCKED_SOURCE_PROXY = http://<IP_VM>:8888`

## PR correlate

- #357 — fix timeout ISTAT SDMX 300→600s (lentezza vera, non firewall)