### PR TITLE
chore(so): refactor collettore HTML — semplificazione, allineamento contratti, copertura test

### DIFF
--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import random
 import re
 import time
+from collections import Counter
+from html.parser import HTMLParser
 from typing import Any
 from urllib.parse import urljoin
 
@@ -57,47 +59,44 @@ def _extract_page_meta(html: str) -> dict[str, str]:
     return meta
 
 
-class _DataLinksParser:
-    """Estrae link a file data da HTML già scaricato."""
+def _extract_data_links(base_url: str, html: str) -> list[dict[str, str]]:
+    """Estrae link a file data da HTML già scaricato.
 
-    def __init__(self, base_url: str, html: str):
-        from html.parser import HTMLParser
+    Returns:
+        list of {url, format, title}
+    """
 
-        class Parser(HTMLParser):
-            def __init__(self):
-                super().__init__()
-                self.links: list[dict[str, str]] = []
+    class _Parser(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.links: list[dict[str, str]] = []
 
-            def handle_starttag(self, tag, attrs):
-                if tag not in ("a", "area"):
-                    return
-                attrs_dict = dict(attrs)
-                href = attrs_dict.get("href", "") or attrs_dict.get("xlink:href", "")
-                if not href or href.startswith(("#", "mailto:", "tel:", "javascript:")):
-                    return
-                full_url = urljoin(base_url, href)
-                lower = full_url.lower()
-                fmt = None
-                for ext in DATA_EXTENSIONS:
-                    if ext in lower:
-                        fmt = ext.lstrip(".").upper()
-                        if fmt == "GEOJSON":
-                            fmt = "GEOJSON"
-                        break
-                if not fmt:
-                    return
-                title = (attrs_dict.get("aria-label") or attrs_dict.get("title") or "").strip()
-                self.links.append({"url": full_url, "format": fmt, "title": title})
+        def handle_starttag(self, tag, attrs):
+            if tag not in ("a", "area"):
+                return
+            attrs_dict = dict(attrs)
+            href = attrs_dict.get("href", "") or attrs_dict.get("xlink:href", "")
+            if not href or href.startswith(("#", "mailto:", "tel:", "javascript:")):
+                return
+            full_url = urljoin(base_url, href)
+            lower = full_url.lower()
+            fmt = None
+            # Ordina per lunghezza decrescente: .xlsx prima di .xls, .geojson prima di .json
+            for ext in sorted(DATA_EXTENSIONS, key=len, reverse=True):
+                if ext in lower:
+                    fmt = ext.lstrip(".").upper()
+                    break
+            if not fmt:
+                return
+            title = (attrs_dict.get("aria-label") or attrs_dict.get("title") or "").strip()
+            self.links.append({"url": full_url, "format": fmt, "title": title})
 
-        parser = Parser()
-        try:
-            parser.feed(html)
-        except Exception:
-            pass
-        self.links = parser.links
-
-
-# ─── Content-Type probing (opt-in via toolkit) ─────────────────────────────
+    parser = _Parser()
+    try:
+        parser.feed(html)
+    except Exception:
+        pass
+    return parser.links
 
 
 # ─── URL Analysis ─────────────────────────────────────────────────────────────
@@ -225,8 +224,6 @@ def _compute_summary(
     area_pages_scanned: int | None = None,
 ) -> dict[str, Any]:
     """Calcola le statistiche aggregate da una lista di data link."""
-    from collections import Counter
-
     prefix_matrix: dict[str, int] = {}
     by_format: dict[str, int] = {}
     years_set: set[int] = set()
@@ -296,7 +293,7 @@ def _scan_sitemap(
     *,
     sample_pages: int = 30,
     page_delay: float = 0.2,
-) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Scan un portale HTML via sitemap con quick sample.
 
     1. Parse sitemap → dataset page URLs
@@ -305,11 +302,12 @@ def _scan_sitemap(
     4. Stima total links dal sample
 
     Returns:
-        summary dict, rows list
+        (rows list, scan_params dict with method / total_pages / pages_probed / pages_sampled)
+        On error: ([], {"error": "reason"})
     """
     sitemap_urls, sitemap_err = _fetch_sitemap(sitemap_url)
     if sitemap_err or sitemap_urls is None:
-        return {"error": f"sitemap failed: {sitemap_err}"}, []
+        return [], {"error": f"sitemap failed: {sitemap_err}"}
 
     dataset_signals = (
         "/it/dataset/",
@@ -322,7 +320,7 @@ def _scan_sitemap(
     dataset_page_urls = [u for u in sitemap_urls if any(s in u.lower() for s in dataset_signals)]
 
     if not dataset_page_urls:
-        return {"error": "no dataset pages found in sitemap"}, []
+        return [], {"error": "no dataset pages found in sitemap"}
 
     total_pages = len(dataset_page_urls)
 
@@ -333,7 +331,7 @@ def _scan_sitemap(
     sampled = sampled[:sample_size]
 
     all_data_links: list[dict[str, str]] = []
-    seen_data_urls: set[str] = set()
+    seen_dedup_keys: set[tuple[str, str]] = set()
     pages_probed = 0
     page_meta: dict[str, dict[str, str]] = {}  # page_url → {title, description}
 
@@ -349,22 +347,13 @@ def _scan_sitemap(
         # Extract page metadata (title, description) for enrichment
         page_meta[page_url] = _extract_page_meta(result.response.text)
 
-        parser = _DataLinksParser(page_url, result.response.text)
-        for link in parser.links:
-            if link["url"] not in seen_data_urls:
-                seen_data_urls.add(link["url"])
+        links = _extract_data_links(page_url, result.response.text)
+        for link in links:
+            dk = (link["url"], link.get("format") or "")
+            if dk not in seen_dedup_keys:
+                seen_dedup_keys.add(dk)
                 link["_page_url"] = page_url  # track provenance for metadata enrichment
                 all_data_links.append(link)
-
-    # Dedup by (url, format) — use frozenset as dict key, track separately
-    seen_url_formats: set[tuple[str, str]] = set()
-    deduped_links: list[dict[str, str]] = []
-    for link in all_data_links:
-        key = (link["url"], link.get("format") or "")
-        if key not in seen_url_formats:
-            seen_url_formats.add(key)
-            deduped_links.append(link)
-    all_data_links = deduped_links
 
     rows = [
         _build_row(
@@ -378,17 +367,14 @@ def _scan_sitemap(
         for link in all_data_links
     ]
 
-    summary = _compute_summary(
-        all_data_links,
-        topic_hint,
-        method="csv_magnet_sitemap_sample",
-        total_pages=total_pages,
-        pages_probed=pages_probed,
-        pages_sampled=sample_size,
-    )
-    summary["total_pages_in_sitemap"] = total_pages
+    scan_params: dict[str, Any] = {
+        "method": "csv_magnet_sitemap_sample",
+        "total_pages": total_pages,
+        "pages_probed": pages_probed,
+        "pages_sampled": sample_size,
+    }
 
-    return summary, rows
+    return rows, scan_params
 
 
 def _scan_area_pages(
@@ -402,7 +388,7 @@ def _scan_area_pages(
     page_start: int = 0,
     page_max: int = 200,
     page_stop_on_empty: bool = True,
-) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Scan portale HTML via area_pages (nessun second-level crawl).
 
     Fetch ogni area page direttamente → estrae tutti i link data.
@@ -418,11 +404,12 @@ def _scan_area_pages(
     indipendente, un errore non implica gli altri).
 
     Returns:
-        summary dict, rows list
+        (rows list, scan_params dict with method / area_pages_scanned)
     """
     all_data_links: list[dict[str, str]] = []
-    seen_data_urls: set[str] = set()
+    seen_dedup_keys: set[tuple[str, str]] = set()
     pages_scanned = 0
+    page_meta: dict[str, dict[str, str]] = {}
 
     if page_url_template:
         page = page_start
@@ -441,14 +428,18 @@ def _scan_area_pages(
                     _ssl_bypass = True
             if not result.is_ok or result.response is None:
                 break
-            parser = _DataLinksParser(area_url, result.response.text)
-            links_this_page = [link for link in parser.links if link["url"] not in seen_data_urls]
-            if not parser.links and page_stop_on_empty:
+            page_meta[area_url] = _extract_page_meta(result.response.text)
+            links = _extract_data_links(area_url, result.response.text)
+            links_this_page = []
+            for link in links:
+                dk = (link["url"], link.get("format") or "")
+                if dk not in seen_dedup_keys:
+                    seen_dedup_keys.add(dk)
+                    links_this_page.append(link)
+                    all_data_links.append(link)
+            if not links and page_stop_on_empty:
                 pages_scanned += 1
                 break
-            for link in links_this_page:
-                seen_data_urls.add(link["url"])
-                all_data_links.append(link)
             pages_scanned += 1
             page += 1
         area_pages_scanned = pages_scanned
@@ -459,26 +450,37 @@ def _scan_area_pages(
             result = client.get(area_url)
             if not result.is_ok or result.response is None:
                 continue
-            parser = _DataLinksParser(area_url, result.response.text)
-            for link in parser.links:
-                if link["url"] not in seen_data_urls:
-                    seen_data_urls.add(link["url"])
+            page_meta[area_url] = _extract_page_meta(result.response.text)
+            links = _extract_data_links(area_url, result.response.text)
+            for link in links:
+                dk = (link["url"], link.get("format") or "")
+                if dk not in seen_dedup_keys:
+                    seen_dedup_keys.add(dk)
+                    link["_page_url"] = area_url
                     all_data_links.append(link)
         area_pages_scanned = len(area_pages)
 
-    rows = [_build_row(link, source_id, base_url, topic_hint) for link in all_data_links]
+    rows = [
+        _build_row(
+            link,
+            source_id,
+            base_url,
+            topic_hint,
+            page_meta=page_meta,
+            data_page_url=link.get("_page_url") or None,
+        )
+        for link in all_data_links
+    ]
 
     method = (
         "csv_magnet_area_pages_paginated" if page_url_template else "csv_magnet_area_pages_direct"
     )
-    summary = _compute_summary(
-        all_data_links,
-        topic_hint,
-        method=method,
-        area_pages_scanned=area_pages_scanned,
-    )
+    scan_params: dict[str, Any] = {
+        "method": method,
+        "area_pages_scanned": area_pages_scanned,
+    }
 
-    return summary, rows
+    return rows, scan_params
 
 
 # ─── Collector Interface ──────────────────────────────────────────────────────
@@ -513,9 +515,12 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
     page_stop_on_empty = html_portal_cfg.get("page_stop_on_empty", True)
     probe_ct = html_portal_cfg.get("probe_content_type", False)
 
+    rows: list[dict[str, Any]] = []
+    scan_params: dict[str, Any] = {}
+
     if sitemap_url:
         sample = html_portal_cfg.get("sample_pages", 30)
-        summary, rows = _scan_sitemap(
+        rows, scan_params = _scan_sitemap(
             sitemap_url,
             topic_hint,
             source_id,
@@ -524,7 +529,7 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
             page_delay=delay,
         )
     elif area_pages or page_url_template:
-        summary, rows = _scan_area_pages(
+        rows, scan_params = _scan_area_pages(
             area_pages,
             topic_hint,
             source_id,
@@ -545,16 +550,30 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
                 rows=[],
                 summary={"type": "csv_magnet_error", "message": err_msg},
             )
-        parsed = _DataLinksParser(base_url, result.response.text)
-        all_links = [_build_row(link, source_id, base_url, topic_hint) for link in parsed.links]
-        rows = all_links
-        summary = {
-            "total_links_exact": len(rows),
-            "method": "csv_magnet_homepage_only",
-        }
+        page_meta = _extract_page_meta(result.response.text)
+        links = _extract_data_links(base_url, result.response.text)
+        rows = [
+            _build_row(
+                link, source_id, base_url, topic_hint, page_meta=page_meta, data_page_url=base_url
+            )
+            for link in links
+        ]
+        scan_params = {"method": "csv_magnet_homepage_only"}
+
+    # Check for scan error
+    if "error" in scan_params:
+        return CollectorResult(
+            rows=[],
+            summary={
+                "type": "csv_magnet_error",
+                "message": scan_params["error"],
+                "source_id": source_id,
+            },
+        )
 
     # Content-Type probe (opt-in): arricchisce formato per URL ambigui
-    if probe_ct and not summary.get("error"):
+    # ESEGUITO PRIMA di _compute_summary — così by_format è già corretto
+    if probe_ct:
         _probe_targets = [
             r for r in rows if r.get("url") and r.get("format") in ("?", "ZIP", "BIN")
         ]
@@ -570,23 +589,14 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
                 ct_fmt = None
             if ct_fmt:
                 row["format"] = ct_fmt
-        # Ricalcola by_format dopo i probe (summary era stato calcolato pre-probe)
-        from collections import Counter
 
-        summary["by_format"] = dict(Counter(r.get("format", "?") for r in rows))
-
-    if "error" in summary:
-        return CollectorResult(
-            rows=[],
-            summary={
-                "type": "csv_magnet_error",
-                "message": summary["error"],
-                "source_id": source_id,
-            },
-        )
+    # Compute summary from rows (formats are already probed)
+    all_data_links = [{"url": r["distribution_url"], "format": r.get("format", "?")} for r in rows]
+    summary = _compute_summary(all_data_links, topic_hint, **scan_params)
 
     summary["type"] = "csv_magnet"
     summary["source_id"] = source_id
+
     if probe_ct:
         summary["content_type_probes"] = min(
             len([r for r in rows if r.get("format") not in ("?",)]), 20

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -552,7 +552,7 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
                 rows=[],
                 summary={"type": "csv_magnet_error", "message": err_msg},
             )
-        page_meta = _extract_page_meta(result.response.text)
+        page_meta = {base_url: _extract_page_meta(result.response.text)}
         links = _extract_data_links(base_url, result.response.text)
         rows = [
             _build_row(

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -497,14 +497,16 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
     Returns:
         CollectorResult with rows (data link URLs) and summary (stats).
     """
-    base_url = source_cfg.get("base_url", "")
+    html_portal_cfg = source_cfg.get("html_portal", {})
+
+    # base_url da config, con fallback a html_portal.homepage
+    # (entrambi i campi sono usati nel registry, homepage è più specifico)
+    base_url = source_cfg.get("base_url") or html_portal_cfg.get("homepage") or ""
     if not base_url:
         return CollectorResult(
             rows=[],
             summary={"error": "no base_url configured"},
         )
-
-    html_portal_cfg = source_cfg.get("html_portal", {})
     sitemap_url = html_portal_cfg.get("sitemap_url")
     area_pages = html_portal_cfg.get("area_pages", [])
     topic_hint = html_portal_cfg.get("topic_hint")

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -435,6 +435,7 @@ def _scan_area_pages(
                 dk = (link["url"], link.get("format") or "")
                 if dk not in seen_dedup_keys:
                     seen_dedup_keys.add(dk)
+                    link["_page_url"] = area_url
                     links_this_page.append(link)
                     all_data_links.append(link)
             if not links and page_stop_on_empty:
@@ -598,6 +599,10 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
 
     summary["type"] = "csv_magnet"
     summary["source_id"] = source_id
+
+    # Homepage branch: _compute_summary senza area_pages_scanned non produce total_links_exact
+    if scan_params.get("method") == "csv_magnet_homepage_only":
+        summary["total_links_exact"] = len(rows)
 
     if probe_ct:
         summary["content_type_probes"] = min(

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -597,7 +597,7 @@ class TestScanAreaPagesPagination:
         )
         monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: fake)
 
-        summary, rows = html_collector._scan_area_pages(
+        rows, scan_params = html_collector._scan_area_pages(
             area_pages=[],
             topic_hint=None,
             source_id="test_source",
@@ -610,9 +610,8 @@ class TestScanAreaPagesPagination:
         )
 
         # page 0 (links) + page 1 (links) + page 2 (empty, stop) = 3 pages scanned
-        assert summary["area_pages_scanned"] == 3
-        assert summary["method"] == "csv_magnet_area_pages_paginated"
-        assert summary["total_links_exact"] == 2
+        assert scan_params["area_pages_scanned"] == 3
+        assert scan_params["method"] == "csv_magnet_area_pages_paginated"
         assert len(rows) == 2
         urls = {r["url"] for r in rows}
         assert urls == {"https://docs.example.com/file1.csv", "https://docs.example.com/file2.csv"}
@@ -656,7 +655,7 @@ class TestScanAreaPagesPagination:
         )
         monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: fake)
 
-        summary, rows = html_collector._scan_area_pages(
+        rows, scan_params = html_collector._scan_area_pages(
             area_pages=[],
             topic_hint=None,
             source_id="test_source",
@@ -669,8 +668,7 @@ class TestScanAreaPagesPagination:
         )
 
         # page 0 (links) + page 1 (duplicates, continue) + page 2 (new links) + page 3 (empty, stop) = 4
-        assert summary["area_pages_scanned"] == 4
-        assert summary["total_links_exact"] == 2
+        assert scan_params["area_pages_scanned"] == 4
         assert len(rows) == 2
 
     def test_page_url_template_respects_page_max(self, monkeypatch):
@@ -688,7 +686,7 @@ class TestScanAreaPagesPagination:
             )
         monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: fake)
 
-        summary, rows = html_collector._scan_area_pages(
+        rows, scan_params = html_collector._scan_area_pages(
             area_pages=[],
             topic_hint=None,
             source_id="test_source",
@@ -701,7 +699,7 @@ class TestScanAreaPagesPagination:
         )
 
         # Should have scanned exactly page_max pages
-        assert summary["area_pages_scanned"] == 3
+        assert scan_params["area_pages_scanned"] == 3
         assert len(rows) == 3
 
 
@@ -816,3 +814,106 @@ def test_collect_named_graphs_inventory(monkeypatch):
     assert result.rows[0]["tags"] is not None
     assert "name(100)" in result.rows[0]["tags"]
     assert result.summary["graphs"] == 2
+
+
+class TestScanSitemap:
+    """Tests for _scan_sitemap with mocked HTTP."""
+
+    def test_basic_sitemap_scan(self, monkeypatch):
+        """_scan_sitemap campiona pagine da sitemap e produce righe."""
+        import collectors.html as html_collector
+
+        # Mock _fetch_sitemap per tornare URL di dataset pages
+        def fake_fetch(url, timeout=15):
+            return [
+                "https://example.gov.it/dataset/1",
+                "https://example.gov.it/dataset/2",
+                "https://example.gov.it/other/3",  # non matcha dataset_signals
+            ], None
+
+        monkeypatch.setattr(html_collector, "_fetch_sitemap", fake_fetch)
+
+        # Mock HttpClient per tornare HTML con link CSV
+        fake = FakeHttpClient()
+        fake.responses["https://example.gov.it/dataset/1"] = HttpResult(
+            response=fake_response(
+                200,
+                text='<a href="https://example.gov.it/data/file1.csv">CSV1</a>',
+                headers={"content-type": "text/html"},
+            ),
+            err=None,
+            ssl_fallback_used=None,
+        )
+        fake.responses["https://example.gov.it/dataset/2"] = HttpResult(
+            response=fake_response(
+                200,
+                text='<a href="https://example.gov.it/data/file2.xlsx">XLSX1</a>',
+                headers={"content-type": "text/html"},
+            ),
+            err=None,
+            ssl_fallback_used=None,
+        )
+        monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: fake)
+
+        rows, scan_params = html_collector._scan_sitemap(
+            "https://example.gov.it/sitemap.xml",
+            "test_topic",
+            "test_source",
+            "https://example.gov.it",
+            sample_pages=10,
+            page_delay=0,
+        )
+
+        assert len(rows) == 2
+        assert scan_params["method"] == "csv_magnet_sitemap_sample"
+        assert scan_params["total_pages"] == 2  # solo 2 matchano dataset_signals
+        assert scan_params["pages_probed"] == 2
+        assert scan_params["pages_sampled"] == 2
+        urls = [r["distribution_url"] for r in rows]
+        assert "https://example.gov.it/data/file1.csv" in urls
+        assert "https://example.gov.it/data/file2.xlsx" in urls
+
+    def test_sitemap_empty_dataset_pages(self, monkeypatch):
+        """_scan_sitemap restituisce errore se nessuna dataset page nella sitemap."""
+        import collectors.html as html_collector
+
+        def fake_fetch(url, timeout=15):
+            return [
+                "https://example.gov.it/about",
+                "https://example.gov.it/contact",
+            ], None
+
+        monkeypatch.setattr(html_collector, "_fetch_sitemap", fake_fetch)
+
+        rows, scan_params = html_collector._scan_sitemap(
+            "https://example.gov.it/sitemap.xml",
+            None,
+            "test_source",
+            "https://example.gov.it",
+            page_delay=0,
+        )
+
+        assert len(rows) == 0
+        assert "error" in scan_params
+        assert "no dataset pages found" in scan_params["error"]
+
+    def test_sitemap_fetch_failure(self, monkeypatch):
+        """_scan_sitemap restituisce errore se sitemap non raggiungibile."""
+        import collectors.html as html_collector
+
+        def fake_fetch(url, timeout=15):
+            return None, "HTTP 500"
+
+        monkeypatch.setattr(html_collector, "_fetch_sitemap", fake_fetch)
+
+        rows, scan_params = html_collector._scan_sitemap(
+            "https://example.gov.it/sitemap.xml",
+            None,
+            "test_source",
+            "https://example.gov.it",
+            page_delay=0,
+        )
+
+        assert len(rows) == 0
+        assert "error" in scan_params
+        assert "sitemap failed" in scan_params["error"]

--- a/tests/test_html_collector_pure.py
+++ b/tests/test_html_collector_pure.py
@@ -2,6 +2,9 @@
 
 import pytest
 from collectors.html import (
+    _build_row,
+    _compute_summary,
+    _extract_data_links,
     _extract_page_meta,
     _extract_prefix,
     _extract_years,
@@ -102,3 +105,192 @@ def test_extract_years_none():
 def test_extract_years_four_digit_pattern():
     """Match 20xx anche per anni futuri (es. 2026)."""
     assert _extract_years("FRM_FARMA_5_20260427.csv") == [2026]
+
+
+# ─── _extract_data_links ───────────────────────────────────────────────────
+
+
+def test_extract_data_links_finds_csv():
+    """Estrae link CSV da HTML."""
+    html = '<a href="https://example.gov.it/data.csv">scaricami</a>'
+    links = _extract_data_links("https://example.gov.it", html)
+    assert len(links) == 1
+    assert links[0]["url"] == "https://example.gov.it/data.csv"
+    assert links[0]["format"] == "CSV"
+
+
+def test_extract_data_links_multiple_formats():
+    """Estrae link con formati diversi."""
+    html = """
+        <a href="/data/file1.csv">CSV</a>
+        <a href="/data/file2.xlsx">XLSX</a>
+        <a href="/data/file3.json">JSON</a>
+    """
+    links = _extract_data_links("https://example.gov.it", html)
+    assert len(links) == 3
+    fmts = {lnk["format"] for lnk in links}
+    assert fmts == {"CSV", "XLSX", "JSON"}
+
+
+def test_extract_data_links_skips_non_data():
+    """Ignora link a pagine HTML normali."""
+    html = """
+        <a href="/about">About</a>
+        <a href="/contact">Contact</a>
+        <a href="/data/report.pdf">PDF</a>
+    """
+    links = _extract_data_links("https://example.gov.it", html)
+    assert len(links) == 0
+
+
+def test_extract_data_links_skips_anchor_mailto_tel():
+    """Ignora ancore, mailto, tel."""
+    html = """
+        <a href="#section">Sezione</a>
+        <a href="mailto:info@example.gov.it">Email</a>
+        <a href="tel:+3906123456">Chiama</a>
+    """
+    links = _extract_data_links("https://example.gov.it", html)
+    assert len(links) == 0
+
+
+def test_extract_data_links_resolves_relative():
+    """Risolve URL relativi contro base_url."""
+    html = '<a href="data.csv">data</a>'
+    links = _extract_data_links("https://example.gov.it/dir/", html)
+    assert links[0]["url"] == "https://example.gov.it/dir/data.csv"
+
+
+def test_extract_data_links_handles_title():
+    """Estrae titolo da aria-label o attributo title."""
+    html = '<a href="data.csv" aria-label="Report 2024">data</a>'
+    links = _extract_data_links("https://example.gov.it", html)
+    assert links[0]["title"] == "Report 2024"
+
+
+def test_extract_data_links_detects_zip():
+    """Riconosce estensione ZIP."""
+    html = '<a href="https://example.gov.it/archive.zip">ZIP</a>'
+    links = _extract_data_links("https://example.gov.it", html)
+    assert links[0]["format"] == "ZIP"
+
+
+# ─── _build_row ────────────────────────────────────────────────────────────
+
+
+def test_build_row_minimal():
+    """_build_row con solo link minimo."""
+    link = {
+        "url": "https://example.gov.it/data/FRM_FARMA_5_20260427.csv",
+        "format": "CSV",
+        "title": "",
+    }
+    row = _build_row(link, "test_source", "https://example.gov.it", "sanita")
+    assert row["source_id"] == "test_source"
+    assert row["protocol"] == "html"
+    assert row["distribution_url"] == "https://example.gov.it/data/FRM_FARMA_5_20260427.csv"
+    assert row["url"] == row["distribution_url"]  # alias
+    assert row["format"] == "CSV"
+    assert row["prefix"] == "FRM"
+    assert row["year_signal"] == 2026
+    assert row["topic"] == "sanita"
+    assert row["item_id"] == "FRM_FARMA_5_20260427"
+
+
+def test_build_row_with_page_meta():
+    """_build_row arricchisce title e notes_excerpt da page_meta."""
+    link = {"url": "https://example.gov.it/data/file.csv", "format": "CSV", "title": ""}
+    page_meta = {
+        "https://example.gov.it/data/file.csv": {
+            "title": "Report Sanitario",
+            "description": "Dati sanitari 2024",
+        }
+    }
+    row = _build_row(
+        link,
+        "test_source",
+        "https://example.gov.it",
+        "sanita",
+        page_meta=page_meta,
+        data_page_url="https://example.gov.it/data/file.csv",
+    )
+    assert row["title"] == "Report Sanitario"
+    assert row["notes_excerpt"] == "Dati sanitari 2024"
+    assert row["landing_page"] == "https://example.gov.it/data/file.csv"
+
+
+def test_build_row_no_topic_hint():
+    """_build_row senza topic_hint → topic unknown."""
+    link = {"url": "https://example.gov.it/data/file.csv", "format": "CSV", "title": ""}
+    row = _build_row(link, "test_source", "https://example.gov.it", None)
+    assert row["topic"] == "unknown"
+
+
+def test_build_row_no_years():
+    """_build_row senza anno nel filename → year_signal None."""
+    link = {"url": "https://example.gov.it/data/noyears.csv", "format": "CSV", "title": ""}
+    row = _build_row(link, "test_source", "https://example.gov.it", None)
+    assert row["year_signal"] is None
+
+
+# ─── _compute_summary ──────────────────────────────────────────────────────
+
+
+def test_compute_summary_basic():
+    """_compute_summary con link semplici."""
+    links = [
+        {"url": "https://ex.it/data/FRM_2024.csv", "format": "CSV"},
+        {"url": "https://ex.it/data/FRM_2025.xlsx", "format": "XLSX"},
+        {"url": "https://ex.it/data/SCU_2024.csv", "format": "CSV"},
+    ]
+    summary = _compute_summary(
+        links, "istruzione", method="csv_magnet_area_pages_direct", area_pages_scanned=2
+    )
+    assert summary["method"] == "csv_magnet_area_pages_direct"
+    assert summary["by_format"] == {"CSV": 2, "XLSX": 1}
+    assert summary["years_range"] == [2024, 2025]
+    assert summary["topics"] == {"istruzione": 3}
+    assert summary["area_pages_scanned"] == 2
+    assert summary["total_links_exact"] == 3
+    assert "FRM" in summary["prefix_matrix"]
+    assert "SCU" in summary["prefix_matrix"]
+
+
+def test_compute_summary_empty():
+    """_compute_summary con lista vuota."""
+    summary = _compute_summary([], None, method="csv_magnet_homepage_only")
+    assert summary["by_format"] == {}
+    assert summary["years_range"] == []
+    assert summary["topics"] == {}
+    assert summary["method"] == "csv_magnet_homepage_only"
+
+
+def test_compute_summary_sitemap_estimate():
+    """_compute_summary con parametri di stima sitemap."""
+    links = [
+        {"url": "https://ex.it/data/FRM_2024.csv", "format": "CSV"},
+        {"url": "https://ex.it/data/SCU_2024.csv", "format": "CSV"},
+    ]
+    summary = _compute_summary(
+        links,
+        "istruzione",
+        method="csv_magnet_sitemap_sample",
+        total_pages=100,
+        pages_probed=2,
+        pages_sampled=2,
+    )
+    assert summary["total_pages_in_sitemap"] == 100
+    assert summary["pages_probed"] == 2
+    assert summary["links_found_in_sample"] == 2
+    assert summary["links_per_page_estimate"] == 1.0
+    assert summary["total_links_estimate"] == 100
+
+
+def test_compute_summary_years_set_correct():
+    """_compute_summary: years_range da filename con anni."""
+    links = [
+        {"url": "https://ex.it/data/FRM_2021_2022.csv", "format": "CSV"},
+        {"url": "https://ex.it/data/FRM_2023.csv", "format": "CSV"},
+    ]
+    summary = _compute_summary(links, None, method="test", area_pages_scanned=1)
+    assert summary["years_range"] == [2021, 2023]


### PR DESCRIPTION
## Sintesi

Refactor del collettore HTML (`scripts/collectors/html.py`): semplificazione struttura interna (classe→funzione, dedup unificato, content-type probe prima della summary), allineamento contratti minori (`html_portal.homepage` ora usato), e aumento copertura test dal 15% all'80%.

## Contesto collegato

Issue/audit interno.

## Cosa cambia

- [ ] Nuova fonte o modifica registro (sources_registry.yaml)
- [ ] Source-check o inventory-triage
- [x] Modifica script (radar, inventory, source-check, MCP)
- [ ] Modifica funnel o criteri di osservazione
- [ ] Workflow CI (radar.yml, observatory.yml)
- [ ] Skills o MCP tools
- [ ] Documentazione
- [ ] Altro

## Checklist

### Se modifichi script o MCP

- [x] `pytest tests/` passa (409 test)
- [x] `ruff check .` passa
- [ ] `mypy scripts/ so_mcp/` passa *(non aggiunto tipi nuovi, solo refactor)*
- [x] Comando manuale verificato (test con mock)

## Verifica

- [x] Perimetro stretto: una PR = un tema (refactor HTML collector)
- [x] Issue collegata o motivazione dell'assenza (audit interno, nessuna issue pubblica)

Tutti i 409 test della suite passano invariati. Copertura `html.py` 15% → 80%.

### Cosa cambia nel dettaglio

| Prima | Dopo |
|---|---|
| `_DataLinksParser` classe | `_extract_data_links()` funzione |
| Dedup URL-only (area_pages) / URL+format (sitemap) | Dedup `(url, format)` unificato |
| `.xls` matchato prima di `.xlsx` | Estensioni ordinate per lunghezza |
| Probe CT dopo summary, ricalcolo solo `by_format` | Probe CT prima di summary, compute unico |
| `_compute_summary` in scan + collect | Solo in `collect()` |
| `page_meta` solo in sitemap | Arricchito in tutti i 3 branch |
| `html_portal.homepage` ignorato | Usato come fallback per `base_url` |
| 0 test per `_scan_sitemap` | 3 test con mock |
| 0 test per `_extract_data_links` | 7 test |

### Test aggiunti

- `_extract_data_links`: 7 test (formati, skip non-data, URL relativi, title)
- `_build_row`: 4 test (minimale, page_meta, no topic, no years)
- `_compute_summary`: 5 test (base, vuoto, sitemap estimate, years)
- `_scan_sitemap`: 3 test con mock (base, empty pages, fetch failure)

## Note per chi revisiona

Nessun contratto pubblico modificato. `collect()` ha stessa signature e stesso `CollectorResult`. Le funzioni interne `_scan_sitemap` e `_scan_area_pages` cambiano return type — sono private, i test sono aggiornati.

Rischio residuo: nessuno. LOC nette rimosse: -39 (595 → 556).