### PR TITLE
refactor(ckan): rimuovi strategia current_list, -269 righe

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -12,18 +12,18 @@ istat_sdmx:
     value: 4212
     method: dataflow_count
     reliability: medium
-    note: Re-baseline su endpoint esploradati (MCP ondata). Il valore 4212 e' il
-      conteggio riproducibile via MCP discover_dataflows (no keyword, no
-      blacklist) dopo filtro NonProductionDataflow. Il valore 509 era il
-      conteggio su sdmx.istat.it (endpoint diverso).
+    note: Re-baseline su endpoint esploradati (MCP ondata). Il valore 4212 e' il conteggio
+      riproducibile via MCP discover_dataflows (no keyword, no blacklist) dopo filtro
+      NonProductionDataflow. Il valore 509 era il conteggio su sdmx.istat.it (endpoint
+      diverso).
   verdict: go
   note: Endpoint SDMX ricco e ad alto valore per scouting e source-check.
   datasets_in_use:
-    - istat_gini_regionale
-    - istat_housing_crowding
-    - istat_ipab_aree
-    - istat_pil_territoriale
-    - popolazione_istat_comunale_2019_2025
+  - istat_gini_regionale
+  - istat_housing_crowding
+  - istat_ipab_aree
+  - istat_pil_territoriale
+  - popolazione_istat_comunale_2019_2025
 anac:
   source_kind: catalog
   protocol: ckan
@@ -32,10 +32,6 @@ anac:
   inventory:
     fq: organization:anac
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: package_search con fq=organization:anac
-      restituisce tutti i 70 dataset ANAC con metadata completi. current_list
-      non necessario.
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-05-24'
@@ -43,15 +39,15 @@ anac:
     value: 70
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:anac su dati.gov.it.
-      70 dataset harvestati dal portale ANAC.
+    note: Conteggio via package_search con fq=organization:anac su dati.gov.it. 70
+      dataset harvestati dal portale ANAC.
   verdict: go
   note: 'Fonte via dati.gov.it (harvesting ANAC). I download raw vanno al portale
     diretto dati.anticorruzione.it con User-Agent browser (WAF blocca solo python-requests).
     70 dataset: CIG (2007-2023), SMARTCIG, OCDS, stazioni appaltanti, aggiudicatari,
     subappalti, varianti, PNRR indicatori, SOA. CC-BY-SA 4.0.'
   datasets_in_use:
-    - anac_bandi_gara
+  - anac_bandi_gara
 inps:
   source_kind: catalog
   protocol: ckan
@@ -59,9 +55,6 @@ inps:
   base_url: https://serviziweb2.inps.it/odapi/package_list?limit=1
   inventory:
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: "current_package_list_with_resources degrada a offset
-      alti (2300+ timeout 30s) — package_show_sample +16 workers è più veloce.\n"
     package_show_sample: true
     package_show_timeout: 5
     sample_size: 10000
@@ -72,26 +65,23 @@ inps:
     value: 2323
     method: package_list
     reliability: high
-    note: Inventory via package_list + package_show_sample (16 workers).
-      current_package_list_with_resources testato ma scartato per lentezza a
-      offset alti. package_show_sample più veloce.
+    note: Inventory via package_list + package_show_sample (16 workers). current_package_list_with_resources
+      testato ma scartato per lentezza a offset alti. package_show_sample più veloce.
   verdict: go
-  note: Catalogo CKAN INPS — inventory via package_list + package_show_sample
-    (current_package_list_with_resources lento a offset alti).
+  note: Catalogo CKAN INPS — inventory via package_list + package_show_sample (current_package_list_with_resources
+    lento a offset alti).
   datasets_in_use:
-    - inps_pensioni_trimestrale
-    - pensioni_pa_dag
+  - inps_pensioni_trimestrale
+  - pensioni_pa_dag
 openbdap:
   source_kind: catalog
   protocol: ckan
   observation_mode: catalog-watch
-  base_url:
-    https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
+  base_url: https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
   inventory:
     timeout: 600
     skip_package_search: true
     skip_package_search_reason: timeout sistematico a 60s
-    skip_current_list: true
     package_show_sample: true
     package_show_max_workers: 4
     package_show_timeout: 10
@@ -103,17 +93,17 @@ openbdap:
     value: 3772
     method: package_list
     reliability: medium
-    note: Conteggio totale package rilevati via package_list; package_search
-      restituisce count inaffidabile.
+    note: Conteggio totale package rilevati via package_list; package_search restituisce
+      count inaffidabile.
   verdict: go
-  note: Catalogo CKAN molto ricco; osservazione iniziale stretta a livello
-    inventario senza intake o monitor diffuso.
+  note: Catalogo CKAN molto ricco; osservazione iniziale stretta a livello inventario
+    senza intake o monitor diffuso.
   datasets_in_use:
-    - bdap_anagrafe_enti
-    - bdap_entrate_stato
-    - bdap_lea
-    - bdap_spese_stato
-    - dipendenti_pubblici
+  - bdap_anagrafe_enti
+  - bdap_entrate_stato
+  - bdap_lea
+  - bdap_spese_stato
+  - dipendenti_pubblici
 inail_opendata:
   source_kind: portal
   protocol: aem
@@ -121,10 +111,9 @@ inail_opendata:
   base_url: https://dati.inail.it/
   last_probed: '2026-06-22'
   verdict: go
-  note: Portale AEM con Open API documentate. Superficie operativa reale =
-    catalogo AEM + Open API, non CKAN standard (logo nel footer fuorviante).
-    Baseline inventariale non ancora difendibile; tenere in radar-only finche'
-    non definito un metodo stabile.
+  note: Portale AEM con Open API documentate. Superficie operativa reale = catalogo
+    AEM + Open API, non CKAN standard (logo nel footer fuorviante). Baseline inventariale
+    non ancora difendibile; tenere in radar-only finche' non definito un metodo stabile.
   datasets_in_use: []
 mim_opendata:
   source_kind: catalog
@@ -142,21 +131,20 @@ mim_opendata:
       Personale, Valutazione, Edilizia, Adozioni). 1116 link CSV/XLS. Prefix: ALU=300,
       EDI=282, SCU=132. Nessuna sitemap disponibile.'
   verdict: go
-  note: Portale Ministero Istruzione — csv_magnet scan via area_pages (no
-    sitemap).
+  note: Portale Ministero Istruzione — csv_magnet scan via area_pages (no sitemap).
   html_portal:
     topic_hint: istruzione
     area_pages:
-      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole
-      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Studenti
-      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Personale%20Scuola
-      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Sistema%20Nazionale%20di%20Valutazione
-      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Edilizia%20Scolastica
-      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Adozioni%20libri%20di%20testo
+    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole
+    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Studenti
+    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Personale%20Scuola
+    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Sistema%20Nazionale%20di%20Valutazione
+    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Edilizia%20Scolastica
+    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Adozioni%20libri%20di%20testo
     delay_seconds: 0.3
   datasets_in_use:
-    - mim_alunni_corso_eta
-    - mim_anagrafica_scuole_statali
+  - mim_alunni_corso_eta
+  - mim_anagrafica_scuole_statali
 dati_camera:
   source_kind: catalog
   protocol: sparql
@@ -172,26 +160,26 @@ dati_camera:
     method: sparql_query
     query_name: camera_dcat
     reliability: medium
