### PR TITLE
chore: bump toolkit from v1.38.1 to v1.40.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.38.1",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.40.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Sintesi

Bump della dipendenza toolkit da v1.38.1 a v1.40.0.

## Cosa cambia

- `pyproject.toml`: `@v1.38.1` → `@v1.40.0`

## Verifica

```bash
python -m pytest tests/test_integration_toolkit_scout.py -v
# 5 passed in 8.55s
```

Tra v1.38.1 e v1.40.0 l'unica modifica a `toolkit/scout/` è un fix mypy (`resp.close()` → `getattr`). Nessun API change. `toolkit/profile/` invariato.

## Checklist

- [x] Test di integrazione SO↔toolkit passano
- [x] Nessun API change nelle funzioni importate da SO