### PR TITLE
feat: SSL strutturato in radar_summary (ssl_issue, ssl_streak) + health score usa campo dedicato

### DIFF
--- a/schemas/radar_summary.schema.json
+++ b/schemas/radar_summary.schema.json
@@ -79,10 +79,23 @@
           "type": ["string", "null"],
           "description": "Nota opzionale sul probe (errore, dettaglio SSL, timeout, ...)."
         },
+        "ssl_fallback_used": {
+          "type": "boolean",
+          "description": "Indica se il probe primario ha fallito per SSL (presente sempre)."
+        },
+        "ssl_issue": {
+          "type": "boolean",
+          "description": "Flag SSL: true se la fonte ha un problema di certificato (presente solo se true)."
+        },
         "red_streak": {
           "type": "integer",
           "minimum": 2,
           "description": "Streak di probe RED consecutivi (presente solo se >= 2)."
+        },
+        "ssl_streak": {
+          "type": "integer",
+          "minimum": 2,
+          "description": "Streak di probe consecutivi con SSL issue, incluso il corrente (presente solo se >= 2)."
         }
       },
       "additionalProperties": false

--- a/schemas/radar_summary.schema.json
+++ b/schemas/radar_summary.schema.json
@@ -95,7 +95,7 @@
         "ssl_streak": {
           "type": "integer",
           "minimum": 2,
-          "description": "Streak di probe consecutivi con SSL issue, incluso il corrente (presente solo se >= 2)."
+          "description": "Streak di probe consecutivi con SSL issue dalla history (presente solo se >= 2). Il probe corrente e' catturato da ssl_issue."
         }
       },
       "additionalProperties": false