-    note: Baseline fissata con query custom Camera perché il catalogo usa
-      proprietà DC 1.1 Elements per titolo e descrizione.
+    note: Baseline fissata con query custom Camera perché il catalogo usa proprietà
+      DC 1.1 Elements per titolo e descrizione.
   sparql:
     endpoint_url: https://dati.camera.it/sparql
     query_name: camera_dcat
     limit: 5000
     timeout_seconds: 60
     query: "PREFIX dcat: <http://www.w3.org/ns/dcat#>\nPREFIX dc: <http://purl.org/dc/elements/1.1/>\n\
-      PREFIX dct: <http://purl.org/dc/terms/>\nSELECT DISTINCT ?dataset ?title ?description
-      ?modified ?landingPage\nWHERE {\n  ?dataset a dcat:Dataset .\n  OPTIONAL { ?dataset
-      dc:title ?title . }\n  OPTIONAL { ?dataset dc:description ?description . }\n\
-      \  OPTIONAL { ?dataset dct:modified ?modified . }\n  OPTIONAL { ?dataset dcat:landingPage
-      ?landingPage . }\n}\nORDER BY ?dataset\nLIMIT 5000\n"
+      PREFIX dct: <http://purl.org/dc/terms/>\nSELECT DISTINCT ?dataset ?title ?description\
+      \ ?modified ?landingPage\nWHERE {\n  ?dataset a dcat:Dataset .\n  OPTIONAL {\
+      \ ?dataset dc:title ?title . }\n  OPTIONAL { ?dataset dc:description ?description\
+      \ . }\n  OPTIONAL { ?dataset dct:modified ?modified . }\n  OPTIONAL { ?dataset\
+      \ dcat:landingPage ?landingPage . }\n}\nORDER BY ?dataset\nLIMIT 5000\n"
   verdict: go
-  note: Catalogo linked-data Camera inventariabile via query SPARQL custom. Il
-    template DCAT generico non valorizza titolo e descrizione perché l'endpoint
-    usa dc:title e dc:description.
+  note: Catalogo linked-data Camera inventariabile via query SPARQL custom. Il template
+    DCAT generico non valorizza titolo e descrizione perché l'endpoint usa dc:title
+    e dc:description.
   datasets_in_use:
-    - camera_deputati_legislature
-    - camera_votazioni_sparql
+  - camera_deputati_legislature
+  - camera_votazioni_sparql
 dati_senato:
   source_kind: catalog
   protocol: sparql
@@ -199,8 +187,8 @@ dati_senato:
   base_url: https://dati.senato.it/sparql
   inventory:
     timeout: 600
-    timeout_reason: 99 query SPARQL (1 discover + 98 schema enrich × 15 pred).
-      stimate 5s/query su Virtuoso. 99 × 5 × 1.2 = 594s
+    timeout_reason: 99 query SPARQL (1 discover + 98 schema enrich × 15 pred). stimate
+      5s/query su Virtuoso. 99 × 5 × 1.2 = 594s
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-05-31'
@@ -209,9 +197,9 @@ dati_senato:
     method: named_graphs
     query_name: named_graphs
     reliability: medium
-    note: Baseline via enumerazione named graphs SPARQL. ~98 grafi organizzati
-      per categoria (composizione, ddl, votazioni, emendamenti, ecc.) e
-      legislatura (01-19). Fonte non ha DCAT catalog.
+    note: Baseline via enumerazione named graphs SPARQL. ~98 grafi organizzati per
+      categoria (composizione, ddl, votazioni, emendamenti, ecc.) e legislatura (01-19).
+      Fonte non ha DCAT catalog.
   sparql:
     endpoint_url: https://dati.senato.it/sparql
     inventory_mode: named_graphs
@@ -220,21 +208,21 @@ dati_senato:
     timeout_seconds: 300
     graph_uri_prefix: http://dati.senato.it/
     graph_uri_blacklist:
-      - localhost
-      - virtrdf
-      - owl#
-      - rules.skos
-      - virtrdf-label
-      - '8890'
-      - b3sifp
-      - b3sonto
-      - facets
-      - teseo
+    - localhost
+    - virtrdf
+    - owl#
+    - rules.skos
+    - virtrdf-label
+    - '8890'
+    - b3sifp
+    - b3sonto
+    - facets
+    - teseo
   verdict: go
-  note: Portale Open Data Senato. SPARQL endpoint Virtuoso (GET). Inventory via
-    enumerazione named graphs (~98 grafi categoria/legislatura). Download
-    CSV/JSON via POST form autenticato (non crawlabile). CC BY 3.0. Speculare a
-    dati_camera ma senza DCAT catalog.
+  note: Portale Open Data Senato. SPARQL endpoint Virtuoso (GET). Inventory via enumerazione
+    named graphs (~98 grafi categoria/legislatura). Download CSV/JSON via POST form
+    autenticato (non crawlabile). CC BY 3.0. Speculare a dati_camera ma senza DCAT
+    catalog.
   datasets_in_use: []
 dati_cultura:
   source_kind: catalog
@@ -249,17 +237,16 @@ dati_cultura:
     method: sparql_query
     query_name: dcat_datasets
     reliability: medium
-    note: Catalogo linked-data MiC (ArCo) con metadati DCAT interrogabili via
-      SPARQL. ~150 dataset/thesaurus nel catalogo. Pilot per inventory SPARQL
-      oltre ISPRA.
+    note: Catalogo linked-data MiC (ArCo) con metadati DCAT interrogabili via SPARQL.
+      ~150 dataset/thesaurus nel catalogo. Pilot per inventory SPARQL oltre ISPRA.
   sparql:
     endpoint_url: https://dati.cultura.gov.it/sparql
     query_name: dcat_datasets
     limit: 5000
     timeout_seconds: 90
   verdict: go
-  note: Catalogo ArCo MiC inventariabile via SPARQL DCAT. Source-check
-    completato con verdict catalog-watch.
+  note: Catalogo ArCo MiC inventariabile via SPARQL DCAT. Source-check completato
+    con verdict catalog-watch.
   datasets_in_use: []
 ispra_linked_data:
   source_kind: catalog
@@ -280,14 +267,14 @@ ispra_linked_data:
     query_name: dcat_datasets
     limit: 5000
   verdict: go
-  note: Catalogo linked-data ISPRA con metadati DCAT interrogabili via SPARQL.
-    Pilot per inventory SPARQL; non sostituisce le fonti operative ISPRA già
-    usate per pipeline tabellari.
+  note: Catalogo linked-data ISPRA con metadati DCAT interrogabili via SPARQL. Pilot
+    per inventory SPARQL; non sostituisce le fonti operative ISPRA già usate per pipeline
+    tabellari.
   datasets_in_use:
-    - ispra_consumo_suolo
-    - ispra_ru_base
-    - ispra_ru_costi_kg
-    - ispra_ru_costi_procapite
+  - ispra_consumo_suolo
+  - ispra_ru_base
+  - ispra_ru_costi_kg
+  - ispra_ru_costi_procapite
 consip_open_data:
   source_kind: catalog
   protocol: ckan
@@ -300,13 +287,13 @@ consip_open_data:
     value: 17
     method: package_list
     reliability: medium
-    note: Baseline iniziale su CKAN package_list. I source-check del 2026-04-10
-      hanno confermato almeno due dataset primari difendibili (bandi-e-gare,
-      consumi-convenzioni) e un support dataset chiaro (operatori-economici).
+    note: Baseline iniziale su CKAN package_list. I source-check del 2026-04-10 hanno
+      confermato almeno due dataset primari difendibili (bandi-e-gare, consumi-convenzioni)
+      e un support dataset chiaro (operatori-economici).
   verdict: go
-  note: Catalogo CKAN piccolo ma difendibile per catalog-watch. I source-check
-    dataset-specifici hanno confermato che il catalogo contiene almeno due
-    target primari e un support dataset utile per il filone Consip acquisti PA.
+  note: Catalogo CKAN piccolo ma difendibile per catalog-watch. I source-check dataset-specifici
+    hanno confermato che il catalogo contiene almeno due target primari e un support
+    dataset utile per il filone Consip acquisti PA.
   datasets_in_use: []
 lavoro_opendata:
   source_kind: catalog
@@ -316,10 +303,6 @@ lavoro_opendata:
   inventory:
     fq: organization:ministero-del-lavoro
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: package_search con
-      fq=organization:ministero-del-lavoro restituisce 83 dataset con metadata
-      completi. current_list non necessario.
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-05-24'
@@ -327,13 +310,12 @@ lavoro_opendata:
     value: 83
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:ministero-del-lavoro
-      su dati.gov.it. 83 dataset harvestati dal portale Ministero del Lavoro.
+    note: Conteggio via package_search con fq=organization:ministero-del-lavoro su
+      dati.gov.it. 83 dataset harvestati dal portale Ministero del Lavoro.
   verdict: go
