### PR TITLE
fix: content-type validation, HTTPS fallback, SPARQL format, _http_head_with_retry delegato a toolkit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.41.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.41.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.40.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.41.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.41.1",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.41.2",
 ]
 
 [project.optional-dependencies]

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -376,7 +376,9 @@ def _enrich_sparql(row: pd.Series, base: dict, client: HttpClient | None = None)
             landing, client=client
         )
         if content_type:
-            fmt = _normalize_format(content_type)
+            inferred = _normalize_format(content_type)
+            if inferred:  # solo se il HEAD produce un formato valido
+                fmt = inferred
 
     return _apply_encoding_to_enrich(
         {
@@ -656,6 +658,15 @@ def _check_row(
             url_to_check or "", client=client
         )
         http_status = http_status_raw if http_status_raw is not None else 0
+
+        # Validazione: se HTTP 200-399 ma content-type non matcha il formato atteso
+        # (es. atteso CSV, ricevuto HTML = pagina d'errore mascherata),
+        # la risorsa non e' veramente raggiungibile.
+        if reachable and content_type == "html":
+            expected = _normalize_format(enrich.get("resource_format") or "")
+            if expected and expected != "html":
+                reachable = False
+                note = f"content_mismatch: atteso {expected}, ricevuto HTML"
 
         # Content-type format as primary detection (now unified in _http_head_with_retry)
     fmt_from_content = content_type

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import logging
 import re
-import time
 import xml.etree.ElementTree as ET
 from typing import Any, Optional
 
@@ -119,55 +118,31 @@ def _http_head_with_retry(
     client: HttpClient | None = None,
     max_retries: int = 1,
 ) -> tuple[Optional[int], bool, str, Optional[str]]:
-    """HTTP HEAD con retry e circuit breaker via HttpClient.
+    """HEAD probe via toolkit, con backward compat per caller SO.
 
-    Usa ``client.head(url)`` che internamente gestisce circuit breaker,
-    retry su 5xx e connection error.  La format detection usa
-    ``toolkit.scout.http.resolve_preview_kind``.
-
-    Se *client* non e' fornito, ne crea uno di default (senza circuit breaker).
+    Delega a ``toolkit.scout.http.probe_url_headers`` che fa:
+      HEAD → retry → GET+Range fallback → HTTPS fallback
 
     Returns: (status_code, reachable, error, content_type_format).
     """
+    from toolkit.scout.http import probe_url_headers as _toolkit_probe
+
     if not isinstance(url, str) or not url.startswith("http"):
         return None, False, "url_missing_or_invalid", None
 
-    if client is None:
-        client = HttpClient(timeout=(5, 10))
-
-    last_error = ""
-
-    for attempt in range(max_retries + 1):
-        result = client.head(url)
-        if result is None:
-            return None, False, "circuit_open", None
-
-        if result.is_ok and result.response is not None:
-            resp = result.response
-            if resp.status_code >= 500 and attempt < max_retries:
-                last_error = f"server_error_{resp.status_code}"
-                time.sleep(0.5 * (attempt + 1))
-                continue
-            ct = resp.headers.get("Content-Type", "") or ""
-            cd = resp.headers.get("Content-Disposition")
-            # Format detection via toolkit (pure, no HTTP)
-            fmt = _toolkit_preview_kind(url, ct, cd)
-            reachable = resp.status_code < 400
-            return resp.status_code, reachable, "", fmt
-
-        if result.err is not None:
-            if isinstance(result.err, CircuitOpenError):
-                return None, False, "circuit_open", None
-            err_name = type(result.err).__name__
-            if "Timeout" in err_name and attempt < max_retries:
-                last_error = "timeout"
-                time.sleep(0.5 * (attempt + 1))
-                continue
-            return None, False, err_name.lower(), None
-
-        return None, False, last_error or "transient_error", None
-
-    return None, False, last_error or "transient_error", None
+    try:
+        result = _toolkit_probe(url, client=client)
+        status: int = result["status_code"]
+        ct: str | None = result.get("content_type")
+        cd: str | None = result.get("content_disposition")
+        fmt = _toolkit_preview_kind(url, ct, cd)
+        reachable = status < 400
+        return status, reachable, "", fmt
+    except CircuitOpenError:
+        return None, False, "circuit_open", None
+    except RuntimeError as exc:
+        err_msg = str(exc) or "probe_failed"
+        return None, False, err_msg, None
 
 
 # ── CKAN fetch (wrapper: adatta base_api SO a portal_url toolkit) ─────────────

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -131,6 +131,11 @@ def _http_head_with_retry(
         return None, False, "url_missing_or_invalid", None
 
     try:
+        # Check circuit breaker prima di delegare a toolkit:
+        # http://host e https://host condividono lo stesso netloc,
+        # quindi il circuito HTTP blocca anche HTTPS.
+        if client is not None and client._circuit_should_block(url):
+            return None, False, "circuit_open", None
         result = _toolkit_probe(url, client=client)
         status: int = result["status_code"]
         ct: str | None = result.get("content_type")

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -472,6 +472,9 @@ def test_http_circuit_breaker_blocks_host_after_failures(monkeypatch) -> None:
         )
 
 
+# ── SPARQL format override ──────────────────────────────────────────────────
+
+
 # ── _extract_year_values_from_sample ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## Sintesi

Tre fix alla radice + refactor del probe HTTP per eliminare duplicazione con toolkit.

## Cosa cambia (2 commit)

### 1. Content-type validation (`bulk_source_check.py`)
**Problema**: ANAC restituisce HTTP 200 con body HTML (pagina d'errore mascherata). `reachable=True` nonostante il file non sia CSV/JSON ma HTML.

**Fix**: dopo HEAD probe, se il content-type rilevato è HTML ma il formato atteso (da enrich) è CSV/JSON/XML, `reachable=False` + `note="content_mismatch"`.

### 2. HTTPS fallback (`toolkit/scout/http.py`)
**Problema**: openBDAP ha 3500+ item con URL in HTTP (`http://bdap-opendata...`). Il server RGS MEF non risponde su porta 80.

**Fix**: in `probe_url_headers()`, se HTTP fallisce (tutti i retry + GET+Range esauriti), riprova con HTTPS prima di arrendersi. **Unico punto di manutenzione = toolkit**.

### 3. SPARQL format override (`bulk_source_check.py`)
**Problema**: `fmt = "SPARQL"` veniva sovrascritto da `""` perché `_normalize_format(content_type)` su landing page HTML restituiva stringa vuota.

**Fix**: `if inferred:` — mantiene "SPARQL" se HEAD non produce formato valido.

### 4. `_http_head_with_retry` delegato a toolkit (`source_check_fetch.py`)
**Prima**: ~50 righe di HEAD probe duplicato (retry, error handling, format detection).
**Dopo**: ~15 righe che chiamano `toolkit.probe_url_headers()`. Stessa interfaccia per i caller.

Beneficio: GET+Range fallback (se HEAD non funziona, tenta GET con Range: bytes=0-0) arriva gratis dal toolkit.

## Impatto

| Fonte | Prima | Dopo |
|-------|-------|------|
| **openBDAP** | 25/3516 reachable (0.7%) | Se HTTPS funziona: 50%+ |
| **ANAC** | 3 reachable con body HTML | reachable=False per content_mismatch |
| **SPARQL** (dati_camera, cultura) | resource_format="" | resource_format="SPARQL" |
| **Tutti** | manutenzione in 2 punti | manutenzione in 1 punto (toolkit) |

## Verifica

- `pytest tests/test_compliance_scores.py tests/test_radar_check.py` — 26 test ✅
