### PR TITLE
feat(radar): aggiungi Eligendo — archivio storico elettorale DAIT

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -13,8 +13,8 @@ istat_sdmx:
     method: dataflow_count
     reliability: medium
     note: Re-baseline su endpoint esploradati (MCP ondata). Il valore 4212 e' il
-      conteggio riproducibile via MCP discover_dataflows (no keyword, no 
-      blacklist) dopo filtro NonProductionDataflow. Il valore 509 era il 
+      conteggio riproducibile via MCP discover_dataflows (no keyword, no
+      blacklist) dopo filtro NonProductionDataflow. Il valore 509 era il
       conteggio su sdmx.istat.it (endpoint diverso).
   verdict: go
   note: Endpoint SDMX ricco e ad alto valore per scouting e source-check.
@@ -33,8 +33,8 @@ anac:
     fq: organization:anac
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con fq=organization:anac 
-      restituisce tutti i 70 dataset ANAC con metadata completi. current_list 
+    skip_current_list_reason: package_search con fq=organization:anac
+      restituisce tutti i 70 dataset ANAC con metadata completi. current_list
       non necessario.
   last_probed: '2026-06-20'
   catalog_baseline:
@@ -43,7 +43,7 @@ anac:
     value: 70
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:anac su dati.gov.it. 
+    note: Conteggio via package_search con fq=organization:anac su dati.gov.it.
       70 dataset harvestati dal portale ANAC.
   verdict: go
   note: 'Fonte via dati.gov.it (harvesting ANAC). I download raw vanno al portale
@@ -72,11 +72,11 @@ inps:
     value: 2323
     method: package_list
     reliability: high
-    note: Inventory via package_list + package_show_sample (16 workers). 
-      current_package_list_with_resources testato ma scartato per lentezza a 
+    note: Inventory via package_list + package_show_sample (16 workers).
+      current_package_list_with_resources testato ma scartato per lentezza a
       offset alti. package_show_sample più veloce.
   verdict: go
-  note: Catalogo CKAN INPS — inventory via package_list + package_show_sample 
+  note: Catalogo CKAN INPS — inventory via package_list + package_show_sample
     (current_package_list_with_resources lento a offset alti).
   datasets_in_use:
     - inps_pensioni_trimestrale
@@ -85,7 +85,7 @@ openbdap:
   source_kind: catalog
   protocol: ckan
   observation_mode: catalog-watch
-  base_url: 
+  base_url:
     https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
   inventory:
     timeout: 600
@@ -102,10 +102,10 @@ openbdap:
     value: 3772
     method: package_list
     reliability: medium
-    note: Conteggio totale package rilevati via package_list; package_search 
+    note: Conteggio totale package rilevati via package_list; package_search
       restituisce count inaffidabile.
   verdict: go
-  note: Catalogo CKAN molto ricco; osservazione iniziale stretta a livello 
+  note: Catalogo CKAN molto ricco; osservazione iniziale stretta a livello
     inventario senza intake o monitor diffuso.
   datasets_in_use:
     - bdap_anagrafe_enti
@@ -120,9 +120,9 @@ inail_opendata:
   base_url: https://dati.inail.it/
   last_probed: '2026-06-20'
   verdict: go
-  note: Portale AEM con Open API documentate. Superficie operativa reale = 
-    catalogo AEM + Open API, non CKAN standard (logo nel footer fuorviante). 
-    Baseline inventariale non ancora difendibile; tenere in radar-only finche' 
+  note: Portale AEM con Open API documentate. Superficie operativa reale =
+    catalogo AEM + Open API, non CKAN standard (logo nel footer fuorviante).
+    Baseline inventariale non ancora difendibile; tenere in radar-only finche'
     non definito un metodo stabile.
   datasets_in_use: []
 mim_opendata:
@@ -141,7 +141,7 @@ mim_opendata:
       Personale, Valutazione, Edilizia, Adozioni). 1116 link CSV/XLS. Prefix: ALU=300,
       EDI=282, SCU=132. Nessuna sitemap disponibile.'
   verdict: go
