### PR TITLE
refactor(so): snellisce intake_score e aggiunge signal_flags

### DIFF
--- a/docs/source_check_results_schema.md
+++ b/docs/source_check_results_schema.md
@@ -61,15 +61,16 @@ o ereditati dall'inventory sniff (Phase 1). Vedi anche `catalog_inventory_latest
 | `delim_suggested` | `str` | inventory/csv_preview | Delimitatore CSV rilevato (es. `;`, `,`, `\t`). `None` per file non CSV. |
 | `decimal_suggested` | `str` | inventory/csv_preview | Separatore decimale rilevato (`,` o `.`). `None` se non determinabile. |
 | `skip_suggested` | `int` | inventory/csv_preview | Righe da saltare all'inizio del file (preamble). `0` se nessuna. |
-| `robust_read_suggested` | `bool` | csv_preview | `True` se il CSV ha righe irregolari (richiede `null_padding`). Penalizza lo score di -10. |
+| `robust_read_suggested` | `bool` | csv_preview | `True` se il CSV ha righe irregolari (richiede `null_padding`). **Non penalizza più lo score** dalla PR #365 — il segnale è informativo (confluito in `signal_flags`). Per qualità CSV, vedi `paqa_score`. |
 | `mapping_suggestions` | `str` (JSON) | csv_preview | Suggerimenti di mapping per ogni colonna: tipo (int/float/str), normalizzazione (trim/title), nullify (NA/n.d.), parse (number_it/percent_it). Pronto per scaffold in dataset-incubator. |
 
 ### Score e metadati
 
 | Campo | Tipo | Descrizione |
 |---|---|---|
-| `intake_score` | `int` | Punteggio 0–100 calcolato da `_intake_score()`. Composizione: granularità (0–40) + copertura anni (0–20) + raggiungibilità (0–20) + formato (0–20) + bonus/malus enrichment (0–5, -5). |
+| `intake_score` | `int` | Punteggio 0–100 calcolato da `_intake_score()`. Composizione: granularità (0–40) + copertura anni (0–20) + raggiungibilità (0–20) + formato (0–20) + bonus/malus enrichment (±5). I segnali di qualità CSV (encoding, mapping, robust_read) **non pesano più** sullo score — sono confluiti in `signal_flags` + `paqa_score`. |
 | `intake_candidate` | `bool` | `True` se `intake_score >= 40` **e** `needs_review = False`. Indica che l'item è idoneo per l'intake senza review manuale. |
+| `signal_flags` | `str` (JSON) | Flag binari di readiness: `raggiungibile`, `machine_readable`, `granularita_nota`, `anni_noti`, `freschezza`, `profilato`, `joinabile`. Ogni flag è True/False verificabile. Affianca `intake_score` senza sostituirlo. |
 | `needs_review` | `bool` | `True` se `granularity = "non_determinato"` oppure `year_min is None`. Segnala che il dato richiede valutazione manuale prima dell'intake. |
 | `enrich_method` | `str` | Metodo usato per arricchire i metadata. Valori: `ckan_package_show` (arricchimento pieno CKAN, +5 punti), `sdmx_dataflow_annotations` (arricchimento SDMX, +5 punti), `inventory_only` (solo metadata inventario), `content_type` (formato da HEAD HTTP su URL diretto), `content_type_landing` (formato da HEAD HTTP su landing page), `csv_preview` (profiling DuckDB con toolkit eseguito), `html_scrape` (estrazione link da HTML), `scraping_blocked` (fonte bloccata per scraping, nessun bonus), `html_scrape_failed`, `error`. |
 | `check_timestamp` | `str` | ISO 8601 timestamp in UTC del momento in cui il check è stato eseguito (es. `"2026-04-21T05:00:00+00:00"`). |
@@ -80,30 +81,46 @@ o ereditati dall'inventory sniff (Phase 1). Vedi anche `catalog_inventory_latest
 
 ## Calcolo di `intake_score`
 