-  note: Fonte via dati.gov.it (harvesting Ministero del Lavoro). Sostituisce
-    fonte diretta dati.lavoro.gov.it che aveva WAF. 83 dataset su lavoro
-    (rapporti attivati/cessati, missioni, qualifiche professionali, genere,
-    settore ATECO, ripartizione geografica).
+  note: Fonte via dati.gov.it (harvesting Ministero del Lavoro). Sostituisce fonte
+    diretta dati.lavoro.gov.it che aveva WAF. 83 dataset su lavoro (rapporti attivati/cessati,
+    missioni, qualifiche professionali, genere, settore ATECO, ripartizione geografica).
   datasets_in_use: []
 mur_ustat:
   source_kind: catalog
@@ -343,10 +325,6 @@ mur_ustat:
   inventory:
     fq: organization:ministero-universita-e-ricerca
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: package_search con
-      fq=organization:ministero-universita-e-ricerca restituisce 69 dataset con
-      metadata completi. current_list non necessario.
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-05-24'
@@ -354,15 +332,14 @@ mur_ustat:
     value: 69
     method: package_search
     reliability: high
-    note: Conteggio via package_search con
-      fq=organization:ministero-universita-e-ricerca su dati.gov.it. 69 dataset
-      harvestati dal portale MUR.
+    note: Conteggio via package_search con fq=organization:ministero-universita-e-ricerca
+      su dati.gov.it. 69 dataset harvestati dal portale MUR.
   verdict: go
-  note: Fonte via dati.gov.it (harvesting MUR). Sostituisce fonte diretta
-    dati-ustat.mur.gov.it che aveva ConnectTimeout. 69 dataset su istruzione
-    universitaria (contribuzione atenei, DSU regionale, collegi, AFAM).
+  note: Fonte via dati.gov.it (harvesting MUR). Sostituisce fonte diretta dati-ustat.mur.gov.it
+    che aveva ConnectTimeout. 69 dataset su istruzione universitaria (contribuzione
+    atenei, DSU regionale, collegi, AFAM).
   datasets_in_use:
-    - mur_contribuzione_universitaria
+  - mur_contribuzione_universitaria
 opencoesione:
   source_kind: catalog
   protocol: ckan
@@ -371,33 +348,29 @@ opencoesione:
   inventory:
     fq: organization:pcm-opencoesione
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: 'package_search con fq=organization:pcm-opencoesione
-      restituisce 561 dataset (3 core: progetti, soggetti, pagamenti). current_list
-      non necessario.'
   last_probed: '2026-06-22'
   verdict: go
-  note: "Fonte via dati.gov.it (harvesting PCM-OpenCoesione). Sostituisce accesso
+  note: 'Fonte via dati.gov.it (harvesting PCM-OpenCoesione). Sostituisce accesso
     diretto a opencoesione.gov.it (API REST instabile: 403/timeout). 561 dataset totali
     su dati.gov.it; i 3 core sono progetti, soggetti, pagamenti (CSV + Parquet). Licenza
-    CC BY 4.0. File raw su opencoesione.gov.it. Ultimo aggiornamento contenuti: 2026-02-28.\n"
+    CC BY 4.0. File raw su opencoesione.gov.it. Ultimo aggiornamento contenuti: 2026-02-28.
+
+    '
   catalog_baseline:
     captured_at: '2026-06-03'
     metric: package_count
     value: 561
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:pcm-opencoesione su
-      dati.gov.it. 561 dataset harvestati da OpenCoesione (3 core + 558
-      granulari per tema/ciclo/ambito).
+    note: Conteggio via package_search con fq=organization:pcm-opencoesione su dati.gov.it.
+      561 dataset harvestati da OpenCoesione (3 core + 558 granulari per tema/ciclo/ambito).
   datasets_in_use:
-    - opencoesione_progetti
+  - opencoesione_progetti
 mef_irpef:
   source_kind: catalog
   protocol: html
   observation_mode: catalog-watch
-  base_url:
-    https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
+  base_url: https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-05-03'
@@ -409,18 +382,17 @@ mef_irpef:
       totali su singola pagina statica. Nessuna sitemap ne sottopagine. Prefix: REG,
       cla, sesso, Redditi. Serie 2010-2025.'
   verdict: go
-  note: Portale MEF Dipartimento Finanze — Open Data IRPEF comunale. Dati
-    fiscali regionali per tipo reddito, classi, sesso. Alta rilevanza civica per
-    analisi disuguaglianza e gettito regionale.
+  note: Portale MEF Dipartimento Finanze — Open Data IRPEF comunale. Dati fiscali
+    regionali per tipo reddito, classi, sesso. Alta rilevanza civica per analisi disuguaglianza
+    e gettito regionale.
   html_portal:
     topic_hint: fisco
-    homepage:
-      https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
+    homepage: https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
     delay_seconds: 0.2
     probe_content_type: true
   datasets_in_use:
-    - irpef_comunale
-    - mef_irpef_regionale
+  - irpef_comunale
+  - mef_irpef_regionale
 opencivitas:
   source_kind: catalog
   protocol: html
@@ -433,11 +405,11 @@ opencivitas:
     value: 1084
     method: csv_magnet_area_pages_paginated
     reliability: medium
-    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback
-      necessario per cert invalido.
+    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback necessario
+      per cert invalido.
   verdict: go
-  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL
-    fallback attivo. ZIP con CSV/XLSX dentro.
+  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL fallback
+    attivo. ZIP con CSV/XLSX dentro.
   html_portal:
     topic_hint: trasparenza
     page_url_template: https://www.opencivitas.it/it/open-data?page={page}
@@ -447,30 +419,32 @@ opencivitas:
     delay_seconds: 0.3
     probe_content_type: true
   datasets_in_use:
-    - opencivitas_fsc_2025_rso
+  - opencivitas_fsc_2025_rso
 aifa:
   source_kind: catalog
   protocol: html
   observation_mode: catalog-watch
   base_url: https://www.aifa.gov.it/dati-aifa
   verdict: go
-  note: "Portale Open Data AIFA — CSV scaricabili senza autenticazione. Licenza CC-BY
+  note: 'Portale Open Data AIFA — CSV scaricabili senza autenticazione. Licenza CC-BY
     4.0. Inventory via area_pages (sito principale ha protezioni anti-bot). Dataset:
     liste farmaci, provvedimenti, sperimentazioni cliniche, farmacovigilanza, incarichi,
-    bandi.\n"
+    bandi.
+
+    '
   html_portal:
     topic_hint: sanita
     area_pages:
-      - https://www.aifa.gov.it/web/guest/liste-dei-farmaci
-      - https://www.aifa.gov.it/web/guest/provvedimenti-aifa
-      - https://www.aifa.gov.it/web/guest/sperimentazioni-cliniche
-      - https://www.aifa.gov.it/web/guest/farmacovigilanza-open-data
-      - https://www.aifa.gov.it/web/guest/incarichi-e-consulenze
-      - https://www.aifa.gov.it/web/guest/bandi-di-gara-e-contratti-
+    - https://www.aifa.gov.it/web/guest/liste-dei-farmaci
+    - https://www.aifa.gov.it/web/guest/provvedimenti-aifa
+    - https://www.aifa.gov.it/web/guest/sperimentazioni-cliniche
+    - https://www.aifa.gov.it/web/guest/farmacovigilanza-open-data
+    - https://www.aifa.gov.it/web/guest/incarichi-e-consulenze
+    - https://www.aifa.gov.it/web/guest/bandi-di-gara-e-contratti-
     delay_seconds: 0.5
     probe_content_type: true
   datasets_in_use:
-    - aifa_spesa_consumo
+  - aifa_spesa_consumo
   last_probed: '2026-06-22'
 dait:
   source_kind: catalog