-  note: Portale Ministero Istruzione — csv_magnet scan via area_pages (no 
+  note: Portale Ministero Istruzione — csv_magnet scan via area_pages (no
     sitemap).
   html_portal:
     topic_hint: istruzione
@@ -171,7 +171,7 @@ dati_camera:
     method: sparql_query
     query_name: camera_dcat
     reliability: medium
-    note: Baseline fissata con query custom Camera perché il catalogo usa 
+    note: Baseline fissata con query custom Camera perché il catalogo usa
       proprietà DC 1.1 Elements per titolo e descrizione.
   sparql:
     endpoint_url: https://dati.camera.it/sparql
@@ -185,8 +185,8 @@ dati_camera:
       \  OPTIONAL { ?dataset dct:modified ?modified . }\n  OPTIONAL { ?dataset dcat:landingPage
       ?landingPage . }\n}\nORDER BY ?dataset\nLIMIT 5000\n"
   verdict: go
-  note: Catalogo linked-data Camera inventariabile via query SPARQL custom. Il 
-    template DCAT generico non valorizza titolo e descrizione perché l'endpoint 
+  note: Catalogo linked-data Camera inventariabile via query SPARQL custom. Il
+    template DCAT generico non valorizza titolo e descrizione perché l'endpoint
     usa dc:title e dc:description.
   datasets_in_use:
     - camera_deputati_legislature
@@ -198,7 +198,7 @@ dati_senato:
   base_url: https://dati.senato.it/sparql
   inventory:
     timeout: 600
-    timeout_reason: 99 query SPARQL (1 discover + 98 schema enrich × 15 pred). 
+    timeout_reason: 99 query SPARQL (1 discover + 98 schema enrich × 15 pred).
       stimate 5s/query su Virtuoso. 99 × 5 × 1.2 = 594s
   last_probed: '2026-06-20'
   catalog_baseline:
@@ -208,8 +208,8 @@ dati_senato:
     method: named_graphs
     query_name: named_graphs
     reliability: medium
-    note: Baseline via enumerazione named graphs SPARQL. ~98 grafi organizzati 
-      per categoria (composizione, ddl, votazioni, emendamenti, ecc.) e 
+    note: Baseline via enumerazione named graphs SPARQL. ~98 grafi organizzati
+      per categoria (composizione, ddl, votazioni, emendamenti, ecc.) e
       legislatura (01-19). Fonte non ha DCAT catalog.
   sparql:
     endpoint_url: https://dati.senato.it/sparql
@@ -230,9 +230,9 @@ dati_senato:
       - facets
       - teseo
   verdict: go
-  note: Portale Open Data Senato. SPARQL endpoint Virtuoso (GET). Inventory via 
-    enumerazione named graphs (~98 grafi categoria/legislatura). Download 
-    CSV/JSON via POST form autenticato (non crawlabile). CC BY 3.0. Speculare a 
+  note: Portale Open Data Senato. SPARQL endpoint Virtuoso (GET). Inventory via
+    enumerazione named graphs (~98 grafi categoria/legislatura). Download
+    CSV/JSON via POST form autenticato (non crawlabile). CC BY 3.0. Speculare a
     dati_camera ma senza DCAT catalog.
   datasets_in_use: []
 dati_cultura:
@@ -248,8 +248,8 @@ dati_cultura:
     method: sparql_query
     query_name: dcat_datasets
     reliability: medium
-    note: Catalogo linked-data MiC (ArCo) con metadati DCAT interrogabili via 
-      SPARQL. ~150 dataset/thesaurus nel catalogo. Pilot per inventory SPARQL 
+    note: Catalogo linked-data MiC (ArCo) con metadati DCAT interrogabili via
+      SPARQL. ~150 dataset/thesaurus nel catalogo. Pilot per inventory SPARQL
       oltre ISPRA.
   sparql:
     endpoint_url: https://dati.cultura.gov.it/sparql
