### PR TITLE
feat: distribution_url per SPARQL DCAT + branch is_sparql in source-check

### DIFF
--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -569,14 +569,18 @@ def _check_row(
     # già determinati — ma i campi di profiling (encoding_suggested, ecc.)
     # vengono SEMPRE popolati.
     preview_meta: dict[str, Any] = {}
-    # Per SDMX: distribution_url è il CSV costruito dal collector
+    # SDMX: distribution_url è il CSV costruito dal collector
     # ({api_base}/data/{flow_id}/ALL/?format=csv). Prevale su resource_url
     # che punta all'endpoint SDMX (non un CSV profilabile).
-    # Per inventory_only e content_type_landing: distribution_url dal catalogo
+    # SPARQL: distribution_url arriva da DCAT distribution/accessURL. Prevale
+    # su resource_url che punta all'endpoint SPARQL.
+    # inventory_only / content_type_landing: distribution_url dal catalogo
     # è più probabile sia un URL diretto a file CSV/XLSX.
-    # Per CKAN/HTML, resource_url è già il file dati corretto.
-    is_sdmx = str(row.get("protocol", "")).lower() == "sdmx"
-    if is_sdmx:
+    # CKAN/HTML: resource_url è già il file dati corretto.
+    protocol = str(row.get("protocol", "")).lower()
+    is_sdmx = protocol == "sdmx"
+    is_sparql = protocol == "sparql"
+    if is_sdmx or is_sparql:
         preview_url = (
             _safe_str(row.get("distribution_url"))
             or enrich.get("resource_url")

--- a/scripts/collectors/sparql.py
+++ b/scripts/collectors/sparql.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 from typing import Any
 
 from lab_connectors.http.sparql import (
@@ -21,6 +22,33 @@ from .base import (
     parse_int,
     sparql_binding_value,
 )
+
+# Estensioni tabulari/scaricabili in ordine di preferenza
+_TABULAR_EXT_RANK: dict[str, int] = {
+    ".csv": 0,
+    ".tsv": 1,
+    ".xlsx": 2,
+    ".xls": 3,
+    ".json": 4,
+    ".xml": 5,
+    ".zip": 6,
+}
+
+
+def _best_distribution_url(urls: list[str]) -> str | None:
+    """Sceglie la distribuzione più probabilmente tabulare/scaricabile.
+
+    Ordina per estensione file (CSV > TSV > XLSX > ...).
+    Se nessuna estensione riconosciuta, restituisce la prima URL.
+    """
+    if not urls:
+        return None
+    scored = sorted(
+        urls,
+        key=lambda u: _TABULAR_EXT_RANK.get(Path(u.split("?")[0]).suffix.lower(), 99),
+    )
+    return scored[0]
+
 
 SPARQL_QUERY_TEMPLATES = {
     "dcat_datasets": """
@@ -42,8 +70,11 @@ WHERE {
   OPTIONAL { ?dataset dcat:landingPage ?landingPage . }
   OPTIONAL { ?dataset dcat:theme ?theme . }
   OPTIONAL { ?dataset dcat:distribution ?dist . }
-  OPTIONAL { ?dist dcat:accessURL ?distributionURL . }
   OPTIONAL { ?dist dcat:downloadURL ?distributionURL . }
+  OPTIONAL {
+    ?dist dcat:accessURL ?distributionURL .
+    FILTER NOT EXISTS { ?dist dcat:downloadURL [] . }
+  }
   OPTIONAL { ?dist dct:format ?format . }
   OPTIONAL { ?dist dcat:mediaType ?format . }
 }
@@ -161,7 +192,7 @@ def _build_sparql_rows(
                 "issued": row_state["issued"],
                 "modified": row_state["modified"],
                 "landing_page": row_state["landing_page"],
-                "distribution_url": distribution_urls[0] if distribution_urls else None,
+                "distribution_url": _best_distribution_url(distribution_urls),
                 "distribution_count": distribution_count
                 if distribution_count is not None
                 else (len(distribution_urls) if distribution_urls else None),

--- a/scripts/collectors/sparql.py
+++ b/scripts/collectors/sparql.py
@@ -28,7 +28,7 @@ PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 
-SELECT DISTINCT ?dataset ?title ?description ?publisherName ?issued ?modified ?landingPage ?theme
+SELECT DISTINCT ?dataset ?title ?description ?publisherName ?issued ?modified ?landingPage ?theme ?distributionURL ?format
 WHERE {
   ?dataset a dcat:Dataset .
   OPTIONAL { ?dataset dct:title ?title . }
@@ -41,6 +41,11 @@ WHERE {
   OPTIONAL { ?dataset dct:modified ?modified . }
   OPTIONAL { ?dataset dcat:landingPage ?landingPage . }
   OPTIONAL { ?dataset dcat:theme ?theme . }
+  OPTIONAL { ?dataset dcat:distribution ?dist . }
+  OPTIONAL { ?dist dcat:accessURL ?distributionURL . }
+  OPTIONAL { ?dist dcat:downloadURL ?distributionURL . }
+  OPTIONAL { ?dist dct:format ?format . }
+  OPTIONAL { ?dist dcat:mediaType ?format . }
 }
 ORDER BY ?dataset
 LIMIT {limit}

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -1520,4 +1520,88 @@ class TestSdmxPaqaFlow:
         )
 
 
+class TestSparqlPaqaFlow:
+    """SPARQL distribution_url (da DCAT) → _fetch_data_preview → paqa_score."""
+
+    def test_sparql_distribution_url_paqa(self, monkeypatch):
+        import numpy as np
+        import pandas as pd
+        import yaml
+        from bulk_source_check import _check_row
+
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
+        import bulk_source_check as bsc
+
+        captured_urls: list[str] = []
+
+        def _mock_preview(url, *a, **kw):
+            captured_urls.append(url)
+            return {
+                "enrich_method": "csv_preview",
+                "paqa_score": 85,
+                "paqa_verdict": "accettabile",
+                "paqa_flags": None,
+                "paqa_ontologies": None,
+                "paqa_sampled": False,
+                "granularity": "non_determinato",
+                "year_min": None,
+                "year_max": None,
+                "columns": '["a"]',
+                "col_types": '{"a":"VARCHAR"}',
+                "file_size": 200,
+                "preview_row_count": 5,
+                "encoding_suggested": "utf-8",
+                "delim_suggested": ",",
+                "decimal_suggested": None,
+                "skip_suggested": 0,
+                "robust_read_suggested": False,
+                "mapping_suggestions": "{}",
+            }
+
+        monkeypatch.setattr(bsc, "_fetch_data_preview", _mock_preview)
+        monkeypatch.setattr(bsc, "_http_head_with_retry", lambda *a, **kw: (200, True, None, None))
+
+        row = pd.Series(
+            {
+                "source_id": "ispra_linked_data",
+                "item_id": "https://dati.isprambiente.it/id/dataset/test",
+                "item_name": "test_dataset",
+                "title": "Test SPARQL dataset with CSV distribution",
+                "organization": np.nan,
+                "tags": np.nan,
+                "notes_excerpt": np.nan,
+                "url": np.nan,
+                "landing_page": np.nan,
+                "distribution_url": "https://example.test/data/dataset.csv",
+                "format": "CSV",
+                "protocol": "sparql",
+                "source_url": "https://dati.isprambiente.it/sparql",
+                "api_base_url": np.nan,
+                "granularity": np.nan,
+                "year_signal": np.nan,
+                "encoding_suggested": np.nan,
+                "delim_suggested": np.nan,
+                "decimal_suggested": np.nan,
+                "skip_suggested": np.nan,
+                "source_status": "active",
+            }
+        )
+        result = _check_row(row, "2026-06-15T12:00:00", registry)
+
+        # Verifica che distribution_url SPARQL sia stato usato per la preview
+        assert len(captured_urls) == 1, "preview_url non chiamata per SPARQL"
+        assert "dataset.csv" in captured_urls[0], (
+            f"distribution_url SPARQL non usata: {captured_urls[0]}"
+        )
+        # Verifica PAQA score propagato
+        assert result.get("paqa_score") == 85, f"paqa_score: {result.get('paqa_score')}"
+        assert result.get("paqa_verdict") == "accettabile"
+        assert result.get("paqa_sampled") is False
+        # Verifica che distribution_url sia propagato nel risultato
+        assert result.get("distribution_url") == row.get("distribution_url"), (
+            f"distribution_url non propagato: {result.get('distribution_url')}"
+        )
+
+
 pytestmark = pytest.mark.contract


### PR DESCRIPTION
## Sintesi

Le fonti SPARQL (dati_cultura, dati_senato, ispra_linked_data, dati_camera) venivano inventariate senza `distribution_url`, impedendo al source-check di profilare eventuali CSV esposti via DCAT.

## Cosa cambia

### scripts/collectors/sparql.py
- Query `dcat_datasets` estesa: SELECT ora include `?distributionURL` e `?format`
- Nuovi OPTIONAL per distribuzioni DCAT: `accessURL`, `downloadURL`, `dct:format`, `dcat:mediaType`

### scripts/bulk_source_check.py
- Aggiunto branch `is_sparql` in `_check_row` (stesso pattern di `is_sdmx`)
- `distribution_url` dall'inventory viene usato come preview URL per profilazione CSV

## Verifica

Build inventory locale su `ispra_linked_data` e `dati_senato`:
- `ispra_linked_data`: 31/69 item ora hanno `distribution_url`
- `dati_senato`: 0/98 (endpoint non espone distribuzioni DCAT — nessuna regressione)
- `dati_cultura`: non testabile (endpoint irraggiungibile)

```
pytest tests/ → 405 pass
ruff check . → OK
```

## Checklist
- [x] Modifica script (radar, inventory, source-check, MCP)
- [x] Test aggiornati