@@ -479,11 +453,13 @@ dait:
   base_url: https://dait.interno.gov.it/contenuti/tipo/open_data
   last_probed: '2026-06-22'
   verdict: go
-  note: "DAIT — Anagrafe Amministratori locali. CSV snapshot annuali 1991-2026 + \
-    \ corrente. 41 su 42 entry sono snapshot dello stesso dataset. radar-only iniziale
-    per evitare rumore catalog inventory sui 41 snapshot.\n"
+  note: 'DAIT — Anagrafe Amministratori locali. CSV snapshot annuali 1991-2026 +  corrente.
+    41 su 42 entry sono snapshot dello stesso dataset. radar-only iniziale per evitare
+    rumore catalog inventory sui 41 snapshot.
+
+    '
   datasets_in_use:
-    - dait_amministratori_locali
+  - dait_amministratori_locali
 eligendo:
   source_kind: catalog
   protocol: html
@@ -491,11 +467,13 @@ eligendo:
   base_url: https://elezionistorico.interno.gov.it/eligendo/opendata.php
   last_probed: '2026-06-22'
   verdict: go
-  note: "Eligendo — Archivio storico elettorale del DAIT (Ministero dell'Interno).\
-    \  Risultati elettorali per comune dal 1946: Camera (19 tornate 1948-2022),  Senato
-    (19 tornate), Europee (10 tornate 1979-2024), Regionali (1970-),  Comunali, Referendum,
-    Assemblea Costituente. 312 file in ZIP/CSV. radar-only perche' l'inventario e'
-    embedded in JS, non in link HTML diretti. Issue intake #523 su dataset-incubator.\n"
+  note: 'Eligendo — Archivio storico elettorale del DAIT (Ministero dell''Interno).  Risultati
+    elettorali per comune dal 1946: Camera (19 tornate 1948-2022),  Senato (19 tornate),
+    Europee (10 tornate 1979-2024), Regionali (1970-),  Comunali, Referendum, Assemblea
+    Costituente. 312 file in ZIP/CSV. radar-only perche'' l''inventario e'' embedded
+    in JS, non in link HTML diretti. Issue intake #523 su dataset-incubator.
+
+    '
   datasets_in_use: []
 mit_opendata:
   source_kind: catalog
@@ -504,26 +482,29 @@ mit_opendata:
   base_url: https://dati.mit.gov.it/catalog/api/3/action/package_list?limit=1
   last_probed: '2026-06-22'
   verdict: go
-  note: "Portale CKAN MIT — 67 dataset su trasporti, infrastrutture, incidentalità,
+  note: 'Portale CKAN MIT — 67 dataset su trasporti, infrastrutture, incidentalità,
     veicoli, opere pubbliche. Include dataset già in uso dal Lab (mit_incidentalita_mensile,
-    mit_opere_incompiute).\n"
+    mit_opere_incompiute).
+
+    '
   datasets_in_use:
-    - mit_incidentalita_mensile
-    - mit_opere_incompiute_2020
+  - mit_incidentalita_mensile
+  - mit_opere_incompiute_2020
 openga:
   source_kind: catalog
   protocol: ckan
   observation_mode: catalog-watch
-  base_url:
-    https://openga.giustizia-amministrativa.it/api/3/action/package_list?limit=1
+  base_url: https://openga.giustizia-amministrativa.it/api/3/action/package_list?limit=1
   last_probed: '2026-06-22'
   verdict: go
-  note: "Portale CKAN Giustizia Amministrativa — ~270 dataset su ricorsi TAR+CDS,
+  note: 'Portale CKAN Giustizia Amministrativa — ~270 dataset su ricorsi TAR+CDS,
     sentenze, ordinanze, pareri. CC-BY 4.0. Aggiornamento mensile. Si incastra con
-    civile_flussi (giustizia ordinaria).\n"
+    civile_flussi (giustizia ordinaria).
+
+    '
   datasets_in_use:
-    - openga_ricorsi_appalto
-    - openga_ricorsi_cds
+  - openga_ricorsi_appalto
+  - openga_ricorsi_cds
 giustizia_statistiche:
   source_kind: catalog
   protocol: html
@@ -531,24 +512,26 @@ giustizia_statistiche:
   base_url: https://datiestatistiche.giustizia.it/
   last_probed: '2026-06-22'
   verdict: go
-  note: "Portale statistico Ministero Giustizia — XLSX scaricabili su flussi civili/penali,
+  note: 'Portale statistico Ministero Giustizia — XLSX scaricabili su flussi civili/penali,
     clearance rate, disposition time, sorveglianza, intercettazioni, monitoraggio
-    tribunali, durata procedimenti. Include dataset già in uso dal Lab.\n"
+    tribunali, durata procedimenti. Include dataset già in uso dal Lab.
+
+    '
   html_portal:
     topic_hint: giustizia
     area_pages:
-      - https://datiestatistiche.giustizia.it/page/it/flussi-tribunali-ordinari-e-corti-di-appello
-      - https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-civile
-      - https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-penale
-      - https://datiestatistiche.giustizia.it/it/sorveglianza.page
-      - https://datiestatistiche.giustizia.it/it/intercettazioni.page
-      - https://datiestatistiche.giustizia.it/page/it/durata-dei-procedimenti-civili
-      - https://datiestatistiche.giustizia.it/page/it/monitoraggio-mensile-dei-tribunal
+    - https://datiestatistiche.giustizia.it/page/it/flussi-tribunali-ordinari-e-corti-di-appello
+    - https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-civile
+    - https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-penale
+    - https://datiestatistiche.giustizia.it/it/sorveglianza.page
+    - https://datiestatistiche.giustizia.it/it/intercettazioni.page
+    - https://datiestatistiche.giustizia.it/page/it/durata-dei-procedimenti-civili
+    - https://datiestatistiche.giustizia.it/page/it/monitoraggio-mensile-dei-tribunal
     delay_seconds: 0.3
     probe_content_type: true
   datasets_in_use:
-    - civile_flussi
-    - giustizia_penale_indicatori
+  - civile_flussi
+  - giustizia_penale_indicatori
 cortecostituzionale:
   source_kind: catalog
   protocol: html
@@ -556,9 +539,11 @@ cortecostituzionale:
   base_url: https://dati.cortecostituzionale.it/Scarica_i_dati/Scarica_i_dati
   last_probed: '2026-06-22'
   verdict: go
-  note: "Portale Open Data Corte Costituzionale — Pronunce (1956-oggi), Massime, Anagrafica
+  note: 'Portale Open Data Corte Costituzionale — Pronunce (1956-oggi), Massime, Anagrafica
     Giudici, Atti di promovimento. CSV/XML/JSON in ZIP. Agg. giornaliero. Endpoint
-    SPARQL disponibile.\n"
+    SPARQL disponibile.
+
+    '
   html_portal:
     topic_hint: giustizia
     homepage: https://dati.cortecostituzionale.it/Scarica_i_dati/Scarica_i_dati
@@ -572,44 +557,46 @@ terna_opendata:
   base_url: https://dati.terna.it/
   last_probed: '2026-06-22'
   verdict: go
-  note: "Portale Dati Terna — API Sitecore REST. 31+ dataset su energia (fabbisogno,
+  note: 'Portale Dati Terna — API Sitecore REST. 31+ dataset su energia (fabbisogno,
     generazione, trasmissione, mercato, adeguatezza). API pubblica ritorna XLSX. Già
-    in uso da pipeline Lab. Catalog-watch richiederebbe connector custom.\n"
+    in uso da pipeline Lab. Catalog-watch richiederebbe connector custom.
+
+    '
   api_discovery:
     endpoint: https://dati.terna.it/api/sitecore/dati/downloadcenter/records
     known_datasets:
-      - TotalLoad
-      - MarketLoad
-      - PeakValleyLoad
-      - DailyDataIndexes
-      - InternationalComparisons
-      - IMCEI
-      - IMSER
-      - ElectricalEnergy
-      - Market
-      - IndustrialSector
-      - ServiceSector
-      - Total
-      - ConsumptionBySource
-      - ElectricityItaly
-      - ElectricityByType
-      - ActualGeneration
-      - RenewableGeneration
-      - EnergyBalance
-      - RenewableSources
-      - NonRenewableSources
-      - Storage
-      - ElectricityBySource
-      - ProductionRenewableSources
-      - HydroPower
-      - GrossVsCO2Emissions
-      - ProductionThermal
-      - ThermalHeat
-      - CapacityRenewableSources
-      - CapacityThermal
-      - GenerationPlants
+    - TotalLoad
+    - MarketLoad
+    - PeakValleyLoad
+    - DailyDataIndexes
+    - InternationalComparisons
+    - IMCEI
+    - IMSER
+    - ElectricalEnergy
+    - Market
+    - IndustrialSector
+    - ServiceSector
+    - Total
+    - ConsumptionBySource
+    - ElectricityItaly
+    - ElectricityByType
+    - ActualGeneration
+    - RenewableGeneration
+    - EnergyBalance
+    - RenewableSources
+    - NonRenewableSources
+    - Storage
+    - ElectricityBySource
+    - ProductionRenewableSources
+    - HydroPower
+    - GrossVsCO2Emissions
+    - ProductionThermal
+    - ThermalHeat
+    - CapacityRenewableSources
+    - CapacityThermal
+    - GenerationPlants
   datasets_in_use:
-    - terna_electricity_by_source
+  - terna_electricity_by_source
 ministero_interno:
   source_kind: catalog
   protocol: ckan
@@ -618,10 +605,6 @@ ministero_interno:
   inventory:
     fq: organization:ministero-dell-interno
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: package_search con
-      fq=organization:ministero-dell-interno restituisce 38 dataset con metadata
-      completi.
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-05-24'
@@ -629,14 +612,12 @@ ministero_interno:
     value: 38
     method: package_search
     reliability: high
-    note: Conteggio via package_search con
-      fq=organization:ministero-dell-interno su dati.gov.it. 38 dataset su
-      elezioni (per comune) e ANPR (popolazione).
+    note: Conteggio via package_search con fq=organization:ministero-dell-interno
+      su dati.gov.it. 38 dataset su elezioni (per comune) e ANPR (popolazione).
   verdict: go
-  note: Fonte via dati.gov.it. Dati elezioni (Politiche 2022, Comunali 2024,
-    Europee 2024, Regionali) per comune + ANPR (popolazione residente, cambi
-    residenza, certificati, AIRE). Alto valore civico per analisi territoriale
-    del voto.
+  note: Fonte via dati.gov.it. Dati elezioni (Politiche 2022, Comunali 2024, Europee
+    2024, Regionali) per comune + ANPR (popolazione residente, cambi residenza, certificati,
+    AIRE). Alto valore civico per analisi territoriale del voto.
   datasets_in_use: []
 agid:
   source_kind: catalog
@@ -646,10 +627,6 @@ agid:
   inventory:
     fq: organization:agenzia-per-l-italia-digitale
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: package_search con
-      fq=organization:agenzia-per-l-italia-digitale restituisce 40 dataset con
-      metadata completi.
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-05-24'
@@ -657,15 +634,14 @@ agid:
     value: 40
     method: package_search
     reliability: high
-    note: Conteggio via package_search con
-      fq=organization:agenzia-per-l-italia-digitale su dati.gov.it. 40 dataset
-      IPA (enti, PEC, domicili digitali, servizi, RTD).
+    note: Conteggio via package_search con fq=organization:agenzia-per-l-italia-digitale
+      su dati.gov.it. 40 dataset IPA (enti, PEC, domicili digitali, servizi, RTD).
   verdict: go
   note: 'Fonte via dati.gov.it. IPA — Indice delle PA: enti, unita organizzative,
     PEC, domicili digitali, responsabili transizione digitale, servizi digitali, fatturazione
     elettronica, cloud. Codice_IPA chiave di join con ANAC.'
   datasets_in_use:
-    - ipa_istat_mapping
+  - ipa_istat_mapping
 noipa_sparql:
   source_kind: catalog
   protocol: sparql
@@ -673,12 +649,11 @@ noipa_sparql:
   base_url: https://sparql-noipa.mef.gov.it/sparql
   last_probed: '2026-06-22'
   verdict: hold
-  note: NoiPA SPARQL — MEF/RGS. Dati mensili personale PA (entries-{YYYYMM},
-    2019-2026) + pensioni PA (entriesPensioni-{YYYYMM}, 2017-oggi). ~490k
-    soggetti/mese. L'endpoint risponde solo in XML
-    (application/sparql-results+xml). Inventory non funzionante finché
-    execute_sparql() in lab-connectors non supporta XML. Radar-only in attesa di
-    parser XML o di endpoint JSON.
+  note: NoiPA SPARQL — MEF/RGS. Dati mensili personale PA (entries-{YYYYMM}, 2019-2026)
+    + pensioni PA (entriesPensioni-{YYYYMM}, 2017-oggi). ~490k soggetti/mese. L'endpoint
+    risponde solo in XML (application/sparql-results+xml). Inventory non funzionante
+    finché execute_sparql() in lab-connectors non supporta XML. Radar-only in attesa
+    di parser XML o di endpoint JSON.
   datasets_in_use: []
 mimit_rna:
   source_kind: catalog
@@ -688,10 +663,6 @@ mimit_rna:
   inventory:
     fq: organization:ministero-delle-imprese-e-del-made-in-italy
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: package_search con
-      fq=organization:ministero-delle-imprese-e-del-made-in-italy restituisce
-      370 dataset (RNA Aiuti + RNA Misure) con metadata.
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-05-24'
@@ -699,9 +670,8 @@ mimit_rna:
     value: 370
     method: package_search
     reliability: high
-    note: Conteggio via package_search con
-      fq=organization:ministero-delle-imprese-e-del-made-in-italy su
-      dati.gov.it. 370 dataset (133 RNA Aiuti + 237 RNA Misure).
+    note: Conteggio via package_search con fq=organization:ministero-delle-imprese-e-del-made-in-italy
+      su dati.gov.it. 370 dataset (133 RNA Aiuti + 237 RNA Misure).
   verdict: go
   note: 'Fonte via dati.gov.it. RNA — Registro Nazionale Aiuti di Stato. 133 dataset
     mensili Aiuti (2017-2026, XML, ~14.500 record/mese) + 237 dataset Misure (1994-2023).
@@ -717,10 +687,6 @@ ministero_salute:
   inventory:
     fq: organization:ministero-della-salute
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: package_search con
-      fq=organization:ministero-della-salute restituisce 51 dataset con
-      metadata.
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-05-24'
@@ -728,10 +694,9 @@ ministero_salute:
     value: 51
     method: package_search
     reliability: high
-    note: Conteggio via package_search con
-      fq=organization:ministero-della-salute su dati.gov.it. 51 dataset
-      (farmacie, posti letto, personale SSN, dispositivi, ASL, fitosanitari).
-      URL raw su dati.salute.gov.it (portale in migrazione).
+    note: Conteggio via package_search con fq=organization:ministero-della-salute
+      su dati.gov.it. 51 dataset (farmacie, posti letto, personale SSN, dispositivi,
+      ASL, fitosanitari). URL raw su dati.salute.gov.it (portale in migrazione).
   verdict: go
   note: 'Fonte via dati.gov.it. Anagrafiche sanitarie nazionali: farmacie, parafarmacie,
     posti letto, personale SSN, ASL, dispositivi medici, fitosanitari. I file raw
@@ -739,10 +704,10 @@ ministero_salute:
     Complementare a dati_salute (csv_magnet) per il catalogo completo del portale
     diretto.'
   datasets_in_use:
-    - farmacie
-    - reparti_ricovero
-    - strutture_asl
-    - strutture_ricovero_asl
+  - farmacie
+  - reparti_ricovero
+  - strutture_asl
+  - strutture_ricovero_asl
 agcm:
   source_kind: catalog
   protocol: ckan