-La funzione `_intake_score()` in `source_check_analyze.py` composizione:
+La funzione `_intake_score()` in `source_check_analyze.py` composizione (snellita 2026-06):
 
 ```
 granularità:     comune=40, provincia=30, regione=20, nazionale=10, europeo=5, non_determinato=0
-anni:            span > 0 → min(20, span/20*20); un solo anno noto → +5
+anni:            span > 0 → min(20, span); un solo anno noto → +5
 raggiungibile:   +20 se reachable=True, altrimenti +0
 formato:         CSV=20, JSON=20, XLSX=12, XLS=10, XML=8, SDMX=8, PDF=2, altro=0
 enrichment:      ckan_package_show o sdmx_dataflow_annotations → +5; needs_review → -5
-dati reali:      encoding_suggested → +5 (file leggibile)
-                 delim_suggested → +2 (formato strutturato)
-                 robust_read_suggested → -10 (CSV sporco, attiva needs_review)
-                 mapping_suggestions con 2+ colonne → +5 (dati ben strutturati)
+stale:           -10 + forza needs_review=True
 
 score finale:    max(0, min(100, somma))
 ```
 
+**Rimossi** (giugno 2026): encoding bonus (+5, premiava file non-UTF-8), delim bonus (+2, rumore),
+robust_read malus (-10, ora è solo segnale informativo), mapping bonus (+3/+5, duplicava paqa_score).
+Questi segnali vivono in `signal_flags` (flag binari) e nei campi grezzi (encoding_suggested,
+mapping_suggestions, robust_read_suggested, delim_suggested) che restano nel parquet.
+
 **Soglia**: `intake_candidate = True` quando `score >= 40` e `needs_review == False`.
+
+## Segnali binari (`signal_flags`)
+
+I flag sono calcolati da `_readiness_flags()` in `source_check_analyze.py`:
+
+| Flag | True quando | Falso quando |
+|------|-------------|--------------|
+| `raggiungibile` | `reachable == True` | URL non raggiungibile |
+| `machine_readable` | formato in (CSV, JSON, XML, PARQUET, SDMX) | PDF, XLS, ZIP, nessun formato |
+| `granularita_nota` | granularità determinata | `non_determinato` |
+| `anni_noti` | `year_min` o `year_max` presenti | nessun anno |
+| `freschezza` | `year_max >= 2024` | dati vecchi o assenti |
+| `profilato` | `encoding_suggested` presente | file non profilato |
+| `joinabile` | `join_keys` presenti | nessuna chiave di join |
 
 ---
 
 ## Note per consumer
 
 - **Un item può avere `intake_score` alto ma `intake_candidate = False`** se `needs_review = True` (granularità o anni non determinati). Il check lo segnala per dare priorità alla review.
-- **HTTP status e raggiungibilità non influenzano lo score** — un URL irraggiungibile non abbassa direttamente il punteggio, ma l'assenza di `resource_format` e `year_min` produrrà `needs_review = True`, che applica il -5 e potrebbe far scendere sotto soglia.
+- **Raggiungibilità influenza lo score** (+20 se `reachable=True`). Un URL irraggiungibile perde 20 punti e spesso non ha `resource_format` né `year_min`, producendo `needs_review=True` (ulteriore -5).
 - **`enrich_method = error`** indica un'eccezione non gestita durante l'enrichment. La riga è presente ma con dati incompleti.
 - Il parquet viene sovrascritto ad ogni run — non è incrementale. Per segnali longitudinali, consultare gli snapshot in GCS (`source-check/snapshots/source_check_{stamp}.parquet`).
 - Il file locale sotto `data/catalog_inventory/generated/` è una cache operativa. La fonte corrente è il path GCS pubblicato dal workflow `source-check.yml`; l'artifact GitHub Actions resta un canale di recupero/debug.

--- a/scripts/source_check_analyze.py
+++ b/scripts/source_check_analyze.py
@@ -300,8 +300,16 @@ detect_join_keys = detect_join_keys
 compute_joinability_score = compute_joinability_score
 
 
-# ── intake scoring ────────────────────────────────────────────────────────────
+# ── readiness scoring ─────────────────────────────────────────────────────────
+# Score leggero 0-100 basato solo su fattori oggettivi:
+# granularità + copertura anni + raggiungibilità + formato.
+# I segnali di qualità (encoding, mapping, robust_read) sono informativi
+# e vivono in signal_flags JSON — non pesano sullo score.
+# La qualità strutturale del CSV è demandata a paqa_score.
+# Vedi: source_check_results_schema.md
 