@@ -257,7 +257,7 @@ dati_cultura:
     limit: 5000
     timeout_seconds: 90
   verdict: go
-  note: Catalogo ArCo MiC inventariabile via SPARQL DCAT. Source-check 
+  note: Catalogo ArCo MiC inventariabile via SPARQL DCAT. Source-check
     completato con verdict catalog-watch.
   datasets_in_use: []
 ispra_linked_data:
@@ -279,8 +279,8 @@ ispra_linked_data:
     query_name: dcat_datasets
     limit: 5000
   verdict: go
-  note: Catalogo linked-data ISPRA con metadati DCAT interrogabili via SPARQL. 
-    Pilot per inventory SPARQL; non sostituisce le fonti operative ISPRA già 
+  note: Catalogo linked-data ISPRA con metadati DCAT interrogabili via SPARQL.
+    Pilot per inventory SPARQL; non sostituisce le fonti operative ISPRA già
     usate per pipeline tabellari.
   datasets_in_use:
     - ispra_consumo_suolo
@@ -299,12 +299,12 @@ consip_open_data:
     value: 17
     method: package_list
     reliability: medium
-    note: Baseline iniziale su CKAN package_list. I source-check del 2026-04-10 
-      hanno confermato almeno due dataset primari difendibili (bandi-e-gare, 
+    note: Baseline iniziale su CKAN package_list. I source-check del 2026-04-10
+      hanno confermato almeno due dataset primari difendibili (bandi-e-gare,
       consumi-convenzioni) e un support dataset chiaro (operatori-economici).
   verdict: go
-  note: Catalogo CKAN piccolo ma difendibile per catalog-watch. I source-check 
-    dataset-specifici hanno confermato che il catalogo contiene almeno due 
+  note: Catalogo CKAN piccolo ma difendibile per catalog-watch. I source-check
+    dataset-specifici hanno confermato che il catalogo contiene almeno due
     target primari e un support dataset utile per il filone Consip acquisti PA.
   datasets_in_use: []
 lavoro_opendata:
@@ -316,8 +316,8 @@ lavoro_opendata:
     fq: organization:ministero-del-lavoro
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
-      fq=organization:ministero-del-lavoro restituisce 83 dataset con metadata 
+    skip_current_list_reason: package_search con
+      fq=organization:ministero-del-lavoro restituisce 83 dataset con metadata
       completi. current_list non necessario.
   last_probed: '2026-06-20'
   catalog_baseline:
@@ -326,12 +326,12 @@ lavoro_opendata:
     value: 83
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:ministero-del-lavoro 
+    note: Conteggio via package_search con fq=organization:ministero-del-lavoro
       su dati.gov.it. 83 dataset harvestati dal portale Ministero del Lavoro.
   verdict: go
-  note: Fonte via dati.gov.it (harvesting Ministero del Lavoro). Sostituisce 
-    fonte diretta dati.lavoro.gov.it che aveva WAF. 83 dataset su lavoro 
-    (rapporti attivati/cessati, missioni, qualifiche professionali, genere, 
+  note: Fonte via dati.gov.it (harvesting Ministero del Lavoro). Sostituisce
+    fonte diretta dati.lavoro.gov.it che aveva WAF. 83 dataset su lavoro
+    (rapporti attivati/cessati, missioni, qualifiche professionali, genere,
     settore ATECO, ripartizione geografica).
   datasets_in_use: []
 mur_ustat:
@@ -343,8 +343,8 @@ mur_ustat:
     fq: organization:ministero-universita-e-ricerca
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
-      fq=organization:ministero-universita-e-ricerca restituisce 69 dataset con 
+    skip_current_list_reason: package_search con
+      fq=organization:ministero-universita-e-ricerca restituisce 69 dataset con
       metadata completi. current_list non necessario.
   last_probed: '2026-06-20'
   catalog_baseline:
@@ -353,12 +353,12 @@ mur_ustat:
     value: 69
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-universita-e-ricerca su dati.gov.it. 69 dataset 
+    note: Conteggio via package_search con
+      fq=organization:ministero-universita-e-ricerca su dati.gov.it. 69 dataset
       harvestati dal portale MUR.
   verdict: go
-  note: Fonte via dati.gov.it (harvesting MUR). Sostituisce fonte diretta 
-    dati-ustat.mur.gov.it che aveva ConnectTimeout. 69 dataset su istruzione 
+  note: Fonte via dati.gov.it (harvesting MUR). Sostituisce fonte diretta
+    dati-ustat.mur.gov.it che aveva ConnectTimeout. 69 dataset su istruzione
     universitaria (contribuzione atenei, DSU regionale, collegi, AFAM).
   datasets_in_use:
     - mur_contribuzione_universitaria
@@ -386,8 +386,8 @@ opencoesione:
     value: 561
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:pcm-opencoesione su 
-      dati.gov.it. 561 dataset harvestati da OpenCoesione (3 core + 558 
+    note: Conteggio via package_search con fq=organization:pcm-opencoesione su
+      dati.gov.it. 561 dataset harvestati da OpenCoesione (3 core + 558
       granulari per tema/ciclo/ambito).
   datasets_in_use:
     - opencoesione_progetti
@@ -395,7 +395,7 @@ mef_irpef:
   source_kind: catalog
   protocol: html
   observation_mode: catalog-watch
-  base_url: 
+  base_url:
     https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
   last_probed: '2026-06-20'
   catalog_baseline:
@@ -408,12 +408,12 @@ mef_irpef:
       totali su singola pagina statica. Nessuna sitemap ne sottopagine. Prefix: REG,
       cla, sesso, Redditi. Serie 2010-2025.'
   verdict: go
-  note: Portale MEF Dipartimento Finanze — Open Data IRPEF comunale. Dati 
+  note: Portale MEF Dipartimento Finanze — Open Data IRPEF comunale. Dati
     fiscali regionali per tipo reddito, classi, sesso. Alta rilevanza civica per
     analisi disuguaglianza e gettito regionale.
   html_portal:
     topic_hint: fisco
-    homepage: 
+    homepage:
       https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
     delay_seconds: 0.2
     probe_content_type: true
@@ -432,10 +432,10 @@ opencivitas:
     value: 1084
     method: csv_magnet_area_pages_paginated
     reliability: medium
-    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback 
+    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback
       necessario per cert invalido.
   verdict: go
-  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL 
+  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL
     fallback attivo. ZIP con CSV/XLSX dentro.
   html_portal:
     topic_hint: trasparenza
@@ -483,6 +483,20 @@ dait:
     per evitare rumore catalog inventory sui 41 snapshot.\n"
   datasets_in_use:
     - dait_amministratori_locali
+eligendo:
+  source_kind: catalog
+  protocol: html
+  observation_mode: radar-only
+  base_url: https://elezionistorico.interno.gov.it/eligendo/opendata.php
+  last_probed: '2026-06-20'
+  verdict: go
+  note: "Eligendo — Archivio storico elettorale del DAIT (Ministero dell'Interno). \
+    \ Risultati elettorali per comune dal 1946: Camera (19 tornate 1948-2022), \
+    \ Senato (19 tornate), Europee (10 tornate 1979-2024), Regionali (1970-), \
+    \ Comunali, Referendum, Assemblea Costituente. 312 file in ZIP/CSV.\
+    \ radar-only perche' l'inventario e' embedded in JS, non in link HTML diretti.\
+    \ Issue intake #523 su dataset-incubator.\n"
+  datasets_in_use: []
 mit_opendata:
   source_kind: catalog
   protocol: ckan
@@ -500,7 +514,7 @@ openga:
   source_kind: catalog
   protocol: ckan
   observation_mode: catalog-watch
-  base_url: 
+  base_url:
     https://openga.giustizia-amministrativa.it/api/3/action/package_list?limit=1
   last_probed: '2026-06-20'
   verdict: go
@@ -605,7 +619,7 @@ ministero_interno:
     fq: organization:ministero-dell-interno
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
+    skip_current_list_reason: package_search con
       fq=organization:ministero-dell-interno restituisce 38 dataset con metadata
       completi.
   last_probed: '2026-06-20'
@@ -615,13 +629,13 @@ ministero_interno:
     value: 38
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-dell-interno su dati.gov.it. 38 dataset su 
+    note: Conteggio via package_search con
+      fq=organization:ministero-dell-interno su dati.gov.it. 38 dataset su
       elezioni (per comune) e ANPR (popolazione).
   verdict: go
-  note: Fonte via dati.gov.it. Dati elezioni (Politiche 2022, Comunali 2024, 
-    Europee 2024, Regionali) per comune + ANPR (popolazione residente, cambi 
-    residenza, certificati, AIRE). Alto valore civico per analisi territoriale 
+  note: Fonte via dati.gov.it. Dati elezioni (Politiche 2022, Comunali 2024,
+    Europee 2024, Regionali) per comune + ANPR (popolazione residente, cambi
+    residenza, certificati, AIRE). Alto valore civico per analisi territoriale
     del voto.
   datasets_in_use: []
 agid:
@@ -633,8 +647,8 @@ agid:
     fq: organization:agenzia-per-l-italia-digitale
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
-      fq=organization:agenzia-per-l-italia-digitale restituisce 40 dataset con 
+    skip_current_list_reason: package_search con
+      fq=organization:agenzia-per-l-italia-digitale restituisce 40 dataset con
       metadata completi.
   last_probed: '2026-06-20'
   catalog_baseline:
@@ -643,8 +657,8 @@ agid:
     value: 40
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:agenzia-per-l-italia-digitale su dati.gov.it. 40 dataset 
+    note: Conteggio via package_search con
+      fq=organization:agenzia-per-l-italia-digitale su dati.gov.it. 40 dataset
       IPA (enti, PEC, domicili digitali, servizi, RTD).
   verdict: go
   note: 'Fonte via dati.gov.it. IPA — Indice delle PA: enti, unita organizzative,
@@ -659,10 +673,10 @@ noipa_sparql:
   base_url: https://sparql-noipa.mef.gov.it/sparql
   last_probed: '2026-06-20'
   verdict: hold
-  note: NoiPA SPARQL — MEF/RGS. Dati mensili personale PA (entries-{YYYYMM}, 
-    2019-2026) + pensioni PA (entriesPensioni-{YYYYMM}, 2017-oggi). ~490k 
-    soggetti/mese. L'endpoint risponde solo in XML 
-    (application/sparql-results+xml). Inventory non funzionante finché 
+  note: NoiPA SPARQL — MEF/RGS. Dati mensili personale PA (entries-{YYYYMM},
+    2019-2026) + pensioni PA (entriesPensioni-{YYYYMM}, 2017-oggi). ~490k
+    soggetti/mese. L'endpoint risponde solo in XML
+    (application/sparql-results+xml). Inventory non funzionante finché
     execute_sparql() in lab-connectors non supporta XML. Radar-only in attesa di
     parser XML o di endpoint JSON.
   datasets_in_use: []
@@ -675,8 +689,8 @@ mimit_rna:
     fq: organization:ministero-delle-imprese-e-del-made-in-italy
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
-      fq=organization:ministero-delle-imprese-e-del-made-in-italy restituisce 
+    skip_current_list_reason: package_search con
+      fq=organization:ministero-delle-imprese-e-del-made-in-italy restituisce
       370 dataset (RNA Aiuti + RNA Misure) con metadata.
   last_probed: '2026-06-20'
   catalog_baseline:
@@ -685,8 +699,8 @@ mimit_rna:
     value: 370
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-delle-imprese-e-del-made-in-italy su 
+    note: Conteggio via package_search con
+      fq=organization:ministero-delle-imprese-e-del-made-in-italy su
       dati.gov.it. 370 dataset (133 RNA Aiuti + 237 RNA Misure).
   verdict: go
   note: 'Fonte via dati.gov.it. RNA — Registro Nazionale Aiuti di Stato. 133 dataset
@@ -704,8 +718,8 @@ ministero_salute:
     fq: organization:ministero-della-salute
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
-      fq=organization:ministero-della-salute restituisce 51 dataset con 
+    skip_current_list_reason: package_search con
+      fq=organization:ministero-della-salute restituisce 51 dataset con
       metadata.
   last_probed: '2026-06-20'
   catalog_baseline:
@@ -714,9 +728,9 @@ ministero_salute:
     value: 51
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-della-salute su dati.gov.it. 51 dataset 
-      (farmacie, posti letto, personale SSN, dispositivi, ASL, fitosanitari). 
+    note: Conteggio via package_search con
+      fq=organization:ministero-della-salute su dati.gov.it. 51 dataset
+      (farmacie, posti letto, personale SSN, dispositivi, ASL, fitosanitari).
       URL raw su dati.salute.gov.it (portale in migrazione).
   verdict: go
   note: 'Fonte via dati.gov.it. Anagrafiche sanitarie nazionali: farmacie, parafarmacie,
@@ -737,8 +751,8 @@ agcm:
     fq: organization:agcm
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con fq=organization:agcm 
-      restituisce 53 dataset (rating legalita', concentrazioni). current_list 
+    skip_current_list_reason: package_search con fq=organization:agcm
+      restituisce 53 dataset (rating legalita', concentrazioni). current_list
       non necessario.
   last_probed: '2026-06-20'
   catalog_baseline:
@@ -747,7 +761,7 @@ agcm:
     value: 53
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:agcm su dati.gov.it. 
+    note: Conteggio via package_search con fq=organization:agcm su dati.gov.it.
       53 dataset (rating di legalità, operazioni di concentrazione).
   verdict: go
   note: "Fonte via dati.gov.it (AGCM). 53 dataset su concorrenza e mercato: rating
@@ -760,13 +774,13 @@ unioncamere:
   observation_mode: catalog-watch
   base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
   inventory:
-    fq: 
+    fq:
       organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con 
+    skip_current_list_reason: package_search con
       fq=organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
-      restituisce 352 dataset (imprese per provincia). current_list non 
+      restituisce 352 dataset (imprese per provincia). current_list non
       necessario.
   last_probed: '2026-06-20'
   catalog_baseline:
@@ -775,10 +789,10 @@ unioncamere:
     value: 352
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
+    note: Conteggio via package_search con
       fq=organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
-      su dati.gov.it. 352 dataset provincia per provincia su demografia 
-      d'impresa (natimortalità, femminili, giovanili, straniere, artigiane, 
+      su dati.gov.it. 352 dataset provincia per provincia su demografia
+      d'impresa (natimortalità, femminili, giovanili, straniere, artigiane,
       ATECO). ~340 provincia-specific, ~12 nazionali aggregati.
   verdict: go
   note: "Fonte via dati.gov.it (Unioncamere). 352 dataset su demografia d'impresa
@@ -795,7 +809,7 @@ pagopa:
     fq: organization:pagopa-s-p-a
     timeout: 180
     skip_current_list: true
-    skip_current_list_reason: package_search con fq=organization:pagopa-s-p-a 
+    skip_current_list_reason: package_search con fq=organization:pagopa-s-p-a
       restituisce 8 dataset con metadata completi.
   last_probed: '2026-06-20'
   catalog_baseline:
@@ -804,7 +818,7 @@ pagopa:
     value: 8
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:pagopa-s-p-a su 
+    note: Conteggio via package_search con fq=organization:pagopa-s-p-a su
       dati.gov.it. 8 dataset (transazioni pagoPA, IO App, SEND).
   verdict: go
   note: 'Fonte via dati.gov.it. 8 dataset: pagoPA (transazioni per anno, mese, fascia

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -47,9 +47,7 @@ def classify_response(status_code: int) -> str:
     return "RED"
 
 
-def validate_ckan_action_response(
-    base_url: str, response: requests.Response
-) -> tuple[str, str | None]:
+def validate_ckan_action_response(base_url: str, response: ResponseLike) -> tuple[str, str | None]:
     if "/api/3/action/" not in base_url:
         return classify_response(response.status_code), None
 
@@ -75,7 +73,7 @@ def validate_ckan_action_response(
 
 
 def _make_error_result(
-    exc: requests.exceptions.RequestException,
+    exc: Exception,
     *,
     ssl_fallback_used: bool = False,
     ssl_failure: requests.exceptions.SSLError | None = None,
@@ -162,7 +160,7 @@ def _probe_once(base_url: str) -> ProbeResult:
             note="Unexpected: response=None without exception from HttpClient.get",
         )
     ssl_failure_err: requests.exceptions.SSLError | None = None
-    error_exc: requests.exceptions.RequestException
+    error_exc: Exception
     if isinstance(result.err, HttpFallbackError):
         ssl_failure_err = (
             result.err.primary_error

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -149,7 +149,7 @@ def _probe_once(base_url: str) -> ProbeResult:
     if result.is_ok and result.response is not None:
         return _build_probe_result(
             base_url,
-            result.response,
+            result.response,  # type: ignore[arg-type]
             ssl_failure=result.ssl_fallback_used if result.ssl_fallback_used else None,
         )
     # Both failed — result.err carries the final error

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -22,6 +22,7 @@ from _constants import (
     validate_schema,
 )
 from lab_connectors.http import HttpClient, HttpFallbackError
+from lab_connectors.http.types import ResponseLike
 from toolkit.scout.http import is_sdmx_url
 
 USER_AGENT = "DataCivicLab-SourceObservatory/1.0"
@@ -113,7 +114,7 @@ def _make_error_result(
 
 def _build_probe_result(
     base_url: str,
-    response: requests.Response,
+    response: ResponseLike,
     *,
     ssl_failure: requests.exceptions.SSLError | Literal[True] | None = None,
 ) -> ProbeResult:
@@ -149,7 +150,7 @@ def _probe_once(base_url: str) -> ProbeResult:
     if result.is_ok and result.response is not None:
         return _build_probe_result(
             base_url,
-            result.response,  # type: ignore[arg-type]
+            result.response,
             ssl_failure=result.ssl_fallback_used if result.ssl_fallback_used else None,
         )
     # Both failed — result.err carries the final error
@@ -171,7 +172,7 @@ def _probe_once(base_url: str) -> ProbeResult:
         if isinstance(result.err.fallback_error, requests.exceptions.RequestException):
             error_exc = result.err.fallback_error
         else:
-            error_exc = result.err.fallback_error  # type: ignore[assignment]
+            error_exc = result.err.fallback_error
     elif isinstance(result.err, requests.exceptions.SSLError):
         ssl_failure_err = result.err
         error_exc = result.err


### PR DESCRIPTION
## Sintesi

Nuova fonte: Eligendo — Archivio storico elettorale del DAIT (Ministero dell'Interno).

URL: https://elezionistorico.interno.gov.it/eligendo/opendata.php
Protocol: HTML
Mode: radar-only (l'inventario è embedded in JS, non in link HTML diretti)

## Contenuto

312 file disponibili:
- Camera (19 tornate 1948-2022)
- Senato (19 tornate 1948-2022)
- Europee (10 tornate 1979-2024)
- Regionali (37 tornate 1970-2023)
- Comunali (163 tornate)
- Referendum (26 tornate 1946-2020)
- Assemblea Costituente 1946
- Catalogo AGID (27 CSV 2022-2024)

## Issue collegata

dataset-incubator #523 — intake per serie storica elezioni

## Verifica

```bash
python scripts/radar_check.py --dry-run
```

Radar GREEN.