@@ -751,10 +716,6 @@ agcm:
   inventory:
     fq: organization:agcm
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: package_search con fq=organization:agcm
-      restituisce 53 dataset (rating legalita', concentrazioni). current_list
-      non necessario.
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-06-04'
@@ -762,12 +723,14 @@ agcm:
     value: 53
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:agcm su dati.gov.it.
-      53 dataset (rating di legalità, operazioni di concentrazione).
+    note: Conteggio via package_search con fq=organization:agcm su dati.gov.it. 53
+      dataset (rating di legalità, operazioni di concentrazione).
   verdict: go
-  note: "Fonte via dati.gov.it (AGCM). 53 dataset su concorrenza e mercato: rating
-    di legalita' (elenchi settimanali imprese con rating), operazioni di concentrazione
-    2021-2025.\n"
+  note: 'Fonte via dati.gov.it (AGCM). 53 dataset su concorrenza e mercato: rating
+    di legalita'' (elenchi settimanali imprese con rating), operazioni di concentrazione
+    2021-2025.
+
+    '
   datasets_in_use: []
 unioncamere:
   source_kind: catalog
@@ -775,14 +738,8 @@ unioncamere:
   observation_mode: catalog-watch
   base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
   inventory:
-    fq:
-      organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
+    fq: organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: package_search con
-      fq=organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
-      restituisce 352 dataset (imprese per provincia). current_list non
-      necessario.
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-06-04'
@@ -790,16 +747,17 @@ unioncamere:
     value: 352
     method: package_search
     reliability: high
-    note: Conteggio via package_search con
-      fq=organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
-      su dati.gov.it. 352 dataset provincia per provincia su demografia
-      d'impresa (natimortalità, femminili, giovanili, straniere, artigiane,
-      ATECO). ~340 provincia-specific, ~12 nazionali aggregati.
+    note: Conteggio via package_search con fq=organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
+      su dati.gov.it. 352 dataset provincia per provincia su demografia d'impresa
+      (natimortalità, femminili, giovanili, straniere, artigiane, ATECO). ~340 provincia-specific,
+      ~12 nazionali aggregati.
   verdict: go
-  note: "Fonte via dati.gov.it (Unioncamere). 352 dataset su demografia d'impresa
+  note: 'Fonte via dati.gov.it (Unioncamere). 352 dataset su demografia d''impresa
     per provincia: femminili, giovanili, straniere, artigiane, ATECO, forma giuridica.
     Dataset prevalentemente provincia-specifici (~340). ~12 dataset nazionali aggregati
-    (es. 'Italia - Imprese femminili...').\n"
+    (es. ''Italia - Imprese femminili...'').
+
+    '
   datasets_in_use: []
 pagopa:
   source_kind: catalog