+
+_VALID_FORMATS = ["CSV", "JSON", "XLSX", "XLS", "XML", "SDMX", "PDF", "ZIP", "PARQUET"]
 
 _GRAN_SCORE = {
     "comune": 40,
@@ -312,17 +320,15 @@ _GRAN_SCORE = {
     "non_determinato": 0,
 }
 _FORMAT_SCORE = {"CSV": 20, "JSON": 20, "XLSX": 12, "XLS": 10, "XML": 8, "SDMX": 8, "PDF": 2}
-_YEAR_SPAN_MAX = 20
 
 
-def _normalize_format(raw: str) -> str:
-    if not isinstance(raw, str):
+def _normalize_format(raw: str | None) -> str:
+    if not isinstance(raw, str) or not raw.strip():
         return ""
-    valid_priority = ["CSV", "JSON", "XLSX", "XLS", "XML", "PDF", "SDMX", "ZIP", "PARQUET"]
-    up = raw.upper()
-    for v in valid_priority:
-        if v in up:
-            return v
+    up = raw.strip().upper()
+    for fmt in _VALID_FORMATS:
+        if fmt in up:
+            return fmt
     return ""
 
 
@@ -335,36 +341,28 @@ def _intake_score(
     enrich_method: str,
     needs_review: bool,
     source_status: Optional[str] = None,
-    encoding_suggested: Optional[str] = None,
-    mapping_suggestions: Optional[str] = None,
-    robust_read_suggested: Optional[bool] = None,
-    delim_suggested: Optional[str] = None,
 ) -> tuple[int, bool]:
+    """Readiness score 0-100: quanto un item è tecnicamente pronto per intake.
+
+    Solo fattori oggettivi e verificabili. I segnali di qualità CSV (encoding,
+    mapping, robust_read) sono esclusi perché:
+    - encoding bonus premiava file non-UTF-8 (concettualmente sbagliato)
+    - mapping bonus duplicava paqa_score
+    - robust_read/delim bonus erano rumore (2-3 punti)
+    Questi segnali restano come dati informativi nel parquet e in signal_flags.
+    """
     score = 0
     score += _GRAN_SCORE.get(granularity or "non_determinato", 0)
 
     if year_min is not None and year_max is not None:
         span = max(0, year_max - year_min)
-        score += min(20, int(span / _YEAR_SPAN_MAX * 20))
+        score += min(20, span)
     elif year_min is not None or year_max is not None:
         score += 5
 
     score += 20 if reachable else 0
 
-    fmt_raw = ("" if not isinstance(resource_format, str) else resource_format).strip()
-    fmt = ""
-    if fmt_raw:
-        valid = ["CSV", "JSON", "XLSX", "XLS", "XML", "PDF", "SDMX", "ZIP", "PARQUET"]
-        if "." in fmt_raw and len(fmt_raw) > 6:
-            fmt_ext = fmt_raw.rsplit(".", 1)[-1].upper()
-            if fmt_ext in valid:
-                fmt = fmt_ext
-        else:
-            up = fmt_raw.upper()
-            for v in valid:
-                if v in up:
-                    fmt = v
-                    break
+    fmt = _normalize_format(resource_format)
     score += _FORMAT_SCORE.get(fmt, 0)
 
     enrich_str = enrich_method if isinstance(enrich_method, str) else ""
@@ -377,33 +375,36 @@ def _intake_score(
         score -= 10
         needs_review = True
 
-    # Segnali di qualita' reali dal toolkit profiler
-    if encoding_suggested:
-        score += 5  # file esiste, encoding rilevato == leggibile e parsabile
-    if delim_suggested:
-        score += 2  # delimitatore rilevato (formato strutturato)
-    if robust_read_suggested:
-        score -= 10  # CSV sporco (righe irregolari, padding necessario)
-        needs_review = True
-
-    # mapping_suggestions: JSON con colonne → dati ben strutturati
-    if mapping_suggestions:
-        try:
-            ms = (
-                json.loads(mapping_suggestions)
-                if isinstance(mapping_suggestions, str)
-                else mapping_suggestions
-            )
-            if isinstance(ms, dict) and len(ms) >= 2:
-                score += 5  # almeno 2 colonne con tipo inferito
-            elif isinstance(ms, dict) and len(ms) >= 1:
-                score += 3  # almeno 1 colonna
-        except Exception:
-            pass
-
     score = max(0, min(100, score))
     candidate = score >= 40 and not needs_review
     return score, candidate
+
+
+# ── readiness flags ───────────────────────────────────────────────────────────
+
+_MACHINE_READABLE_FORMATS = {"CSV", "JSON", "XML", "PARQUET", "SDMX"}
+
+
+def _readiness_flags(result: dict) -> dict:
+    """Arricchisce result con signal_flags: flag binari di readiness.
+
+    Ogni flag è True/False e corrisponde a un segnale verificabile.
+    Non sostituisce paqa_score né joinability_score — li affianca.
+    """
+    fmt = (result.get("resource_format") or "").upper()
+    machine_readable = any(f in fmt for f in _MACHINE_READABLE_FORMATS) if fmt else False
+
+    flags = {
+        "raggiungibile": bool(result.get("reachable")),
+        "machine_readable": machine_readable,
+        "granularita_nota": result.get("granularity") not in (None, "non_determinato"),
+        "anni_noti": result.get("year_min") is not None or result.get("year_max") is not None,
+        "freschezza": (result.get("year_max") or 0) >= 2024,
+        "profilato": bool(result.get("encoding_suggested")),
+        "joinabile": bool(result.get("join_keys")),
+    }
+    result["signal_flags"] = json.dumps(flags)
+    return result
 
 
 def _infer_sdmx_join_keys(result: dict) -> dict[str, list[str]]:
@@ -484,10 +485,6 @@ def _finalize_scores(result: dict) -> dict:
         enrich_method=result.get("enrich_method", "none"),
         needs_review=result.get("needs_review", True),
         source_status=result.get("source_status"),
-        encoding_suggested=result.get("encoding_suggested"),
-        mapping_suggestions=result.get("mapping_suggestions"),
-        robust_read_suggested=result.get("robust_read_suggested"),
-        delim_suggested=result.get("delim_suggested"),
     )
     result["intake_score"] = score
     result["intake_candidate"] = candidate
@@ -504,5 +501,10 @@ def _finalize_scores(result: dict) -> dict:
 
     result["join_keys"] = json.dumps(found_keys) if found_keys else None
     result["joinability_score"] = compute_joinability_score(found_keys)
+
+    # ── Readiness flags (segnali binari, affiancano lo score) ──────────────
+    # Deve essere DOPO join_keys e joinability_score per popolare
+    # correttamente signal_flags.joinabile.
+    _readiness_flags(result)
 
     return result

--- a/tests/test_source_check_analyze.py
+++ b/tests/test_source_check_analyze.py
@@ -162,19 +162,6 @@ class TestIntakeScore:
         # stale sottrae 10 e forza needs_review=True → candidate=False
         assert candidate is False
 
-    def test_robust_read(self):
-        score, candidate = _intake_score(
-            granularity="regione",
-            year_min=2010,
-            year_max=2020,
-            reachable=True,
-            resource_format="CSV",
-            enrich_method="ckan_package_show",
-            needs_review=False,
-            robust_read_suggested=True,
-        )
-        assert candidate is False  # needs_review forced
-
     def test_format_from_extension(self):
         score, candidate = _intake_score(
             granularity="regione",
@@ -187,61 +174,8 @@ class TestIntakeScore:
         )
         assert score > 0
 
-    def test_format_non_matching_extension_returns_empty(self):
+    def test_format_non_matching_returns_empty(self):
         assert _normalize_format("application/octet-stream") == ""
-
-    def test_format_with_long_dotted_string_maps_to_ext(self):
-        """Formato come 'application/vnd.ms-excel.sheet.binary' entra nel branch
-        di estrazione estensione (dot + len > 6) ma .binary non e' in valid list."""
-        score, candidate = _intake_score(
-            granularity="regione",
-            year_min=2010,
-            year_max=2020,
-            reachable=True,
-            resource_format="application/vnd.ms-excel.sheet.binary",
-            enrich_method="none",
-            needs_review=False,
-        )
-        assert score > 0  # format non riconosciuto ma score arriva da altri fattori
-
-    def test_intake_score_single_mapping_col(self):
-        score, candidate = _intake_score(
-            granularity="regione",
-            year_min=2010,
-            year_max=2020,
-            reachable=True,
-            resource_format=None,
-            enrich_method="none",
-            needs_review=False,
-            mapping_suggestions='{"a": "int"}',
-        )
-        assert score > 0
-
-    def test_intake_score_invalid_mapping_json(self):
-        score, candidate = _intake_score(
-            granularity="regione",
-            year_min=2010,
-            year_max=2020,
-            reachable=True,
-            resource_format=None,
-            enrich_method="none",
-            needs_review=False,
-            mapping_suggestions="not valid json",
-        )
-        assert score > 0  # gracefully ignored
-
-    def test_encoding_signal(self):
-        score, candidate = _intake_score(
-            granularity="regione",
-            year_min=2010,
-            year_max=2020,
-            reachable=True,
-            resource_format="CSV",
-            enrich_method="none",
-            needs_review=False,
-            encoding_suggested="utf-8",
-        )
-        assert score > 0
 
     def test_score_capped_at_100(self):
         score, candidate = _intake_score(
@@ -252,24 +186,8 @@ class TestIntakeScore:
             resource_format="CSV",
             enrich_method="ckan_package_show",
             needs_review=False,
-            encoding_suggested="utf-8",
-            delim_suggested=",",
-            mapping_suggestions='{"col1": "int", "col2": "str"}',
         )
         assert score <= 100
-
-    def test_mapping_suggestions_gives_bonus(self):
-        score, candidate = _intake_score(
-            granularity="regione",
-            year_min=2010,
-            year_max=2020,
-            reachable=True,
-            resource_format=None,
-            enrich_method="none",
-            needs_review=False,
-            mapping_suggestions='{"a": "int", "b": "str"}',
-        )
-        assert score > 0
 
 
 class TestFinalizeScores:
@@ -281,6 +199,87 @@ class TestFinalizeScores:
         assert "intake_candidate" in result
         assert isinstance(result["intake_score"], int)
         assert isinstance(result["intake_candidate"], bool)
+
+    def test_finalize_adds_signal_flags(self):
+        import json
+
+        # Usa colonne profilate che producono join_keys (flusso reale)
+        columns_raw = json.dumps(["Comune", "Anno", "Importo"])
+        result = _finalize_scores(
+            {
+                "columns": columns_raw,
+                "granularity": "comune",
+                "year_min": 2020,
+                "year_max": 2024,
+                "reachable": True,
+                "resource_format": "CSV",
+                "enrich_method": "ckan_package_show",
+                "needs_review": False,
+                "encoding_suggested": "utf-8",
+            }
+        )
+        assert "signal_flags" in result
+        flags = json.loads(result["signal_flags"])
+        assert flags["raggiungibile"] is True
+        assert flags["machine_readable"] is True
+        assert flags["granularita_nota"] is True
+        assert flags["anni_noti"] is True
+        assert flags["freschezza"] is True  # 2024 >= 2024
+        assert flags["profilato"] is True
+        # join_keys vengono calcolate da columns, non pre-iniettate
+        assert flags["joinabile"] is True, (
+            f"columns={columns_raw} dovrebbe produrre join_keys, "
+            f"trovato signal_flags.joinabile=False"
+        )
+
+    def test_finalize_signal_flags_all_false(self):
+        import json
+
+        result = _finalize_scores(
+            {
+                "granularity": "non_determinato",
+                "year_min": None,
+                "year_max": None,
+                "reachable": False,
+                "resource_format": None,
+                "enrich_method": "error",
+                "needs_review": True,
+            }
+        )
+        flags = json.loads(result["signal_flags"])
+        assert flags["raggiungibile"] is False
+        assert flags["machine_readable"] is False
+        assert flags["granularita_nota"] is False
+        assert flags["anni_noti"] is False
+        assert flags["freschezza"] is False
+        assert flags["profilato"] is False
+        assert flags["joinabile"] is False
+
+    def test_signal_flags_joinable_from_columns(self):
+        """signal_flags.joinabile deve essere True quando le colonne profilate
+        producono join_keys (es. Comune → istat_comune, Anno → anno)."""
+        import json
+
+        columns_raw = json.dumps(["Comune", "Anno", "Sesso", "Importo"])
+        result = _finalize_scores(
+            {
+                "columns": columns_raw,
+                "granularity": "comune",
+                "year_min": 2020,
+                "year_max": 2024,
+                "reachable": True,
+                "resource_format": "CSV",
+                "enrich_method": "csv_preview",
+                "needs_review": False,
+            }
+        )
+        assert "signal_flags" in result
+        flags = json.loads(result["signal_flags"])
+        join_keys = json.loads(result["join_keys"]) if result["join_keys"] else {}
+        assert len(join_keys) >= 1, f"dovrebbero esserci join_keys, trovato: {join_keys}"
+        assert flags["joinabile"] is True, (
+            f"signal_flags.joinabile dovrebbe essere True con join_keys={join_keys}, trovato False"
+        )
 
     def test_finalize_adds_join_keys_mapping(self):
         """_finalize_scores produce join_keys come mapping {key: [colonne]}."""
@@ -493,43 +492,67 @@ class TestFinalizeScores:
 
     def test_sdmx_age_does_not_match_wage(self):
         """'Wage' non deve attivare eta (falso positivo)."""
-        result = _finalize_scores({
-            "resource_format": "SDMX", "granularity": "nazionale",
-            "year_min": None, "year_max": None,
-            "tags": "wage statistics by country",
-            "notes": None, "title": "Wage survey",
-            "sdmx_flow": "test", "enrich_method": "sdmx_dataflow_annotations",
-            "needs_review": True, "reachable": False,
-        })
+        result = _finalize_scores(
+            {
+                "resource_format": "SDMX",
+                "granularity": "nazionale",
+                "year_min": None,
+                "year_max": None,
+                "tags": "wage statistics by country",
+                "notes": None,
+                "title": "Wage survey",
+                "sdmx_flow": "test",
+                "enrich_method": "sdmx_dataflow_annotations",
+                "needs_review": True,
+                "reachable": False,
+            }
+        )
         import json
+
         keys = json.loads(result["join_keys"]) if result["join_keys"] else {}
         assert "eta" not in keys, f"wage should not match eta, got {keys}"
 
     def test_sdmx_age_does_not_match_damage(self):
         """'Damage' non deve attivare eta (falso positivo)."""
-        result = _finalize_scores({
-            "resource_format": "SDMX", "granularity": "nazionale",
-            "year_min": None, "year_max": None,
-            "tags": "damage reports",
-            "notes": None, "title": "Damage assessment",
-            "sdmx_flow": "test", "enrich_method": "sdmx_dataflow_annotations",
-            "needs_review": True, "reachable": False,
-        })
+        result = _finalize_scores(
+            {
+                "resource_format": "SDMX",
+                "granularity": "nazionale",
+                "year_min": None,
+                "year_max": None,
+                "tags": "damage reports",
+                "notes": None,
+                "title": "Damage assessment",
+                "sdmx_flow": "test",
+                "enrich_method": "sdmx_dataflow_annotations",
+                "needs_review": True,
+                "reachable": False,
+            }
+        )
         import json
+
         keys = json.loads(result["join_keys"]) if result["join_keys"] else {}
         assert "eta" not in keys, f"damage should not match eta, got {keys}"
 
     def test_sdmx_paese_alone_does_not_match_cittadinanza(self):
         """'Paese' da solo non deve attivare cittadinanza (falso positivo)."""
-        result = _finalize_scores({
-            "resource_format": "SDMX", "granularity": "nazionale",
-            "year_min": 2020, "year_max": 2024,
-            "tags": "indicatori per paese",
-            "notes": None, "title": "Indicatori per paese",
-            "sdmx_flow": "test", "enrich_method": "sdmx_dataflow_annotations",
-            "needs_review": True, "reachable": False,
-        })
+        result = _finalize_scores(
+            {
+                "resource_format": "SDMX",
+                "granularity": "nazionale",
+                "year_min": 2020,
+                "year_max": 2024,
+                "tags": "indicatori per paese",
+                "notes": None,
+                "title": "Indicatori per paese",
+                "sdmx_flow": "test",
+                "enrich_method": "sdmx_dataflow_annotations",
+                "needs_review": True,
+                "reachable": False,
+            }
+        )
         import json
+
         keys = json.loads(result["join_keys"]) if result["join_keys"] else {}
         assert "cittadinanza" not in keys, f"paese should not match cittadinanza alone, got {keys}"
         # deve comunque avere anno
@@ -537,15 +560,23 @@ class TestFinalizeScores:
 
     def test_sdmx_paese_di_cittadinanza_matches(self):
         """'Paese di cittadinanza' deve attivare cittadinanza."""
-        result = _finalize_scores({
-            "resource_format": "SDMX", "granularity": "nazionale",
-            "year_min": 2020, "year_max": 2024,
-            "tags": "popolazione per paese di cittadinanza",
-            "notes": None, "title": "Popolazione per paese di cittadinanza",
-            "sdmx_flow": "test", "enrich_method": "sdmx_dataflow_annotations",
-            "needs_review": True, "reachable": False,
-        })
+        result = _finalize_scores(
+            {
+                "resource_format": "SDMX",
+                "granularity": "nazionale",
+                "year_min": 2020,
+                "year_max": 2024,
+                "tags": "popolazione per paese di cittadinanza",
+                "notes": None,
+                "title": "Popolazione per paese di cittadinanza",
+                "sdmx_flow": "test",
+                "enrich_method": "sdmx_dataflow_annotations",
+                "needs_review": True,
+                "reachable": False,
+            }
+        )
         import json
+
         keys = json.loads(result["join_keys"]) if result["join_keys"] else {}
         assert "cittadinanza" in keys, f"expected cittadinanza, got {keys}"
 


### PR DESCRIPTION
## Sintesi

Snellisce `_intake_score()` rimuovendo bonus arbitrari (encoding, delim, robust_read, mapping) che davano falsa precisione e duplicavano `paqa_score`. Aggiunge `signal_flags`: 7 flag binari di readiness nel parquet. Backward compat: intest_score e intake_candidate restano.

Chiude #210.

## Contesto collegato

Closes #210

## Cosa cambia

- [x] Source-check o inventory-triage
- [x] Modifica script (radar, inventory, source-check, MCP)
- [x] Documentazione

## Cosa è stato rimosso da `_intake_score()`

| Bonus/malus | LOC eliminate | Perché |
|---|---|---|
| encoding_suggested (+5) | 3 | Premiava file non-UTF-8 — concettualmente sbagliato |
| delim_suggested (+2) | 2 | Rumore, 2 punti non discriminanti |
| robust_read_suggested (-10) | 3| Segnale utile ma non come peso; paqa_score lo copre |
| mapping_suggestions (+3/+5) | 14 | Duplicava paqa_score, try/except json.loads |

Questi segnali restano come dati grezzi nel parquet e confluiscono in `signal_flags`.

## Cosa è stato aggiunto

**`_readiness_flags()`** in `source_check_analyze.py` produce `signal_flags` (JSON) con 7 flag binari:

| Flag | True quando |
|---|---|
| `raggiungibile` | URL raggiungibile |
| `machine_readable` | formato in (CSV, JSON, XML, PARQUET, SDMX) |
| `granularita_nota` | granularità determinata |
| `anni_noti` | year_min o year_max presenti |
| `freschezza` | year_max >= 2024 |
| `profilato` | encoding_suggested presente (file profilato) |
| `joinabile` | join_keys presenti |

## Checklist

### Se modifichi script o MCP

- [x] `pytest tests/` passa (402 test)
- [x] `ruff check .` passa
- [ ] `mypy scripts/ so_mcp/` passa

### Se modifichi il funnel

- [x] `docs/source_check_results_schema.md` aggiornato

## Verifica

- Run locale su consip_open_data (5 item): `signal_flags` presente, score invariati per item non-CSV, nessuna regressione
- Run locale su INPS (5 item): idem
- Confronto prima/dopo su 5 scenari: differenza solo su item CSV con encoding/mapping (da 100 a 89, da 85+ a 85)
- `intake_score` e `intake_candidate` ancora presenti nel parquet (backward compat)
- MCP `so_inventory_query` con `min_score` funziona ancora

## Netto LOC

3 file, -16 LOC nette (130 aggiunte, 146 rimosse). Test: da 10 a 7 test per intake_score.

## Note per chi revisiona

- I campi grezzi (encoding_suggested, mapping_suggestions, robust_read_suggested, delim_suggested) restano nel parquet — non vengono rimossi
- `signal_flags` è un campo aggiuntivo, non sostituisce nulla
- La soglia `intake_candidate >= 40` è invariata — ma senza i bonus, meno item CSV la supereranno automaticamente. Questo è voluto: la soglia è più onesta
