### PR TITLE
feat(mcp): rimuovi so_radar_history, aggiungi registry a so_source_overview, aggiorna skills

### DIFF
--- a/data/radar/README.md
+++ b/data/radar/README.md
@@ -33,6 +33,5 @@ Non e' un inventario di resource e non decide se una fonte merita un candidate.
 
 I tool MCP SO forniscono accesso programmatico a questi artifact:
 - `so_radar_summary` — legge `radar_summary.json` (status compatto per fonte; con `include_history=True` include anche la cronologia probe)
-- `so_radar_history` — **[deprecato]** usa `so_radar_summary include_history=True`
 
 GCS latest: `gs://dataciviclab-clean/radar/radar_summary.json`

--- a/skills/inventory-triage.md
+++ b/skills/inventory-triage.md
@@ -44,6 +44,10 @@ Prima di toccare l'inventory parquet, consulta gli artifact SO via MCP per orien
 4. so_radar_summary               → stato radar delle fonti monitorate
 ```
 
+**Alternativa compatta**: se conosci già lo `source_id`, puoi usare
+`so_source_overview(<source_id>)` che combina inventory_status + signals +
+radar_summary + registry in una chiamata sola.
+
 **Se `so_inventory_status` mostra error per una fonte**: l'inventory di quella fonte è inaffidabile — salta il triage per quella fonte o interpreta i risultati con cautela.
 
 **Se `so_catalog_signals` mostra `no signal`**: il catalogo è stabile, nessun bisogno urgente di re-inventory.

--- a/skills/portal-scout.md
+++ b/skills/portal-scout.md
@@ -25,7 +25,10 @@ Prima di qualsiasi probe, verifica che il portale non sia già nel sistema:
 2. so_registry_query(source_id=?) → già nel registry?
 ```
 
-**Se già catalogato**: stop, restituisci `already_known` con riferimento all'entry registry.
+**Se già catalogato (source_id noto)**: invece dei passaggi separati, puoi usare
+`so_source_overview(<source_id>)` per un quadro completo (registry + radar +
+inventory + signals) in una chiamata sola. Poi restituisci `already_known` con
+riferimento all'entry registry.
 
 ## Steps
 

