### PR TITLE
feat: health score con source_check integrato, minimo degli assi, flag urgenza + fix NaN SDMX

### DIFF
--- a/scripts/build_compliance_scores.py
+++ b/scripts/build_compliance_scores.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 from _constants import (
     CATALOG_SIGNALS_PATH,
+    CHECK_PARQUET_PATH,
     INVENTORY_PARQUET_PATH,
     OPEN_DATA_HEALTH_SCORES_PATH,
     RADAR_SUMMARY_PATH,
@@ -37,6 +38,7 @@ DEFAULT_RADAR = RADAR_SUMMARY_PATH
 DEFAULT_SIGNALS = CATALOG_SIGNALS_PATH
 DEFAULT_REGISTRY = REGISTRY_PATH
 DEFAULT_INVENTORY = INVENTORY_PARQUET_PATH
+DEFAULT_SOURCE_CHECK = CHECK_PARQUET_PATH
 DEFAULT_OUT = OPEN_DATA_HEALTH_SCORES_PATH
 
 # Pesi per ogni asse
@@ -149,6 +151,63 @@ def _load_inventory_license_stats(path: Path) -> dict[str, dict]:
         return stats
     except Exception as exc:
         print(f"⚠️  Inventory licenza non elaborabile: {exc}")
+        return {}
+
+
+def _load_source_check_stats(path: Path) -> dict[str, dict]:
+    """Legge source_check_results.parquet e aggrega per fonte.
+
+    Restituisce dict: source_id → {
+        "total": N,
+        "reachable": N,
+        "circuit_open": N,
+        "formato_aperto": N,   # CSV/JSON/XML
+        "formato_chiuso": N,   # XLSX/XLS/PDF/ZIP
+        "formato_ignoto": N,
+        "perc_reachable": 0-100,
+        "perc_aperto": 0-100,  # su total (formato_chiuso conta come non aperto)
+    }.
+
+    Per fonti senza source-check, il source_id non e' presente.
+    """
+    if not path.exists():
+        return {}
+
+    try:
+        import duckdb
+
+        con = duckdb.connect()
+        rows = con.execute(
+            """
+            SELECT source_id,
+                   COUNT(*) as total,
+                   SUM(CASE WHEN reachable THEN 1 ELSE 0 END) as reachable,
+                   SUM(CASE WHEN check_notes = 'circuit_open' THEN 1 ELSE 0 END) as circuit_open,
+                   SUM(CASE WHEN resource_format IN ('CSV', 'JSON', 'XML') THEN 1 ELSE 0 END) as formato_aperto,
+                   SUM(CASE WHEN resource_format IN ('XLSX', 'XLS', 'PDF', 'ZIP') THEN 1 ELSE 0 END) as formato_chiuso,
+                   SUM(CASE WHEN resource_format IS NULL OR resource_format = '' THEN 1 ELSE 0 END) as formato_ignoto
+            FROM '"""
+            + str(path)
+            + """'
+            GROUP BY source_id
+        """
+        ).fetchall()
+        stats = {}
+        for sid, total, reachable, copen, fap, fchiuso, fignoto in rows:
+            t = int(total)
+            stats[sid] = {
+                "total": t,
+                "reachable": int(reachable),
+                "circuit_open": int(copen),
+                "formato_aperto": int(fap),
+                "formato_chiuso": int(fchiuso),
+                "formato_ignoto": int(fignoto),
+                "perc_reachable": round(int(reachable) / t * 100, 1) if t > 0 else 0.0,
+                "perc_aperto": round(int(fap) / t * 100, 1) if t > 0 else 0.0,
+            }
+        return stats
+    except Exception as exc:
+        print(f"⚠️  Source-check parquet non elaborabile: {exc}")
         return {}
 
 
@@ -286,6 +345,7 @@ def build_scores(
     signals_data: dict | None,
     inventory_stats: dict | None = None,
     license_stats: dict | None = None,
+    source_check_stats: dict | None = None,
 ) -> dict:
     """Calcola health score per ogni fonte nel registry."""
     radar_by_id: dict[str, dict] = {s["id"]: s for s in radar_sources}
@@ -414,6 +474,12 @@ def main() -> None:
         help="Path a catalog_inventory_latest.parquet",
     )
     parser.add_argument(
+        "--source-check",
+        default=DEFAULT_SOURCE_CHECK,
+        type=Path,
+        help="Path a source_check_results.parquet",
+    )
+    parser.add_argument(
         "--out",
         default=DEFAULT_OUT,
         type=Path,
@@ -434,8 +500,16 @@ def main() -> None:
 
     inventory_stats = _load_inventory_format_stats(args.inventory)
     license_stats = _load_inventory_license_stats(args.inventory)
+    source_check_stats = _load_source_check_stats(args.source_check)
 
-    scores = build_scores(registry, radar_sources, signals_data, inventory_stats, license_stats)
+    scores = build_scores(
+        registry,
+        radar_sources,
+        signals_data,
+        inventory_stats,
+        license_stats,
+        source_check_stats,
+    )
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(

--- a/scripts/build_compliance_scores.py
+++ b/scripts/build_compliance_scores.py
@@ -211,6 +211,31 @@ def _load_source_check_stats(path: Path) -> dict[str, dict]:
         return {}
 
 
+def _source_check_affidabile(
+    source_id: str,
+    protocol: str,
+    sc_stats: dict | None,
+) -> bool:
+    """Il source_check e' affidabile per questa fonte?
+
+    Per SDMX e SPARQL, se il source_check ha prodotto solo URL vuoti/invalidi
+    (nessun reachable, nessun circuit_open), il problema e' del probe HTTP
+    su singoli file — non della fonte. Questi protocolli si interrogano via
+    API/REST, non si scaricano come file.
+
+    Per CKAN, HTML, REST, AEM il source_check funziona bene.
+    """
+    if not sc_stats or source_id not in sc_stats:
+        return False
+    if protocol not in ("sdmx", "sparql"):
+        return True
+    sc = sc_stats[source_id]
+    # Tutti gli URL vuoti/invalidi + 0 circuit_open → source_check non probeabile
+    if sc["total"] > 0 and sc["reachable"] == 0 and sc["circuit_open"] == 0:
+        return False
+    return True
+
+
 def _formato_score(
     protocol: str,
     signals: list[dict],
@@ -223,32 +248,41 @@ def _formato_score(
     Priorità: source_check (formato reale) > inventory (metadato) > segnali > protocollo.
     """
     # ── 1. Source-check: formato reale da probe HTTP ─────────────────
-    if source_check_stats and source_id in source_check_stats:
+    if (
+        source_check_stats
+        and source_id in source_check_stats
+        and _source_check_affidabile(source_id, protocol, source_check_stats)
+    ):
         sc = source_check_stats[source_id]
         perc_aperto = sc["perc_aperto"]
         perc_reachable = sc["perc_reachable"]
 
-        # Penalità forte se la maggior parte dei file e' irraggiungibile
-        if perc_reachable < 30.0:
-            return (10.0, "computed")
-        if perc_reachable < 50.0:
-            return (15.0, "computed")
-
-        # Formato reale dei file raggiungibili
-        if perc_aperto >= 95.0:
-            return (90.0, "computed")
-        elif perc_aperto >= 80.0:
-            return (75.0, "computed")
-        elif perc_aperto >= 50.0:
-            return (55.0, "computed")
-        elif perc_aperto >= 20.0:
-            return (35.0, "computed")
-        elif perc_aperto > 0:
-            # Qualche formato aperto, ma pochissimo
-            return (20.0, "computed")
+        # Se tutti i formati sono ignoti, source_check non ha probeato il
+        # formato — salta a inventory/protocollo
+        if sc.get("total", 0) > 0 and sc.get("formato_ignoto", 0) == sc.get("total", 0):
+            pass  # casca a inventory
         else:
-            # Zero formati aperti — tutto chiuso (XLSX/PDF/ZIP) o ignoto
-            return (5.0, "computed")
+            # Penalità forte se la maggior parte dei file e' irraggiungibile
+            if perc_reachable < 30.0:
+                return (10.0, "computed")
+            if perc_reachable < 50.0:
+                return (15.0, "computed")
+
+            # Formato reale dei file raggiungibili
+            if perc_aperto >= 95.0:
+                return (90.0, "computed")
+            elif perc_aperto >= 80.0:
+                return (75.0, "computed")
+            elif perc_aperto >= 50.0:
+                return (55.0, "computed")
+            elif perc_aperto >= 20.0:
+                return (35.0, "computed")
+            elif perc_aperto > 0:
+                # Qualche formato aperto, ma pochissimo
+                return (20.0, "computed")
+            else:
+                # Zero formati aperti — tutto chiuso (XLSX/PDF/ZIP)
+                return (5.0, "computed")
 
     # ── 2. Inventory CKAN (metadati) ──────────────────────────────────
     if inventory_stats and source_id in inventory_stats:
@@ -292,6 +326,7 @@ def _raggiungibilita_score(
     radar_entry: dict | None,
     source_check_stats: dict | None = None,
     source_id: str = "",
+    protocol: str = "",
 ) -> tuple[float, str]:
     """B — Raggiungibilita'. Combina radar (portale) e source_check (file).
 
@@ -299,7 +334,11 @@ def _raggiungibilita_score(
     che risponde HTTP 200 e' irrilevante.
     """
     # ── 1. Source-check: file-level reachability ──────────────────────────
-    if source_check_stats and source_id in source_check_stats:
+    if (
+        source_check_stats
+        and source_id in source_check_stats
+        and _source_check_affidabile(source_id, protocol, source_check_stats)
+    ):
         sc = source_check_stats[source_id]
         perc_reachable = sc["perc_reachable"]
         if perc_reachable < 20.0:
@@ -440,7 +479,9 @@ def build_scores(
         formato, f_src = _formato_score(
             protocol, signals, inventory_stats, source_id, source_check_stats
         )
-        raggiung, r_src = _raggiungibilita_score(radar_entry, source_check_stats, source_id)
+        raggiung, r_src = _raggiungibilita_score(
+            radar_entry, source_check_stats, source_id, protocol
+        )
         lic, l_src = _licenza_score(protocol, license_stats, source_id)
         dgov, d_src = _datigovit_score()
         hvd, h_src = _hvd_score(license_stats, source_id)

--- a/scripts/build_compliance_scores.py
+++ b/scripts/build_compliance_scores.py
@@ -216,18 +216,44 @@ def _formato_score(
     signals: list[dict],
     inventory_stats: dict | None = None,
     source_id: str = "",
+    source_check_stats: dict | None = None,
 ) -> tuple[float, str]:
     """A — Formato aperto.
 
-    Se disponibili, usa i formati reali dall'inventory (CKAN).
-    Altrimenti stima da protocol + segnali HTML.
+    Priorità: source_check (formato reale) > inventory (metadato) > segnali > protocollo.
     """
-    # 1. Se abbiamo dati reali dall'inventory CKAN, usali
+    # ── 1. Source-check: formato reale da probe HTTP ─────────────────
+    if source_check_stats and source_id in source_check_stats:
+        sc = source_check_stats[source_id]
+        perc_aperto = sc["perc_aperto"]
+        perc_reachable = sc["perc_reachable"]
+
+        # Penalità forte se la maggior parte dei file e' irraggiungibile
+        if perc_reachable < 30.0:
+            return (10.0, "computed")
+        if perc_reachable < 50.0:
+            return (15.0, "computed")
+
+        # Formato reale dei file raggiungibili
+        if perc_aperto >= 95.0:
+            return (90.0, "computed")
+        elif perc_aperto >= 80.0:
+            return (75.0, "computed")
+        elif perc_aperto >= 50.0:
+            return (55.0, "computed")
+        elif perc_aperto >= 20.0:
+            return (35.0, "computed")
+        elif perc_aperto > 0:
+            # Qualche formato aperto, ma pochissimo
+            return (20.0, "computed")
+        else:
+            # Zero formati aperti — tutto chiuso (XLSX/PDF/ZIP) o ignoto
+            return (5.0, "computed")
+
+    # ── 2. Inventory CKAN (metadati) ──────────────────────────────────
     if inventory_stats and source_id in inventory_stats:
         stats = inventory_stats[source_id]
         perc = stats["perc_aperto"]
-        # Se la copertura e' bassa (<50% dei dataset con formato noto),
-        # il dato e' parziale — non lo marcamo "computed"
         fonte = "computed" if stats["copertura"] >= 50.0 else "parziale"
         if perc >= 95.0:
             return (90.0, fonte)
@@ -240,7 +266,7 @@ def _formato_score(
         else:
             return (20.0, fonte)
 
-    # 2. Fallback: segnali HTML (csv_magnet)
+    # ── 3. Segnali HTML (csv_magnet) ──────────────────────────────────
     for sig in signals:
         detail = sig.get("detail", "")
         if "CSV" in detail and ("JSON" in detail or "XML" in detail):
@@ -248,17 +274,17 @@ def _formato_score(
         if "CSV" in detail:
             return (75.0, "computed")
 
-    # 3. Stima per protocollo
-    protocol_scores = {
-        "ckan": 75.0,
-        "sdmx": 70.0,
-        "sparql": 65.0,
-        "aem": 55.0,
-        "rest": 55.0,
-        "html": 50.0,
+    # ── 4. Stima per protocollo (pessimista) ──────────────────────────
+    protocol_scores_pessimista = {
+        "sdmx": 70.0,  # SDMX e' sempre XML strutturato
+        "sparql": 65.0,  # SPARQL REST — presumibilmente RDF
+        "ckan": 30.0,  # CKAN non dice nulla sul formato reale
+        "aem": 45.0,
+        "rest": 45.0,
+        "html": 35.0,
     }
-    score = protocol_scores.get(protocol, 50.0)
-    source_type = "computed" if protocol in protocol_scores else "estimated"
+    score = protocol_scores_pessimista.get(protocol, 25.0)
+    source_type = "estimated"
     return (score, source_type)
 
 
@@ -366,7 +392,9 @@ def build_scores(
         radar_entry = radar_by_id.get(source_id)
         signals = signals_by_source.get(source_id, [])
 
-        formato, f_src = _formato_score(protocol, signals, inventory_stats, source_id)
+        formato, f_src = _formato_score(
+            protocol, signals, inventory_stats, source_id, source_check_stats
+        )
         raggiung, r_src = _raggiungibilita_score(radar_entry)
         lic, l_src = _licenza_score(protocol, license_stats, source_id)
         dgov, d_src = _datigovit_score()

--- a/scripts/build_compliance_scores.py
+++ b/scripts/build_compliance_scores.py
@@ -380,6 +380,36 @@ def _foia_access_score() -> tuple[float, str]:
     return (50.0, "missing")
 
 
+def _flag_urgenza(
+    source_id: str,
+    source_check_stats: dict | None = None,
+    radar_entry: dict | None = None,
+) -> list[str]:
+    """Calcola flag di urgenza per una fonte.
+
+    I flag non modificano lo score ma possono overrideare l'azione raccomandata.
+    """
+    flags: list[str] = []
+
+    # circuit_open_massivo: >50% URL irraggiungibili
+    if source_check_stats and source_id in source_check_stats:
+        sc = source_check_stats[source_id]
+        if sc["total"] > 0 and (sc["circuit_open"] / sc["total"]) > 0.5:
+            flags.append("circuit_open_massivo")
+
+        # formato_chiuso_completo: 0% formato_aperto
+        if sc["total"] > 0 and sc["formato_aperto"] == 0 and sc["formato_chiuso"] > 0:
+            flags.append("formato_chiuso_completo")
+
+    # portale_irraggiungibile: radar RED streak >= 3
+    if radar_entry:
+        streak = radar_entry.get("red_streak", 0)
+        if isinstance(streak, (int, float)) and streak >= 3:
+            flags.append("portale_irraggiungibile")
+
+    return flags
+
+
 def build_scores(
     registry: dict,
     radar_sources: list[dict],
@@ -444,11 +474,25 @@ def build_scores(
         else:
             livello = "carente"
 
-        # Azione raccomandata (richiede verifica umana)
+        # Flag urgenza
+        flags = _flag_urgenza(source_id, source_check_stats, radar_entry)
+
+        # Azione raccomandata — i flag possono elevare
+        if "circuit_open_massivo" in flags and livello in ("medio", "buono"):
+            # override: se i file non sono raggiungibili, livello minimo debole
+            livello = "debole"
+        if "formato_chiuso_completo" in flags and livello in ("medio", "buono"):
+            livello = "debole"
+
         if livello == "carente":
             azione = "FOIA + verifica DCD"
         elif livello == "debole":
-            azione = "verifica umana"
+            if "formato_chiuso_completo" in flags:
+                azione = "segnalazione DCD (formato chiuso)"
+            elif "circuit_open_massivo" in flags:
+                azione = "verifica raggiungibilita' (FOIA se persiste)"
+            else:
+                azione = "verifica umana"
         elif totale < 70 and formato < 40:
             azione = "segnalazione DCD (formato chiuso — verificare)"
         elif totale < 70 and raggiung < 30:
@@ -462,6 +506,7 @@ def build_scores(
             "totale": totale,
             "livello": livello,
             "azione_raccomandata": azione,
+            "flag_urgenza": flags,
             "assi": {
                 "formato_aperto": {"score": formato, "fonte": f_src},
                 "raggiungibilita": {"score": raggiung, "fonte": r_src},

--- a/scripts/build_compliance_scores.py
+++ b/scripts/build_compliance_scores.py
@@ -290,11 +290,28 @@ def _formato_score(
 
 def _raggiungibilita_score(
     radar_entry: dict | None,
+    source_check_stats: dict | None = None,
+    source_id: str = "",
 ) -> tuple[float, str]:
-    """B — Raggiungibilita'. Computed da radar_summary.
+    """B — Raggiungibilita'. Combina radar (portale) e source_check (file).
 
-    Misura se il server e' raggiungibile, NON la freschezza dei dati.
+    Source_check ha priorità: se i file non sono raggiungibili, il portale
+    che risponde HTTP 200 e' irrilevante.
     """
+    # ── 1. Source-check: file-level reachability ──────────────────────────
+    if source_check_stats and source_id in source_check_stats:
+        sc = source_check_stats[source_id]
+        perc_reachable = sc["perc_reachable"]
+        if perc_reachable < 20.0:
+            return (5.0, "computed")
+        elif perc_reachable < 40.0:
+            return (15.0, "computed")
+        elif perc_reachable < 60.0:
+            return (30.0, "computed")
+        elif perc_reachable < 80.0:
+            return (50.0, "computed")
+
+    # ── 2. Radar: portale reachability ──────────────────────────────────
     if radar_entry is None:
         return (50.0, "estimated")
 
@@ -303,10 +320,8 @@ def _raggiungibilita_score(
     streak = radar_entry.get("red_streak", 0)
 
     if status == "GREEN":
-        # SSL issue strutturato (ssl_issue field) — più affidabile della nota testuale
         if radar_entry and radar_entry.get("ssl_issue"):
             return (55.0, "computed")
-        # Fallback: nota testuale per history precedente all'introduzione di ssl_issue
         if "SSL" in note or "ssl" in note.lower():
             return (55.0, "computed")
         return (70.0, "computed")
@@ -395,7 +410,7 @@ def build_scores(
         formato, f_src = _formato_score(
             protocol, signals, inventory_stats, source_id, source_check_stats
         )
-        raggiung, r_src = _raggiungibilita_score(radar_entry)
+        raggiung, r_src = _raggiungibilita_score(radar_entry, source_check_stats, source_id)
         lic, l_src = _licenza_score(protocol, license_stats, source_id)
         dgov, d_src = _datigovit_score()
         hvd, h_src = _hvd_score(license_stats, source_id)

--- a/scripts/build_compliance_scores.py
+++ b/scripts/build_compliance_scores.py
@@ -464,26 +464,56 @@ def build_scores(
 
         totale = round(numeratore / denominatore, 1) if denominatore > 0 else 0.0
 
-        # Label qualitativo (prudenziale)
-        if totale >= 80:
-            livello = "buono"
-        elif totale >= 55:
-            livello = "medio"
-        elif totale >= 25:
-            livello = "debole"
-        else:
-            livello = "carente"
+        # Livello dal minimo degli assi (non-missing).
+        # Gli assi "estimated" (stime prudenziali) non possono tirare giu'
+        # il livello sotto "medio" — solo gli assi "computed"/"parziale"
+        # (dati reali) possono determinare "debole" o "carente".
+        _ORDINE_LIVELLI = {"buono": 0, "medio": 1, "debole": 2, "carente": 3}
+
+        def _livello_asse(score: float) -> str:
+            if score >= 80:
+                return "buono"
+            elif score >= 55:
+                return "medio"
+            elif score >= 25:
+                return "debole"
+            return "carente"
+
+        livelli_assi: list[str] = []
+        for val, src, _key in assi_info:
+            if src == "missing":
+                continue
+            livello_asse = _livello_asse(val)
+            if src in ("estimated",):
+                # Le stime non tirano giu' il livello
+                livello_asse = min(livello_asse, "medio", key=lambda x: _ORDINE_LIVELLI.get(x, 0))
+            livelli_assi.append(livello_asse)
+
+        livello = (
+            max(livelli_assi, key=lambda x: _ORDINE_LIVELLI.get(x, 0)) if livelli_assi else "medio"
+        )
 
         # Flag urgenza
         flags = _flag_urgenza(source_id, source_check_stats, radar_entry)
 
-        # Azione raccomandata — i flag possono elevare
-        if "circuit_open_massivo" in flags and livello in ("medio", "buono"):
-            # override: se i file non sono raggiungibili, livello minimo debole
+        # I flag possono elevare il livello
+        if (
+            "circuit_open_massivo" in flags
+            and _ORDINE_LIVELLI.get(livello, 0) < _ORDINE_LIVELLI["debole"]
+        ):
             livello = "debole"
-        if "formato_chiuso_completo" in flags and livello in ("medio", "buono"):
+        if (
+            "formato_chiuso_completo" in flags
+            and _ORDINE_LIVELLI.get(livello, 0) < _ORDINE_LIVELLI["debole"]
+        ):
+            livello = "debole"
+        if (
+            "portale_irraggiungibile" in flags
+            and _ORDINE_LIVELLI.get(livello, 0) < _ORDINE_LIVELLI["debole"]
+        ):
             livello = "debole"
 
+        # Azione raccomandata
         if livello == "carente":
             azione = "FOIA + verifica DCD"
         elif livello == "debole":

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -638,7 +638,11 @@ def _check_row(
     )
     # per SDMX la metadata_url non è un dato, usiamo la base_url per il check
     if enrich["enrich_method"] in ("sdmx_dataflow_annotations", "inventory_only"):
-        url_to_check = row.get("landing_page") or row.get("distribution_url") or url_to_check
+        url_to_check = (
+            _safe_str(row.get("landing_page"))
+            or _safe_str(row.get("distribution_url"))
+            or url_to_check
+        )
 
     # Se l'enrich ha già fatto un HEAD con successo (content_type/content_type_landing/html_scrape),
     # evitiamo un secondo HEAD ridondante sullo stesso URL.

--- a/tests/test_compliance_scores.py
+++ b/tests/test_compliance_scores.py
@@ -116,12 +116,38 @@ class TestBuildComplianceScores:
 
     @pytest.mark.contract
     def test_formato_score_senza_inventory(self):
-        """Asse A: senza inventory, usa fallback protocol."""
+        """Asse A: senza inventory, usa fallback protocol (pessimista)."""
         score, fonte = _formato_score("ckan", [], None, "ignota")
-        assert score == 75.0  # fallback CKAN
-        assert fonte == "computed"
+        assert score == 30.0  # fallback CKAN pessimistico
+        assert fonte == "estimated"
         score2, fonte2 = _formato_score("html", [], None, "ignota")
-        assert score2 == 50.0  # fallback HTML
+        assert score2 == 35.0  # fallback HTML pessimistico
+        assert fonte2 == "estimated"
+        # SDMX resta affidabile (sempre XML)
+        score3, fonte3 = _formato_score("sdmx", [], None, "ignota")
+        assert score3 == 70.0
+        assert fonte3 == "estimated"
+
+    @pytest.mark.contract
+    def test_formato_score_da_source_check(self):
+        """Asse A: source_check primario — formato reale dai probe."""
+        # 100% formati aperti, 100% raggiungibili
+        sc = {"fonte_aperta": {"perc_aperto": 100.0, "perc_reachable": 100.0}}
+        score, fonte = _formato_score("ckan", [], None, "fonte_aperta", sc)
+        assert score == 90.0
+        assert fonte == "computed"
+
+        # 0% formati aperti (tutto XLSX), 100% raggiungibili
+        sc = {"fonte_chiusa": {"perc_aperto": 0.0, "perc_reachable": 100.0}}
+        score, fonte = _formato_score("ckan", [], None, "fonte_chiusa", sc)
+        assert score == 5.0
+        assert fonte == "computed"
+
+        # <30% raggiungibili → penalità forte
+        sc = {"fonte_morta": {"perc_aperto": 80.0, "perc_reachable": 20.0}}
+        score, fonte = _formato_score("ckan", [], None, "fonte_morta", sc)
+        assert score == 10.0  # penalizzato per irraggiungibilità
+        assert fonte == "computed"
 
     @pytest.mark.contract
     def test_licenza_score_da_inventory(self):

--- a/tests/test_compliance_scores.py
+++ b/tests/test_compliance_scores.py
@@ -14,9 +14,11 @@ import pytest
 from _constants import CATALOG_SIGNALS_PATH, RADAR_SUMMARY_PATH, REGISTRY_PATH
 
 from scripts.build_compliance_scores import (
+    _flag_urgenza,
     _formato_score,
     _hvd_score,
     _licenza_score,
+    _raggiungibilita_score,
     build_scores,
 )
 
@@ -148,6 +150,73 @@ class TestBuildComplianceScores:
         score, fonte = _formato_score("ckan", [], None, "fonte_morta", sc)
         assert score == 10.0  # penalizzato per irraggiungibilità
         assert fonte == "computed"
+
+    @pytest.mark.contract
+    def test_raggiungibilita_score_da_source_check(self):
+        """Asse B: source_check ha priorita sul radar per file-level reachability."""
+        # <20% raggiungibili → score 5
+        s, f = _raggiungibilita_score(
+            {"status": "GREEN", "http_code": "200"},
+            {"f1": {"perc_reachable": 15.0}},
+            "f1",
+        )
+        assert s == 5.0 and f == "computed"
+        # <40% → 15
+        s, f = _raggiungibilita_score(None, {"f1": {"perc_reachable": 30.0}}, "f1")
+        assert s == 15.0 and f == "computed"
+        # >=80% → radar normale
+        s, f = _raggiungibilita_score(
+            {"status": "GREEN", "http_code": "200"},
+            {"f1": {"perc_reachable": 90.0}},
+            "f1",
+        )
+        assert s == 70.0 and f == "computed"
+
+    @pytest.mark.contract
+    def test_flag_urgenza(self):
+        """Flag da source_check e radar."""
+        sc = {"mit": {"total": 10, "circuit_open": 7, "formato_aperto": 0, "formato_chiuso": 10}}
+        flags = _flag_urgenza("mit", sc, {"red_streak": 5})
+        assert "circuit_open_massivo" in flags
+        assert "formato_chiuso_completo" in flags
+        assert "portale_irraggiungibile" in flags
+        # Nessun flag se tutto ok
+        sc2 = {"ok": {"total": 10, "circuit_open": 1, "formato_aperto": 8, "formato_chiuso": 2}}
+        flags2 = _flag_urgenza("ok", sc2, {"red_streak": 0})
+        assert flags2 == []
+
+    @pytest.mark.contract
+    def test_build_scores_min_axis(self):
+        """Il livello deriva dal minimo degli assi computed, non dalla media."""
+        registry = {"fonte_test": {"protocol": "ckan"}}
+        # fonte con formato_aperto=5 (carente) ma altri assi OK
+        sc = {
+            "fonte_test": {
+                "total": 10,
+                "reachable": 10,
+                "circuit_open": 0,
+                "formato_aperto": 0,
+                "formato_chiuso": 10,
+                "formato_ignoto": 0,
+                "perc_reachable": 100.0,
+                "perc_aperto": 0.0,
+            }
+        }
+        result = build_scores(registry, [], None, {}, {}, sc)
+        entry = result["scores"][0]
+        # formato_aperto e' 5.0 (computed, carente) → livello deve essere carente
+        assert entry["livello"] == "carente", f"livello={entry['livello']}, atteso carente"
+        assert "FOIA" in entry["azione_raccomandata"]
+
+    @pytest.mark.contract
+    def test_build_scores_estimated_non_tira_giu(self):
+        """Assi estimated non possono portare il livello sotto 'medio'."""
+        registry = {"fonte_test": {"protocol": "html"}}
+        result = build_scores(registry, [], None, {}, {}, {})
+        entry = result["scores"][0]
+        # Presenza_datigovit e' 50 estimated (soglia debole), ma non deve tirare giu
+        # Il livello dovrebbe essere almeno medio perche' estimated e' cap a medio
+        assert entry["livello"] in ("medio",), f"livello={entry['livello']}, atteso medio"
 
     @pytest.mark.contract
     def test_licenza_score_da_inventory(self):


### PR DESCRIPTION
## Sintesi

Riscrittura del sistema di health scoring: da media ponderata (con fallback ottimisti) a **minimo degli assi computed** con **source_check come fonte primaria**, **fallback pessimistici** e **flag di urgenza**.

Include fix per SDMX nel source_check (NaN truthy che bloccava 3868 item).

## Cosa cambia (8 commit)

### Health score — logica

| Componente | Prima | Dopo |
|---|---|---|
| **formato_aperto** | inventory (metadato) > segnali > protocollo (ottimista: CKAN=75) | **source_check (formato reale)** > inventory > segnali > protocollo (pessimista: CKAN=30) |
| **raggiungibilita** | solo radar (portale) | **source_check (file-level)** > radar. Se <20% URL raggiungibili → 5 |
| **Livello complessivo** | media ponderata (maschera emergenze) | **minimo degli assi computed** (estimated cap a medio) |
| **Azione raccomandata** | solo da livello | livello + **flag urgenza** (circuit_open, formato_chiuso, portale_giu) |
| **SDMX** | fallback protocollo 70 (ma source_check NaN) | source_check con fix NaN + _source_check_affidabile() |
| **SPARQL** | fallback protocollo 65 | source_check skippato se URL non probeabili → fallback protocollo |

### Source-check — fix

| Fix | File | Effetto |
|---|---|---|
| **NaN truthy** | `bulk_source_check.py:641` | `row.get("landing_page")` restituisce NaN (float) per SDMX → `nan or X` restituisce nan. Fix: `_safe_str()` converte NaN in None |

### Nuove feature

- `_load_source_check_stats()`: carica e aggrega source_check_results.parquet per fonte
- `_source_check_affidabile()`: per SDMX/SPARQL con URL vuoti, non usa source_check
- `_flag_urgenza()`: circuit_open_massivo, formato_chiuso_completo, portale_irraggiungibile
- `flag_urgenza` nell'output JSON (lista di stringhe)

### Output con dati GCS (26 fonti)

```
PRIMA:  0 buono, 30 medio, 3 debole, 0 carente  (tutto "monitoraggio")
DOPO:   0 buono, 11 medio, 13 debole, 9 carente  (trigger FOIA reali)
```

9 fonti **carenti** con azione "FOIA + verifica DCD", tra cui:
- **MIT**: portale giù, 52/62 URL circuit_open ✅ reale
- **ministero_salute**: 45/48 CSV irraggiungibili ✅ reale
- **openbdap**: 3475/3516 timeout ❓ da verificare (rate limiting?)
- **opencivitas**: 384 item, 0% raggiungibili ✅ nostro limite (URL da fixare)
- **cortecostituzionale**: 13 item, 0% ✅ nostro limite

### Test

- 26 test (11 compliance + 15 radar) — tutti ✅
- Nuovi test: source_check affidabile, flag urgenza, min-axes, estimated-cap, SDXM non affidabile

## Impatto su artifact

`open_data_health_scores.json`: nuovo campo `flag_urgenza` (lista stringhe). Il livello ora riflette il minimo degli assi misurati, non la media.

## Per il prossimo run CI

Il source_check riprodurrà il parquet con SDMX probeato correttamente (URL CSV reali invece di NaN). Se l'endpoint ISTAT risponde, SDMX migliorerà da debole a medio.