@@ -809,9 +767,6 @@ pagopa:
   inventory:
     fq: organization:pagopa-s-p-a
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: package_search con fq=organization:pagopa-s-p-a
-      restituisce 8 dataset con metadata completi.
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-06-11'
@@ -819,8 +774,8 @@ pagopa:
     value: 8
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:pagopa-s-p-a su
-      dati.gov.it. 8 dataset (transazioni pagoPA, IO App, SEND).
+    note: Conteggio via package_search con fq=organization:pagopa-s-p-a su dati.gov.it.
+      8 dataset (transazioni pagoPA, IO App, SEND).
   verdict: go
   note: 'Fonte via dati.gov.it. 8 dataset: pagoPA (transazioni per anno, mese, fascia
     importo, categoria ente), IO App (messaggi, geografia enti e servizi), SEND (notifiche
@@ -835,9 +790,6 @@ aci:
   inventory:
     fq: organization:aci
     timeout: 180
-    skip_current_list: true
-    skip_current_list_reason: package_search con fq=organization:aci restituisce
-      35 dataset con metadata completi.
   last_probed: '2026-06-22'
   catalog_baseline:
     captured_at: '2026-06-11'

--- a/scripts/build_catalog_inventory.py
+++ b/scripts/build_catalog_inventory.py
@@ -25,7 +25,6 @@ from collectors.ckan import (
     collect as _collect_ckan_inventory,
 )
 from collectors.ckan import (
-    collect_ckan_inventory_via_current_list,
     collect_ckan_inventory_via_package_list,
     collect_ckan_inventory_via_package_show_sample,
     collect_ckan_inventory_via_search,
@@ -47,7 +46,6 @@ def collect_ckan_inventory(source_id: str, source_cfg: dict[str, Any], captured_
         source_cfg,
         captured_at,
         search_fn=collect_ckan_inventory_via_search,
-        current_list_fn=collect_ckan_inventory_via_current_list,
         package_list_fn=collect_ckan_inventory_via_package_list,
         package_show_sample_fn=collect_ckan_inventory_via_package_show_sample,
     )

--- a/scripts/collectors/ckan.py
+++ b/scripts/collectors/ckan.py
@@ -572,13 +572,16 @@ def _ckan_standard_path(
                 merged_rows.append(row)
             else:
                 merged_rows.append({**row, **enriched, "ordinal": row["ordinal"]})
-        return merged_rows, {
+        warn: dict[str, Any] = {
             "type": "package_list_with_package_show_sample",
             "message": f"Enrichment via package_show_sample per {source_id}.",
             "rows_enriched": len(enriched_by_id),
             "rows_missing_metadata": missing_metadata,
             "package_search_error": str(search_exc) if search_exc is not None else None,
         }
+        if sample_warning:
+            warn["package_show_sample_warning"] = sample_warning
+        return merged_rows, warn
 
     return package_list_rows, {
         "type": "fallback_package_list",

--- a/scripts/collectors/ckan.py
+++ b/scripts/collectors/ckan.py
@@ -337,89 +337,6 @@ def _fetch_ckan_chunk_with_fallback(
         current_limit = next_limit
 
 
-def collect_ckan_inventory_via_current_list(
-    source_id: str,
-    source_cfg: dict[str, Any],
-    captured_at: str,
-    *,
-    client: Any | None = None,
-) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    from lab_connectors.http import HttpClient
-
-    if client is None:
-        client = HttpClient(timeout=15, user_agent=USER_AGENT)
-    endpoint = ckan_action_endpoint(source_cfg["base_url"], "current_package_list_with_resources")
-    page_size = 100
-    fallback_page_sizes = (50, 10)
-    request_timeout = 15
-    max_retries = 2
-    retry_delay = 1.0
-    offset = 0
-    ordinal = 1
-    rows: list[dict[str, Any]] = []
-
-    while True:
-        payload, failure_reason, current_limit = _fetch_ckan_chunk_with_fallback(
-            endpoint,
-            {"offset": offset},
-            page_size,
-            client=client,
-            fallback_page_sizes=fallback_page_sizes,
-            request_timeout=request_timeout,
-            max_retries=max_retries,
-            retry_delay=retry_delay,
-        )
-        if payload is None:
-            if rows:
-                return rows, {
-                    "type": "partial_current_package_list_with_resources",
-                    "message": "Arricchimento parziale da current_package_list_with_resources; ultimi chunk in timeout dopo retry.",
-                    "failed_offset": offset,
-                    "failed_limit": current_limit,
-                    "rows_collected": len(rows),
-                    "failure": failure_reason,
-                }
-            raise requests.Timeout(
-                f"CKAN current_package_list_with_resources timed out for {source_id}: {failure_reason}"
-            )
-
-        if not payload.get("success"):
-            raise ValueError(f"CKAN current_package_list_with_resources failed for {source_id}")
-
-        result = payload.get("result")
-        if not isinstance(result, list):
-            raise ValueError(
-                f"Unexpected CKAN payload for {source_id}: current_package_list_with_resources result is not a list"
-            )
-        if not result:
-            break
-
-        for item in result:
-            rows.append(
-                extract_ckan_inventory_row(
-                    source_id=source_id,
-                    source_cfg=source_cfg,
-                    captured_at=captured_at,
-                    item=item,
-                    endpoint=endpoint,
-                    ordinal=ordinal,
-                    inventory_method="current_package_list_with_resources",
-                )
-            )
-            ordinal += 1
-
-        if len(result) < current_limit:
-            break
-        offset += len(result)
-        time.sleep(1.0)
-
-    if not rows:
-        raise ValueError(
-            f"CKAN current_package_list_with_resources returned no rows for {source_id}"
-        )
-    return rows, None
-
-
 def collect_ckan_inventory_via_package_list(
     source_id: str,
     source_cfg: dict[str, Any],
@@ -583,7 +500,6 @@ def collect(
     *,
     client: Any | None = None,
     search_fn=collect_ckan_inventory_via_search,
-    current_list_fn=collect_ckan_inventory_via_current_list,
     package_list_fn=collect_ckan_inventory_via_package_list,
     package_show_sample_fn=collect_ckan_inventory_via_package_show_sample,
 ) -> CollectorResult:
@@ -599,7 +515,6 @@ def collect(
         inv=inv,
         client=client,
         search_fn=search_fn,
-        current_list_fn=current_list_fn,
         package_list_fn=package_list_fn,
         package_show_sample_fn=package_show_sample_fn,
     )
@@ -614,13 +529,15 @@ def _ckan_standard_path(
     *,
     client: Any | None = None,
     search_fn,
-    current_list_fn,
     package_list_fn,
     package_show_sample_fn,
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    """Ramo standard: package_search -> fallback package_list -> current_list.
+    """Ramo standard: package_search -> fallback package_list (+ package_show_sample).
 
-    Tutte le funzioni di inventory ricevono il client condiviso per connection pooling.
+    1. Prova package_search (se non skip_package_search)
+    2. Fallback: package_list (ID nudi)
+    3. Se package_show_sample configurato: arricchisce con package_show
+    4. Altrimenti: usa package_list così com'è
     """
     search_exc: Exception | None = None
 
@@ -629,80 +546,44 @@ def _ckan_standard_path(
             rows = search_fn(source_id, source_cfg, captured_at, client=client)
             return rows, None
         except Exception as exc:
-            search_exc = exc  # per debug
+            search_exc = exc
     else:
         search_exc = ValueError(
             f"CKAN package_search disabled for {source_id} ({inv.get('skip_package_search_reason', 'disabled by registry config')})."
         )
 
     package_list_rows = package_list_fn(source_id, source_cfg, captured_at, client=client)
-    if inv.get("skip_current_list"):
-        if inv.get("package_show_sample"):
-            enriched_rows, sample_warning = package_show_sample_fn(
-                source_id=source_id,
-                source_cfg=source_cfg,
-                captured_at=captured_at,
-                package_list_rows=package_list_rows,
-                sample_size=inv.get("sample_size", 25),
-            )
-            enriched_by_id = {row["item_id"]: row for row in enriched_rows}
-            merged_rows: list[dict[str, Any]] = []
-            missing_metadata = 0
-            for row in package_list_rows:
-                enriched = enriched_by_id.get(row["item_id"])
-                if enriched is None:
-                    missing_metadata += 1
-                    merged_rows.append(row)
-                else:
-                    merged_rows.append({**row, **enriched, "ordinal": row["ordinal"]})
-            warn: dict[str, Any] = {
-                "type": "skip_current_package_list_with_package_show_sample",
-                "message": f"current_package_list_with_resources disabilitato per {source_id}; applicato enrich sample via package_show.",
-                "rows_enriched": len(enriched_by_id),
-                "rows_missing_metadata": missing_metadata,
-            }
-            if sample_warning:
-                warn["package_show_sample_warning"] = sample_warning
-            return merged_rows, warn
-        return package_list_rows, {
-            "type": "skip_current_package_list",
-            "message": f"Enrichment current_package_list_with_resources disabilitato per {source_id} (instabilita SSL/GIL in ambiente locale).",
-        }
 
-    time.sleep(1.0)
-    try:
-        # current_list ha timeout 15s proprio — non passare il client condiviso
-        # (creato con timeout 60s) per non alterare il comportamento di retry
-        current_rows, current_warning = current_list_fn(source_id, source_cfg, captured_at)
-        enriched_by_id = {row["item_id"]: row for row in current_rows}
-        fallback_merged_rows: list[dict[str, Any]] = []
+    if inv.get("package_show_sample"):
+        enriched_rows, sample_warning = package_show_sample_fn(
+            source_id=source_id,
+            source_cfg=source_cfg,
+            captured_at=captured_at,
+            package_list_rows=package_list_rows,
+            sample_size=inv.get("sample_size", 25),
+        )
+        enriched_by_id = {row["item_id"]: row for row in enriched_rows}
+        merged_rows: list[dict[str, Any]] = []
         missing_metadata = 0
         for row in package_list_rows:
             enriched = enriched_by_id.get(row["item_id"])
             if enriched is None:
                 missing_metadata += 1
-                fallback_merged_rows.append(row)
+                merged_rows.append(row)
             else:
-                fallback_merged_rows.append({**row, **enriched, "ordinal": row["ordinal"]})
-
-        fallback_warning: dict[str, Any] = {
-            "type": "fallback_current_package_list_with_resources",
-            "message": "Fallback da package_search a current_package_list_with_resources.",
-            "package_search_error": str(search_exc)
-            if search_exc is not None
-            else "package_search skipped",
+                merged_rows.append({**row, **enriched, "ordinal": row["ordinal"]})
+        return merged_rows, {
+            "type": "package_list_with_package_show_sample",
+            "message": f"Enrichment via package_show_sample per {source_id}.",
             "rows_enriched": len(enriched_by_id),
             "rows_missing_metadata": missing_metadata,
+            "package_search_error": str(search_exc) if search_exc is not None else None,
         }
-        if current_warning:
-            fallback_warning["current_list_warning"] = current_warning
-        return fallback_merged_rows, fallback_warning
-    except Exception as current_list_exc:
-        return package_list_rows, {
-            "type": "fallback_package_list",
-            "message": "Fallback finale a package_list dopo fallimento di package_search e current_package_list_with_resources.",
-            "package_search_error": str(search_exc)
-            if search_exc is not None
-            else "package_search skipped",
-            "current_list_error": str(current_list_exc),
-        }
+
+    return package_list_rows, {
+        "type": "fallback_package_list",
+        "message": "Fallback a package_list dopo fallimento di package_search.",
+        "package_search_error": str(search_exc)
+        if search_exc is not None
+        else "package_search skipped",
+    }

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -11,113 +11,13 @@ from lab_connectors.testing import FakeHttpClient, fake_response
 pytestmark = pytest.mark.contract
 
 
-def test_collect_ckan_inventory_merges_current_list_metadata(monkeypatch) -> None:
-    source_cfg = {
-        "base_url": "https://example.test/api/3/action/package_search",
-        "source_kind": "catalog",
-        "protocol": "ckan",
-        "catalog_baseline": {"method": "package_list"},
-    }
-
-    def fake_search(*_args, **_kwargs):
-        raise ValueError("package_search rotto")
-
-    def fake_package_list(source_id, source_cfg, captured_at, **kwargs):
-        return [
-            {
-                "captured_at": captured_at,
-                "source_id": source_id,
-                "source_kind": source_cfg.get("source_kind"),
-                "protocol": source_cfg.get("protocol"),
-                "inventory_method": "package_list",
-                "item_kind": "dataset",
-                "item_id": "1",
-                "item_name": "1",
-                "title": None,
-                "organization": None,
-                "tags": None,
-                "notes_excerpt": None,
-                "source_url": "https://example.test/api/3/action/package_list",
-                "ordinal": 1,
-            },
-            {
-                "captured_at": captured_at,
-                "source_id": source_id,
-                "source_kind": source_cfg.get("source_kind"),
-                "protocol": source_cfg.get("protocol"),
-                "inventory_method": "package_list",
-                "item_kind": "dataset",
-                "item_id": "2",
-                "item_name": "2",
-                "title": None,
-                "organization": None,
-                "tags": None,
-                "notes_excerpt": None,
-                "source_url": "https://example.test/api/3/action/package_list",
-                "ordinal": 2,
-            },
-        ]
-
-    def fake_current_list(source_id, source_cfg, captured_at, **kwargs):
-        return (
-            [
-                {
-                    "captured_at": captured_at,
-                    "source_id": source_id,
-                    "source_kind": source_cfg.get("source_kind"),
-                    "protocol": source_cfg.get("protocol"),
-                    "inventory_method": "current_package_list_with_resources",
-                    "item_kind": "dataset",
-                    "item_id": "1",
-                    "item_name": "pkg-one",
-                    "title": "Package One",
-                    "organization": "Demo Org",
-                    "tags": "alpha, beta",
-                    "notes_excerpt": "note",
-                    "source_url": "https://example.test/api/3/action/current_package_list_with_resources",
-                    "ordinal": 99,
-                }
-            ],
-            None,
-        )
-
-    monkeypatch.setattr(build_catalog_inventory, "collect_ckan_inventory_via_search", fake_search)
-    monkeypatch.setattr(
-        build_catalog_inventory,
-        "collect_ckan_inventory_via_package_list",
-        fake_package_list,
-    )
-    monkeypatch.setattr(
-        build_catalog_inventory,
-        "collect_ckan_inventory_via_current_list",
-        fake_current_list,
-    )
-    monkeypatch.setattr(collectors.ckan.time, "sleep", lambda _seconds: None)
-
-    rows, warning = build_catalog_inventory.collect_ckan_inventory(
-        "demo", source_cfg, "2026-04-09T12:00:00+00:00"
-    )
-
-    assert [row["ordinal"] for row in rows] == [1, 2]
-    assert rows[0]["item_id"] == "1"
-    assert rows[0]["title"] == "Package One"
-    assert rows[0]["organization"] == "Demo Org"
-    assert rows[1]["item_id"] == "2"
-    assert rows[1]["title"] is None
-
-    assert warning is not None
-    assert warning["type"] == "fallback_current_package_list_with_resources"
-    assert warning["rows_enriched"] == 1
-    assert warning["rows_missing_metadata"] == 1
-
-
-def test_collect_ckan_inventory_skips_current_list_for_inps(monkeypatch) -> None:
+def test_collect_ckan_inventory_via_package_show_sample(monkeypatch) -> None:
     source_cfg = {
         "base_url": "https://www.inps.it/odapi/api/3/action/package_search",
         "source_kind": "catalog",
         "protocol": "ckan",
         "catalog_baseline": {"method": "package_list"},
-        "inventory": {"skip_current_list": True, "package_show_sample": True, "sample_size": 25},
+        "inventory": {"package_show_sample": True, "sample_size": 25},
     }
 
     def fake_search(*_args, **_kwargs):
@@ -143,9 +43,6 @@ def test_collect_ckan_inventory_skips_current_list_for_inps(monkeypatch) -> None
             }
         ]
 
-    def fail_if_called(*_args, **_kwargs):
-        raise AssertionError("current list non dovrebbe essere chiamato per INPS")
-
     def fake_package_show_sample(*_args, **_kwargs):
         return ([], None)
 
@@ -154,11 +51,6 @@ def test_collect_ckan_inventory_skips_current_list_for_inps(monkeypatch) -> None
         build_catalog_inventory,
         "collect_ckan_inventory_via_package_list",
         fake_package_list,
-    )
-    monkeypatch.setattr(
-        build_catalog_inventory,
-        "collect_ckan_inventory_via_current_list",
-        fail_if_called,
     )
     monkeypatch.setattr(
         build_catalog_inventory,
@@ -174,7 +66,7 @@ def test_collect_ckan_inventory_skips_current_list_for_inps(monkeypatch) -> None
     assert rows[0]["item_id"] == "544"
     assert rows[0]["title"] is None
     assert warning is not None
-    assert warning["type"] == "skip_current_package_list_with_package_show_sample"
+    assert warning["type"] == "package_list_with_package_show_sample"
     assert warning["rows_enriched"] == 0
 
 
@@ -244,9 +136,6 @@ def test_collect_ckan_inventory_inps_enriches_with_package_show_sample(monkeypat
             None,
         )
 
-    def fail_if_called(*_args, **_kwargs):
-        raise AssertionError("current list non dovrebbe essere chiamato per INPS")
-
     monkeypatch.setattr(build_catalog_inventory, "collect_ckan_inventory_via_search", fake_search)
     monkeypatch.setattr(
         build_catalog_inventory,
@@ -257,11 +146,6 @@ def test_collect_ckan_inventory_inps_enriches_with_package_show_sample(monkeypat
         build_catalog_inventory,
         "collect_ckan_inventory_via_package_show_sample",
         fake_package_show_sample,
-    )
-    monkeypatch.setattr(
-        build_catalog_inventory,
-        "collect_ckan_inventory_via_current_list",
-        fail_if_called,
     )
 
     rows, warning = build_catalog_inventory.collect_ckan_inventory(
@@ -274,7 +158,7 @@ def test_collect_ckan_inventory_inps_enriches_with_package_show_sample(monkeypat
     assert rows[1]["item_id"] == "545"
     assert rows[1]["title"] is None
     assert warning is not None
-    assert warning["type"] == "skip_current_package_list_with_package_show_sample"
+    assert warning["type"] == "package_list_with_package_show_sample"
     assert warning["rows_enriched"] == 1
     assert warning["rows_missing_metadata"] == 1
 

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -133,7 +133,12 @@ def test_collect_ckan_inventory_inps_enriches_with_package_show_sample(monkeypat
                     "ordinal": 99,
                 }
             ],
-            None,
+            {
+                "type": "partial_package_show_sample",
+                "errors_preview": 1,
+                "enriched_count": 1,
+                "total_requests": 2,
+            },
         )
 
     monkeypatch.setattr(build_catalog_inventory, "collect_ckan_inventory_via_search", fake_search)
@@ -161,6 +166,10 @@ def test_collect_ckan_inventory_inps_enriches_with_package_show_sample(monkeypat
     assert warning["type"] == "package_list_with_package_show_sample"
     assert warning["rows_enriched"] == 1
     assert warning["rows_missing_metadata"] == 1
+    # Verifica che il sample_warning sia propagato
+    assert warning["package_show_sample_warning"]["type"] == "partial_package_show_sample"
+    assert warning["package_show_sample_warning"]["errors_preview"] == 1
+    assert warning["package_show_sample_warning"]["enriched_count"] == 1
 
 
 def test_ckan_get_json_reports_non_json_response(monkeypatch) -> None:


### PR DESCRIPTION
## Sintesi

Rimuove `collect_ckan_inventory_via_current_list()` — 78 righe morte (nessuna fonte attiva la usava). Semplifica `_ckan_standard_path()` da 5 a 3 casi.

## Cosa cambia

| Prima | Dopo |
|---|---|
| 4 strategie: search → list → current_list → show_sample | 2 strategie: search → list + show_sample |
| `skip_current_list` nella registry (tutte 14 fonti CKAN) | Non serve più |
| CONSiP (16 item) e openGA (436 item): solo ID nudi da `package_list` | Ora **metadata completi** via `package_search` |

## Test

- **pytest**: 410/410 pass
- **CONSiP**: `package_search` 16 item con title/format ✅
- **openGA**: `package_search` 436 item con title/format (SSL fallback) ✅
- **openbdap**: `package_list + package_show_sample` 3825 item ✅
- **INPS**: `package_list + package_show_sample` 2323 item ✅

## Metriche

- **-269 righe** nette (177 in ckan.py, 2 in build_catalog_inventory.py, 90 nei test)
- **1 funzione** eliminata (`collect_ckan_inventory_via_current_list`)
- Zero impatto sulle fonti attive (test reali confermati)