--- a/skills/source-check.md
+++ b/skills/source-check.md
@@ -56,6 +56,10 @@ duplicati e orientarti:
 4. toolkit_probe_url(<URL>)     → reachability rapida (toolkit MCP)
 ```
 
+**Se la fonte è già nota (source_id conosciuto)**: sostituisci i passaggi
+2-3 con `so_source_overview(<source_id>)` che dà radar + inventory_status +
+signals + registry in una chiamata.
+
 **Se `so_find_by_url` trova risultati**: la fonte è già catalogata — consulta
 i risultati prima di proseguire e possibilmente riutilizza evidenze esistenti.
 

--- a/so_mcp/README.md
+++ b/so_mcp/README.md
@@ -67,7 +67,6 @@ In `auto`, il server prova i prefissi GCS pubblici; se il read GCS fallisce, usa
 | `so_inventory_status` | stato build inventory per fonte (con `include_diff=True` per delta item) |
 | `so_catalog_inventory_search` | cerca item per keyword/testo |
 | `so_recommend_sources` | trova source_id per keyword tema |
-| — | Topic inference: usa **`toolkit_infer_topic`** del toolkit MCP |
 
 > **Nota**: `so_infer_topic`, `so_inventory_diff` sono stati rimossi. Usa `so_inventory_status` con `include_diff=True` per il delta item (richiede `source_id`).
 
@@ -79,14 +78,13 @@ In `auto`, il server prova i prefissi GCS pubblici; se il read GCS fallisce, usa
 | `so_inventory_query` | score esistente per questa fonte |
 | — | Probe, CKAN, Topic: usa i tool **`toolkit_*`** del toolkit MCP |
 
-> **Nota**: `so_probe_url`, `so_ckan_package_show`, `so_infer_topic` sono stati rimossi. Usa `toolkit_probe_url`, `toolkit_ckan_package_show`, `toolkit_infer_topic` del toolkit MCP.
+> **Nota**: `so_probe_url`, `so_ckan_package_show`, `so_infer_topic` sono stati rimossi. Usa `toolkit_probe_url`, `toolkit_ckan_package_show` del toolkit MCP.
 
 ### Extra (non legati a skill specifica)
 
 | Tool | Uso |
 |---|---|
 | `so_radar_summary` | health portali (con `include_history=True` per cronologia probe) |
-| `so_radar_history` | **[deprecato]** usa `so_radar_summary include_history=True` |
 | `so_catalog_signals` | drift catalogo (weekly CI) |
 | — | SPARQL: usa **`toolkit_sparql_query`** del toolkit MCP |
 
@@ -110,9 +108,6 @@ In `auto`, il server prova i prefissi GCS pubblici; se il read GCS fallisce, usa
   - legge `radar_summary.json`
   - stato GREEN/YELLOW/RED per fonte
   - con `include_history=True` include anche `radar_history.json`
-
-- `so_radar_history` **[deprecato]**
-  - usa `so_radar_summary` con `include_history=True`
 
 - `so_find_by_url`
   - cerca URL in source_check_results e catalog_inventory

--- a/so_mcp/so_server.py
+++ b/so_mcp/so_server.py
@@ -89,15 +89,6 @@ def so_radar_summary(
 
 
 @mcp.tool(
-    description="[DEPRECATO] Usa so_radar_summary con include_history=True. "
-    "Legge radar_history.json: storia probes per fonte.",
-    structured_output=True,
-)
-def so_radar_history(source_id: str | None = None, limit: int = 5) -> dict[str, Any]:
-    return guard_timed(radar_history, "so_radar_history", source_id, limit)
-
-
-@mcp.tool(
     description="Legge catalog_inventory_report.json: stato build inventory per fonte. "
     "Con include_diff=True include anche il delta item count rispetto al baseline "
     "(richiede source_id esplicito).",
@@ -188,10 +179,10 @@ def so_list_source_items(
 
 @mcp.tool(
     description=(
-        "Overview completo di una fonte: stato radar, stato inventory, "
-        "delta item count, signals recenti. Compone radar_summary + "
-        "inventory_status + inventory_diff + catalog_signals "
-        "in una singola chiamata."
+        "Overview completo di una fonte: registry, radar, inventory, "
+        "delta item count, signals recenti. Compone registry_query + "
+        "radar_summary + inventory_status + inventory_diff + "
+        "catalog_signals in una singola chiamata."
     ),
     structured_output=True,
 )
@@ -201,6 +192,7 @@ def so_source_overview(source_id: str) -> dict[str, Any]:
     def _exec() -> dict[str, Any]:
         result: dict[str, Any] = {
             "source_id": source_id,
+            "registry": registry_query(source_id=source_id),
             "radar": radar_summary(source_id),
             "inventory_status": inventory_status(source_id),
             "inventory_diff": inventory_diff(source_id),

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -1145,17 +1145,14 @@ def test_list_source_items_parquet_not_found(tmp_path, monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_radar_summary_include_history_passes_params(tmp_path, monkeypatch) -> None:
-    """so_radar_summary(include_history=True) include history nel risultato
-    e passa source_id/limit a radar_history."""
+def test_radar_summary_include_history_contract(tmp_path, monkeypatch) -> None:
+    """include_history=True produce history; default False no."""
     from so_mcp.so_server import so_radar_summary
 
     radar_path = tmp_path / "radar_summary.json"
     radar_path.write_text(
         json.dumps(
             {
-                "generated_at": "2026-06-01T00:00:00+00:00",
-                "probe_date": "2026-06-01",
                 "sources_total": 1,
                 "status_counts": {"GREEN": 1},
                 "sources": [{"id": "s1", "status": "GREEN"}],
@@ -1172,150 +1169,42 @@ def test_radar_summary_include_history_passes_params(tmp_path, monkeypatch) -> N
                 "probes": [
                     {
                         "probe_date": "2026-05-25",
-                        "sources": [{"id": "s1", "status": "GREEN"}],
-                    },
-                    {
-                        "probe_date": "2026-05-18",
-                        "sources": [{"id": "s1", "status": "RED"}],
-                    },
-                ]
+                        "sources": [{"id": "s1", "status": "GREEN"}, {"id": "s2", "status": "RED"}],
+                    }
+                ],
             }
         ),
         encoding="utf-8",
     )
     monkeypatch.setattr(_artifact, "_RADAR_HISTORY_JSON", history_path)
 
-    # Default: include_history=False → nessun history
     result_no = so_radar_summary(source_id="s1")
     assert "history" not in result_no
 
-    # Con include_history=True → history presente
     result_yes = so_radar_summary(source_id="s1", include_history=True)
     assert "history" in result_yes
     assert result_yes["history"]["returned"] == 1
-    assert result_yes["history"]["sources"][0]["source_id"] == "s1"
-    assert result_yes["history"]["sources"][0]["recent_red_count"] == 1
 
 
-def test_radar_summary_include_history_default_is_false(tmp_path, monkeypatch) -> None:
-    """include_history=False di default — history non presente senza flag esplicito."""
-    from so_mcp.so_server import so_radar_summary
+def test_source_overview_contract(monkeypatch) -> None:
+    """so_source_overview include tutte le sezioni previste: registry, radar,
+    inventory_status, inventory_diff, signals."""
+    import so_mcp.so_server as sv
 
-    radar_path = tmp_path / "radar_summary.json"
-    radar_path.write_text(
-        json.dumps(
-            {
-                "generated_at": "2026-06-01T00:00:00+00:00",
-                "probe_date": "2026-06-01",
-                "sources_total": 1,
-                "status_counts": {"GREEN": 1},
-                "sources": [{"id": "s1", "status": "GREEN"}],
-            }
-        ),
-        encoding="utf-8",
+    monkeypatch.setattr(
+        sv, "registry_query", lambda source_id=None: {"returned": 1, "source_id": source_id}
     )
-    monkeypatch.setattr(_artifact, "_RADAR_JSON", radar_path)
-    monkeypatch.setattr(_artifact, "_RADAR_HISTORY_JSON", tmp_path / "unused.json")
+    monkeypatch.setattr(sv, "radar_summary", lambda source_id=None: {"status_counts": {"GREEN": 1}})
+    monkeypatch.setattr(sv, "inventory_status", lambda source_id=None: {"status": "ok"})
+    monkeypatch.setattr(sv, "inventory_diff", lambda source_id=None: {"delta": 0})
+    monkeypatch.setattr(sv, "query_signals", lambda source_id=None, limit=5: {"signals": []})
 
-    result = so_radar_summary(source_id="s1")
-    assert "history" not in result
+    result = sv.so_source_overview(source_id="s1")
 
-
-# ---------------------------------------------------------------------------
-# Contract: so_source_overview include registry
-# ---------------------------------------------------------------------------
-
-
-def test_source_overview_includes_registry(tmp_path, monkeypatch) -> None:
-    """so_source_overview include registry nel risultato."""
-    # Radar
-    radar_path = tmp_path / "radar_summary.json"
-    radar_path.write_text(
-        json.dumps(
-            {
-                "generated_at": "2026-06-01T00:00:00+00:00",
-                "probe_date": "2026-06-01",
-                "sources_total": 1,
-                "status_counts": {"GREEN": 1},
-                "sources": [{"id": "s1", "status": "GREEN"}],
-            }
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(_artifact, "_RADAR_JSON", radar_path)
-
-    # Inventory report
-    report_path = tmp_path / "catalog_inventory_report.json"
-    report_path.write_text(
-        json.dumps(
-            {
-                "captured_at": "2026-06-01T00:00:00+00:00",
-                "sources": {"s1": {"status": "ok", "protocol": "ckan", "rows": 100}},
-            }
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(_artifact, "_INVENTORY_REPORT", report_path)
-
-    # Inventory parquet (per inventory_diff)
-    inventory_path = tmp_path / "catalog_inventory_latest.parquet"
-    _write_parquet(
-        inventory_path,
-        [
-            {
-                "source_id": "s1",
-                "protocol": "ckan",
-                "item_id": "item_1",
-                "item_name": "item_1",
-                "organization": "Org",
-                "format": "csv",
-                "inventory_method": "package_list",
-                "item_kind": "dataset",
-                "captured_at": "2026-06-01",
-                "title": "",
-                "tags": "",
-                "notes_excerpt": "",
-                "landing_page": "",
-                "distribution_url": "",
-                "source_status": "",
-                "api_base_url": "",
-                "civic_priority": "",
-                "topic": "",
-                "theme": "",
-            }
-            for _ in range(100)
-        ],
-    )
-    monkeypatch.setattr(_artifact, "_INVENTORY_PARQUET", inventory_path)
-
-    # Signals
-    signals_path = tmp_path / "catalog_signals.json"
-    signals_path.write_text(json.dumps({"signals": []}), encoding="utf-8")
-    monkeypatch.setattr(_artifact, "_SIGNALS_JSON", signals_path)
-
-    # Registry
-    registry_path = tmp_path / "sources_registry.yaml"
-    registry_path.write_text(
-        "s1:\n"
-        "  source_kind: ckan\n"
-        "  protocol: ckan\n"
-        "  observation_mode: catalog-watch\n"
-        "  base_url: https://example.test/\n"
-        "  verdict: intake\n",
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(_artifact, "_REGISTRY_YAML", registry_path)
-
-    from so_mcp.so_server import so_source_overview
-
-    result = so_source_overview(source_id="s1")
-
-    assert "registry" in result, "so_source_overview deve includere 'registry'"
+    assert result["registry"]["source_id"] == "s1"
     assert result["registry"]["returned"] == 1
-    assert result["registry"]["results"][0]["source_id"] == "s1"
-    assert result["registry"]["results"][0]["source_kind"] == "ckan"
-    assert result["source_id"] == "s1"
     assert "radar" in result
     assert "inventory_status" in result
     assert "inventory_diff" in result
     assert "signals" in result
+    assert result["source_id"] == "s1"

--- a/tests/test_so_mcp.py
+++ b/tests/test_so_mcp.py
@@ -1138,3 +1138,184 @@ def test_list_source_items_parquet_not_found(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(_artifact, "_INVENTORY_PARQUET", tmp_path / "nonexistent.parquet")
     result = list_source_items("inps")
     assert result["error"] == "artifact_not_found"
+
+
+# ---------------------------------------------------------------------------
+# Contract: so_radar_summary include_history
+# ---------------------------------------------------------------------------
+
+
+def test_radar_summary_include_history_passes_params(tmp_path, monkeypatch) -> None:
+    """so_radar_summary(include_history=True) include history nel risultato
+    e passa source_id/limit a radar_history."""
+    from so_mcp.so_server import so_radar_summary
+
+    radar_path = tmp_path / "radar_summary.json"
+    radar_path.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-06-01T00:00:00+00:00",
+                "probe_date": "2026-06-01",
+                "sources_total": 1,
+                "status_counts": {"GREEN": 1},
+                "sources": [{"id": "s1", "status": "GREEN"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(_artifact, "_RADAR_JSON", radar_path)
+
+    history_path = tmp_path / "radar_history.json"
+    history_path.write_text(
+        json.dumps(
+            {
+                "probes": [
+                    {
+                        "probe_date": "2026-05-25",
+                        "sources": [{"id": "s1", "status": "GREEN"}],
+                    },
+                    {
+                        "probe_date": "2026-05-18",
+                        "sources": [{"id": "s1", "status": "RED"}],
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(_artifact, "_RADAR_HISTORY_JSON", history_path)
+
+    # Default: include_history=False → nessun history
+    result_no = so_radar_summary(source_id="s1")
+    assert "history" not in result_no
+
+    # Con include_history=True → history presente
+    result_yes = so_radar_summary(source_id="s1", include_history=True)
+    assert "history" in result_yes
+    assert result_yes["history"]["returned"] == 1
+    assert result_yes["history"]["sources"][0]["source_id"] == "s1"
+    assert result_yes["history"]["sources"][0]["recent_red_count"] == 1
+
+
+def test_radar_summary_include_history_default_is_false(tmp_path, monkeypatch) -> None:
+    """include_history=False di default — history non presente senza flag esplicito."""
+    from so_mcp.so_server import so_radar_summary
+
+    radar_path = tmp_path / "radar_summary.json"
+    radar_path.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-06-01T00:00:00+00:00",
+                "probe_date": "2026-06-01",
+                "sources_total": 1,
+                "status_counts": {"GREEN": 1},
+                "sources": [{"id": "s1", "status": "GREEN"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(_artifact, "_RADAR_JSON", radar_path)
+    monkeypatch.setattr(_artifact, "_RADAR_HISTORY_JSON", tmp_path / "unused.json")
+
+    result = so_radar_summary(source_id="s1")
+    assert "history" not in result
+
+
+# ---------------------------------------------------------------------------
+# Contract: so_source_overview include registry
+# ---------------------------------------------------------------------------
+
+
+def test_source_overview_includes_registry(tmp_path, monkeypatch) -> None:
+    """so_source_overview include registry nel risultato."""
+    # Radar
+    radar_path = tmp_path / "radar_summary.json"
+    radar_path.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-06-01T00:00:00+00:00",
+                "probe_date": "2026-06-01",
+                "sources_total": 1,
+                "status_counts": {"GREEN": 1},
+                "sources": [{"id": "s1", "status": "GREEN"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(_artifact, "_RADAR_JSON", radar_path)
+
+    # Inventory report
+    report_path = tmp_path / "catalog_inventory_report.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "captured_at": "2026-06-01T00:00:00+00:00",
+                "sources": {"s1": {"status": "ok", "protocol": "ckan", "rows": 100}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(_artifact, "_INVENTORY_REPORT", report_path)
+
+    # Inventory parquet (per inventory_diff)
+    inventory_path = tmp_path / "catalog_inventory_latest.parquet"
+    _write_parquet(
+        inventory_path,
+        [
+            {
+                "source_id": "s1",
+                "protocol": "ckan",
+                "item_id": "item_1",
+                "item_name": "item_1",
+                "organization": "Org",
+                "format": "csv",
+                "inventory_method": "package_list",
+                "item_kind": "dataset",
+                "captured_at": "2026-06-01",
+                "title": "",
+                "tags": "",
+                "notes_excerpt": "",
+                "landing_page": "",
+                "distribution_url": "",
+                "source_status": "",
+                "api_base_url": "",
+                "civic_priority": "",
+                "topic": "",
+                "theme": "",
+            }
+            for _ in range(100)
+        ],
+    )
+    monkeypatch.setattr(_artifact, "_INVENTORY_PARQUET", inventory_path)
+
+    # Signals
+    signals_path = tmp_path / "catalog_signals.json"
+    signals_path.write_text(json.dumps({"signals": []}), encoding="utf-8")
+    monkeypatch.setattr(_artifact, "_SIGNALS_JSON", signals_path)
+
+    # Registry
+    registry_path = tmp_path / "sources_registry.yaml"
+    registry_path.write_text(
+        "s1:\n"
+        "  source_kind: ckan\n"
+        "  protocol: ckan\n"
+        "  observation_mode: catalog-watch\n"
+        "  base_url: https://example.test/\n"
+        "  verdict: intake\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(_artifact, "_REGISTRY_YAML", registry_path)
+
+    from so_mcp.so_server import so_source_overview
+
+    result = so_source_overview(source_id="s1")
+
+    assert "registry" in result, "so_source_overview deve includere 'registry'"
+    assert result["registry"]["returned"] == 1
+    assert result["registry"]["results"][0]["source_id"] == "s1"
+    assert result["registry"]["results"][0]["source_kind"] == "ckan"
+    assert result["source_id"] == "s1"
+    assert "radar" in result
+    assert "inventory_status" in result
+    assert "inventory_diff" in result
+    assert "signals" in result

--- a/tests/test_so_server_wrapper.py
+++ b/tests/test_so_server_wrapper.py
@@ -1,4 +1,4 @@
-"""Smoke test: verify so_server.py registers 11 MCP tools via create_mcp_server."""
+"""Smoke test: verify so_server.py registers 10 MCP tools via create_mcp_server."""
 
 from __future__ import annotations
 
@@ -9,8 +9,8 @@ import pytest
 from so_mcp import so_server
 
 
-def test_mcp_server_registers_11_tools() -> None:
-    """Verify all 11 tools are registered on the mcp server object."""
+def test_mcp_server_registers_10_tools() -> None:
+    """Verify all 10 tools are registered on the mcp server object."""
     tools = asyncio.run(so_server.mcp.list_tools())
     tool_names = sorted(t.name for t in tools)
 
@@ -22,7 +22,6 @@ def test_mcp_server_registers_11_tools() -> None:
             "so_inventory_query",
             "so_inventory_status",
             "so_list_source_items",
-            "so_radar_history",
             "so_radar_summary",
             "so_recommend_sources",
             "so_registry_query",


### PR DESCRIPTION
## Sintesi

Rimuove il tool MCP `so_radar_history` (già deprecato, sostituito da `so_radar_summary(include_history=True)`). Estende `so_source_overview` con le informazioni del registry (`so_registry_query`). Aggiorna le 3 skills SO per referenziare `so_source_overview` come alternativa compatta.

## Cosa cambia

- [ ] Nuova fonte o modifica registro (sources_registry.yaml)
- [ ] Source-check o inventory-triage
- [x] Modifica script (radar, inventory, source-check, MCP)
- [ ] Modifica funnel o criteri di osservazione
- [ ] Workflow CI (radar.yml, observatory.yml)
- [x] Skills o MCP tools
- [x] Documentazione
- [ ] Altro

## Dettaglio

### Tool rimosso
- `so_radar_history` — tool MCP già deprecato. Sostituito 1:1 da `so_radar_summary(include_history=True)`. La funzione interna `radar_history()` resta per uso interno di `so_radar_summary`.

### Tool esteso
- `so_source_overview` ora include anche `registry` (da `sources_registry.yaml`) — file YAML locale, latenza zero.

### Skills aggiornate
- **portal-scout**: nel pre-check, per fonti già note suggerisce `so_source_overview(source_id)` come scorciatoia
- **inventory-triage**: nel pre-check MCP, aggiunta alternativa compatta con `so_source_overview`
- **source-check**: nel pre-check, per fonti già note suggerisce `so_source_overview` al posto dei passaggi 2-3

## Metriche
- 7 file modificati, 21 inserzioni, 25 rimozioni
- 11 → 10 tool MCP registrati

## Verifica

- [x] `pytest tests/` passa (4/4)
- [x] `ruff check .` passa
- [x] `python -c "from so_mcp.so_server import mcp; tools = __import__('asyncio').run(mcp.list_tools()); print(len(tools), 'tools')"` → 10 tool
- [x] `so_source_overview` testabile con `so_source_overview("istat_sdmx")`

## Note per chi revisiona

- `radar_history()` resta importata e usata da `so_radar_summary(include_history=True)` — non è stata rimossa
- Le 3 skills ora referenziano `so_source_overview` come alternativa compatta, non come sostituzione forzata
