### PR TITLE
fix: migra mit_opendata da dati.mit.gov.it (down) a dati.gov.it

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -479,17 +479,26 @@ mit_opendata:
   source_kind: catalog
   protocol: ckan
   observation_mode: catalog-watch
-  base_url: https://dati.mit.gov.it/catalog/api/3/action/package_list?limit=1
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
   last_probed: '2026-06-22'
   verdict: go
-  note: 'Portale CKAN MIT — 67 dataset su trasporti, infrastrutture, incidentalità,
-    veicoli, opere pubbliche. Include dataset già in uso dal Lab (mit_incidentalita_mensile,
-    mit_opere_incompiute).
-
-    '
+  note: 'Dataset del Ministero Infrastrutture e Trasporti via dati.gov.it (portale
+    MIT dati.mit.gov.it non raggiungibile da 2026-05). 70 dataset: contratti pubblici,
+    incidentalità, trasporti, opere pubbliche. CC-BY-4.0.'
   datasets_in_use:
   - mit_incidentalita_mensile
   - mit_opere_incompiute_2020
+  inventory:
+    fq: organization:ministero-infrastrutture-e-trasporti
+    timeout: 180
+  catalog_baseline:
+    captured_at: '2026-06-22'
+    metric: dataset_count
+    value: 70
+    method: package_search
+    reliability: high
+    note: Conteggio via package_search con fq=organization:ministero-infrastrutture-e-trasporti
+      su dati.gov.it.
 openga:
   source_kind: catalog
   protocol: ckan


### PR DESCRIPTION
## Sintesi

Migra `mit_opendata` da `dati.mit.gov.it` (HTTP 500 da 4 settimane) a `dati.gov.it` come `organization:ministero-infrastrutture-e-trasporti`.

70 dataset: contratti pubblici (SCP), incidentalità stradale, trasporti, opere pubbliche. CC-BY-4.0.

## Cosa cambia

| Prima | Dopo |
|---|---|
| `base_url: dati.mit.gov.it/...` (500) | `base_url: dati.gov.it/opendata/...` (200) |
| Nessun inventory config | `package_search` con `fq=organization:ministero-infrastrutture-e-trasporti` |
| 67 dataset (da baseline vecchia) | 70 dataset (baseline nuova via package_search) |

## Test

- `collect_ckan_inventory('mit_opendata', ...)` → 70 rows con metadati completi ✅
- Primo risultato: "Banca dati Servizio Contratti Pubblici - SCP" (formati: csv, json)

## Note

I dataset esistenti (`mit_incidentalita_mensile`, `mit_opere_incompiute_2020`) hanno URL che puntano ancora a `dati.mit.gov.it` nei loro `dataset.yml`. Il source-check tenterà il download e fallirà. Per sbloccare i dati serve migrare gli URL al dump DataStore di dati.gov.it (stessa resource_id, DataStore attivo).