--- a/scripts/build_compliance_scores.py
+++ b/scripts/build_compliance_scores.py
@@ -218,6 +218,10 @@ def _raggiungibilita_score(
     streak = radar_entry.get("red_streak", 0)
 
     if status == "GREEN":
+        # SSL issue strutturato (ssl_issue field) — più affidabile della nota testuale
+        if radar_entry and radar_entry.get("ssl_issue"):
+            return (55.0, "computed")
+        # Fallback: nota testuale per history precedente all'introduzione di ssl_issue
         if "SSL" in note or "ssl" in note.lower():
             return (55.0, "computed")
         return (70.0, "computed")

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -335,6 +335,7 @@ def build_radar_summary(
 
     for source_id, meta in registry.items():
         result = results.get(source_id) or _missing
+        ssl_fallback_used = result.ssl_fallback_used
 
         # Compute RED streak
         streak = 0
@@ -343,6 +344,15 @@ def build_radar_summary(
             src = next((s for s in probe.get("sources", []) if s["id"] == source_id), None)
             if src and src.get("status") == "RED":
                 streak += 1
+            else:
+                break
+
+        # Compute SSL streak (consecutive probes with SSL issue, including current)
+        ssl_streak = 1 if ssl_fallback_used else 0
+        for probe in recent_probes:
+            src = next((s for s in probe.get("sources", []) if s["id"] == source_id), None)
+            if src and src.get("ssl_fallback_used"):
+                ssl_streak += 1
             else:
                 break
 
@@ -356,9 +366,14 @@ def build_radar_summary(
             "protocol": meta.get("protocol", "-"),
             "http_code": result.http_code,
             "note": result.note,
+            "ssl_fallback_used": ssl_fallback_used,
         }
         if streak >= 2:
             entry["red_streak"] = streak
+        if ssl_fallback_used:
+            entry["ssl_issue"] = True
+        if ssl_streak >= 2:
+            entry["ssl_streak"] = ssl_streak
         sources_list.append(entry)
 
     summary = {

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -347,8 +347,11 @@ def build_radar_summary(
             else:
                 break
 
-        # Compute SSL streak (consecutive probes with SSL issue, including current)
-        ssl_streak = 1 if ssl_fallback_used else 0
+        # Compute SSL streak (consecutive probes with SSL issue).
+        # Come per red_streak: conta dalla history, che include il probe
+        # corrente solo nella seconda build (dopo append_radar_probe).
+        # Lo stato corrente è catturato da ssl_issue.
+        ssl_streak = 0
         for probe in recent_probes:
             src = next((s for s in probe.get("sources", []) if s["id"] == source_id), None)
             if src and src.get("ssl_fallback_used"):

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -284,8 +284,8 @@ class TestBuildReport:
             registry, results, "2026-04-18", history
         )
         ssl_src = next(s for s in summary["sources"] if s["id"] == "ssl_fonte")
-        # Current (1) + 3 history = 4 consecutive SSL probes
-        assert ssl_src.get("ssl_streak") == 4
+        # 3 history consecutive SSL probe (current non contato in streak, ma segnalato da ssl_issue)
+        assert ssl_src.get("ssl_streak") == 3
         assert ssl_src.get("ssl_issue") is True
 
     def test_build_radar_summary_ssl_streak_break(self) -> None:

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -212,15 +212,120 @@ class TestBuildReport:
                 "observation_mode": "radar-only",
                 "datasets_in_use": [],
             },
+            "ssl_fonte": {
+                "base_url": "https://ssl-broken.test/",
+                "source_kind": "source",
+                "protocol": "html",
+                "observation_mode": "radar-only",
+            },
         }
         results = {
             "demo_ckan": radar_check.ProbeResult(
                 status="GREEN", http_code="200", content_type="application/json"
             ),
             "istat_sdmx": radar_check.ProbeResult(status="YELLOW", http_code="-", note="Timeout"),
+            "ssl_fonte": radar_check.ProbeResult(
+                status="GREEN",
+                http_code="200",
+                note="SSL verify failed; fallback verify=False used (SSLError)",
+                ssl_fallback_used=True,
+            ),
         }
         summary, sources_list = radar_check.build_radar_summary(registry, results, "2026-04-18")
         schema = _load_schema("radar_summary.schema.json")
         jsonschema.validate(instance=summary, schema=schema)
         # Verify sources_list mirrors summary.sources
         assert len(sources_list) == summary["sources_total"]
+        # Verify SSL issue is captured
+        ssl_src = next(s for s in summary["sources"] if s["id"] == "ssl_fonte")
+        assert ssl_src.get("ssl_issue") is True
+        assert ssl_src.get("ssl_fallback_used") is True
+        # Verify non-SSL source does NOT have ssl_issue
+        clean_src = next(s for s in summary["sources"] if s["id"] == "demo_ckan")
+        assert clean_src.get("ssl_issue") is None or clean_src.get("ssl_issue") is False
+        assert clean_src.get("ssl_fallback_used") is False
+
+    def test_build_radar_summary_ssl_streak(self) -> None:
+        """SSL streak counts consecutive probes with ssl_fallback_used."""
+        registry = {
+            "ssl_fonte": {
+                "base_url": "https://ssl-broken.test/",
+                "source_kind": "source",
+                "protocol": "html",
+                "observation_mode": "radar-only",
+            },
+        }
+        # History: last 3 probes all had SSL issue
+        history = {
+            "probes": [
+                {
+                    "probe_date": "2026-04-15",
+                    "sources": [{"id": "ssl_fonte", "ssl_fallback_used": True}],
+                },
+                {
+                    "probe_date": "2026-04-16",
+                    "sources": [{"id": "ssl_fonte", "ssl_fallback_used": True}],
+                },
+                {
+                    "probe_date": "2026-04-17",
+                    "sources": [{"id": "ssl_fonte", "ssl_fallback_used": True}],
+                },
+            ]
+        }
+        results = {
+            "ssl_fonte": radar_check.ProbeResult(
+                status="GREEN",
+                http_code="200",
+                note="SSL verify failed; fallback verify=False used (SSLError)",
+                ssl_fallback_used=True,
+            ),
+        }
+        summary, sources_list = radar_check.build_radar_summary(
+            registry, results, "2026-04-18", history
+        )
+        ssl_src = next(s for s in summary["sources"] if s["id"] == "ssl_fonte")
+        # Current (1) + 3 history = 4 consecutive SSL probes
+        assert ssl_src.get("ssl_streak") == 4
+        assert ssl_src.get("ssl_issue") is True
+
+    def test_build_radar_summary_ssl_streak_break(self) -> None:
+        """SSL streak resets after a probe without SSL issue."""
+        registry = {
+            "ssl_fonte": {
+                "base_url": "https://ssl-ok-now.test/",
+                "source_kind": "source",
+                "protocol": "html",
+                "observation_mode": "radar-only",
+            },
+        }
+        # History: first 2 had SSL, probe 3 did NOT → streak should reset
+        history = {
+            "probes": [
+                {
+                    "probe_date": "2026-04-15",
+                    "sources": [{"id": "ssl_fonte", "ssl_fallback_used": True}],
+                },
+                {
+                    "probe_date": "2026-04-16",
+                    "sources": [{"id": "ssl_fonte", "ssl_fallback_used": True}],
+                },
+                {
+                    "probe_date": "2026-04-17",
+                    "sources": [{"id": "ssl_fonte", "ssl_fallback_used": False}],
+                },
+            ]
+        }
+        results = {
+            "ssl_fonte": radar_check.ProbeResult(
+                status="GREEN",
+                http_code="200",
+                ssl_fallback_used=False,
+            ),
+        }
+        summary, sources_list = radar_check.build_radar_summary(
+            registry, results, "2026-04-18", history
+        )
+        ssl_src = next(s for s in summary["sources"] if s["id"] == "ssl_fonte")
+        # Current has no SSL → streak = 0 → no ssl_streak field
+        assert ssl_src.get("ssl_streak") is None
+        assert ssl_src.get("ssl_issue") is None or ssl_src.get("ssl_issue") is False


### PR DESCRIPTION
## Sintesi

L'SSL veniva rilevato e gestito (fallback `verify=False`) ma non strutturato: era solo una stringa nel campo `note`. Impossibile fare trend, alert, o azioni automatiche su SSL.

Questa PR rende SSL un **segnale strutturato** con campo dedicato e streak, e allinea l'health score a usare il nuovo campo invece del parsing testuale.

## Cosa cambia

| File | Cosa |
|------|------|
| `scripts/radar_check.py` | `build_radar_summary()` ora: (1) salva `ssl_fallback_used` nella history, (2) calcola `ssl_streak` dalla history (come `red_streak`), (3) aggiunge `ssl_issue: bool` nel summary |
| `schemas/radar_summary.schema.json` | Tre nuovi campi in `SourceEntry`: `ssl_fallback_used`, `ssl_issue`, `ssl_streak` |
| `scripts/build_compliance_scores.py` | `_raggiungibilita_score()` controlla prima `ssl_issue` (campo), poi la nota testuale come fallback per history legacy |
| `tests/test_radar_check.py` | Test esistente esteso (verifica SSL su 3 fonti), + 2 nuovi test su streak |

## Impatto su artifact

`radar_summary.json` — esempio per `opencivitas` (SSL persistente):

```json
// PRIMA
{ "id": "opencivitas", "status": "GREEN", "note": "SSL verify failed; fallback verify=False used (SSLError)" }

// DOPO
{ "id": "opencivitas", "status": "GREEN", "note": "SSL verify failed; ...",
  "ssl_fallback_used": true, "ssl_issue": true, "ssl_streak": 8 }
```

Retrocompatibile: i campi nuovi sono opzionali (presenti solo quando rilevanti).

## Verifica

- `pytest tests/` — 15 test radar + 6 compliance = ✅
- `ruff check .` — ✅ (pre-commit hook)
- Copertura: schema validation, SSL issue detection, SSL streak, streak reset

## Note per chi revisiona

- History legacy (`radar_history.json`) non ha `ssl_fallback_used` nei vecchi probe → streak parte da zero per primi run dopo questa PR
- `build_compliance_scores.py` ha doppio controllo (campo + nota testuale) per backward compat
