### PR TITLE
feat: per-source concurrency limit in source_check + MIMIT RNA rate limiting fix

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -12,18 +12,18 @@ istat_sdmx:
     value: 4212
     method: dataflow_count
     reliability: medium
-    note: Re-baseline su endpoint esploradati (MCP ondata). Il valore 4212 e' il
-      conteggio riproducibile via MCP discover_dataflows (no keyword, no 
-      blacklist) dopo filtro NonProductionDataflow. Il valore 509 era il 
-      conteggio su sdmx.istat.it (endpoint diverso).
+    note: Re-baseline su endpoint esploradati (MCP ondata). Il valore 4212 e' il conteggio
+      riproducibile via MCP discover_dataflows (no keyword, no blacklist) dopo filtro
+      NonProductionDataflow. Il valore 509 era il conteggio su sdmx.istat.it (endpoint
+      diverso).
   verdict: go
   note: Endpoint SDMX ricco e ad alto valore per scouting e source-check.
   datasets_in_use:
-    - istat_gini_regionale
-    - istat_housing_crowding
-    - istat_ipab_aree
-    - istat_pil_territoriale
-    - popolazione_istat_comunale_2019_2025
+  - istat_gini_regionale
+  - istat_housing_crowding
+  - istat_ipab_aree
+  - istat_pil_territoriale
+  - popolazione_istat_comunale_2019_2025
 anac:
   source_kind: catalog
   protocol: ckan
@@ -39,15 +39,15 @@ anac:
     value: 70
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:anac su dati.gov.it. 
-      70 dataset harvestati dal portale ANAC.
+    note: Conteggio via package_search con fq=organization:anac su dati.gov.it. 70
+      dataset harvestati dal portale ANAC.
   verdict: go
   note: 'Fonte via dati.gov.it (harvesting ANAC). I download raw vanno al portale
     diretto dati.anticorruzione.it con User-Agent browser (WAF blocca solo python-requests).
     70 dataset: CIG (2007-2023), SMARTCIG, OCDS, stazioni appaltanti, aggiudicatari,
     subappalti, varianti, PNRR indicatori, SOA. CC-BY-SA 4.0.'
   datasets_in_use:
-    - anac_bandi_gara
+  - anac_bandi_gara
 inps:
   source_kind: catalog
   protocol: ckan
@@ -65,21 +65,19 @@ inps:
     value: 2323
     method: package_list
     reliability: high
-    note: Inventory via package_list + package_show_sample (16 workers). 
-      current_package_list_with_resources testato ma scartato per lentezza a 
-      offset alti. package_show_sample più veloce.
+    note: Inventory via package_list + package_show_sample (16 workers). current_package_list_with_resources
+      testato ma scartato per lentezza a offset alti. package_show_sample più veloce.
   verdict: go
-  note: Catalogo CKAN INPS — inventory via package_list + package_show_sample 
-    (current_package_list_with_resources lento a offset alti).
+  note: Catalogo CKAN INPS — inventory via package_list + package_show_sample (current_package_list_with_resources
+    lento a offset alti).
   datasets_in_use:
-    - inps_pensioni_trimestrale
-    - pensioni_pa_dag
+  - inps_pensioni_trimestrale
+  - pensioni_pa_dag
 openbdap:
   source_kind: catalog
   protocol: ckan
   observation_mode: catalog-watch
-  base_url: 
-    https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
+  base_url: https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
   inventory:
     timeout: 1200
     skip_package_search: true
@@ -95,17 +93,17 @@ openbdap:
     value: 3772
     method: package_list
     reliability: medium
-    note: Conteggio totale package rilevati via package_list; package_search 
-      restituisce count inaffidabile.
+    note: Conteggio totale package rilevati via package_list; package_search restituisce
+      count inaffidabile.
   verdict: go
-  note: Catalogo CKAN molto ricco; osservazione iniziale stretta a livello 
-    inventario senza intake o monitor diffuso.
+  note: Catalogo CKAN molto ricco; osservazione iniziale stretta a livello inventario
+    senza intake o monitor diffuso.
   datasets_in_use:
-    - bdap_anagrafe_enti
-    - bdap_entrate_stato
-    - bdap_lea
-    - bdap_spese_stato
-    - dipendenti_pubblici
+  - bdap_anagrafe_enti
+  - bdap_entrate_stato
+  - bdap_lea
+  - bdap_spese_stato
+  - dipendenti_pubblici
 inail_opendata:
   source_kind: portal
   protocol: aem
@@ -113,10 +111,9 @@ inail_opendata:
   base_url: https://dati.inail.it/
   last_probed: '2026-06-25'
   verdict: go
-  note: Portale AEM con Open API documentate. Superficie operativa reale = 
-    catalogo AEM + Open API, non CKAN standard (logo nel footer fuorviante). 
-    Baseline inventariale non ancora difendibile; tenere in radar-only finche' 
-    non definito un metodo stabile.
+  note: Portale AEM con Open API documentate. Superficie operativa reale = catalogo
+    AEM + Open API, non CKAN standard (logo nel footer fuorviante). Baseline inventariale
+    non ancora difendibile; tenere in radar-only finche' non definito un metodo stabile.
   datasets_in_use: []
 mim_opendata:
   source_kind: catalog
@@ -134,21 +131,20 @@ mim_opendata:
       Personale, Valutazione, Edilizia, Adozioni). 1116 link CSV/XLS. Prefix: ALU=300,
       EDI=282, SCU=132. Nessuna sitemap disponibile.'
   verdict: go
-  note: Portale Ministero Istruzione — csv_magnet scan via area_pages (no 
-    sitemap).
+  note: Portale Ministero Istruzione — csv_magnet scan via area_pages (no sitemap).
   html_portal:
     topic_hint: istruzione
     area_pages:
-      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole
-      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Studenti
-      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Personale%20Scuola
-      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Sistema%20Nazionale%20di%20Valutazione
-      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Edilizia%20Scolastica
-      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Adozioni%20libri%20di%20testo
+    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole
+    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Studenti
+    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Personale%20Scuola
+    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Sistema%20Nazionale%20di%20Valutazione
+    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Edilizia%20Scolastica
+    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Adozioni%20libri%20di%20testo
     delay_seconds: 0.3
   datasets_in_use:
-    - mim_alunni_corso_eta
-    - mim_anagrafica_scuole_statali
+  - mim_alunni_corso_eta
+  - mim_anagrafica_scuole_statali
 dati_camera:
   source_kind: catalog
   protocol: sparql
@@ -164,26 +160,26 @@ dati_camera:
     method: sparql_query
     query_name: camera_dcat
     reliability: medium
-    note: Baseline fissata con query custom Camera perché il catalogo usa 
-      proprietà DC 1.1 Elements per titolo e descrizione.
+    note: Baseline fissata con query custom Camera perché il catalogo usa proprietà
+      DC 1.1 Elements per titolo e descrizione.
   sparql:
     endpoint_url: https://dati.camera.it/sparql
     query_name: camera_dcat
     limit: 5000
     timeout_seconds: 60
     query: "PREFIX dcat: <http://www.w3.org/ns/dcat#>\nPREFIX dc: <http://purl.org/dc/elements/1.1/>\n\
-      PREFIX dct: <http://purl.org/dc/terms/>\nSELECT DISTINCT ?dataset ?title ?description
-      ?modified ?landingPage\nWHERE {\n  ?dataset a dcat:Dataset .\n  OPTIONAL { ?dataset
-      dc:title ?title . }\n  OPTIONAL { ?dataset dc:description ?description . }\n\
-      \  OPTIONAL { ?dataset dct:modified ?modified . }\n  OPTIONAL { ?dataset dcat:landingPage
-      ?landingPage . }\n}\nORDER BY ?dataset\nLIMIT 5000\n"
+      PREFIX dct: <http://purl.org/dc/terms/>\nSELECT DISTINCT ?dataset ?title ?description\
+      \ ?modified ?landingPage\nWHERE {\n  ?dataset a dcat:Dataset .\n  OPTIONAL {\
+      \ ?dataset dc:title ?title . }\n  OPTIONAL { ?dataset dc:description ?description\
+      \ . }\n  OPTIONAL { ?dataset dct:modified ?modified . }\n  OPTIONAL { ?dataset\
+      \ dcat:landingPage ?landingPage . }\n}\nORDER BY ?dataset\nLIMIT 5000\n"
   verdict: go
-  note: Catalogo linked-data Camera inventariabile via query SPARQL custom. Il 
-    template DCAT generico non valorizza titolo e descrizione perché l'endpoint 
-    usa dc:title e dc:description.
+  note: Catalogo linked-data Camera inventariabile via query SPARQL custom. Il template
+    DCAT generico non valorizza titolo e descrizione perché l'endpoint usa dc:title
+    e dc:description.
   datasets_in_use:
-    - camera_deputati_legislature
-    - camera_votazioni_sparql
+  - camera_deputati_legislature
+  - camera_votazioni_sparql
 dati_senato:
   source_kind: catalog
   protocol: sparql
@@ -191,8 +187,8 @@ dati_senato:
   base_url: https://dati.senato.it/sparql
   inventory:
     timeout: 600
-    timeout_reason: 99 query SPARQL (1 discover + 98 schema enrich × 15 pred). 
-      stimate 5s/query su Virtuoso. 99 × 5 × 1.2 = 594s
+    timeout_reason: 99 query SPARQL (1 discover + 98 schema enrich × 15 pred). stimate
+      5s/query su Virtuoso. 99 × 5 × 1.2 = 594s
   last_probed: '2026-06-25'
   catalog_baseline:
     captured_at: '2026-05-31'
@@ -201,9 +197,9 @@ dati_senato:
     method: named_graphs
     query_name: named_graphs
     reliability: medium
-    note: Baseline via enumerazione named graphs SPARQL. ~98 grafi organizzati 
-      per categoria (composizione, ddl, votazioni, emendamenti, ecc.) e 
-      legislatura (01-19). Fonte non ha DCAT catalog.
+    note: Baseline via enumerazione named graphs SPARQL. ~98 grafi organizzati per
+      categoria (composizione, ddl, votazioni, emendamenti, ecc.) e legislatura (01-19).
+      Fonte non ha DCAT catalog.
   sparql:
     endpoint_url: https://dati.senato.it/sparql
     inventory_mode: named_graphs
@@ -212,21 +208,21 @@ dati_senato:
     timeout_seconds: 300
     graph_uri_prefix: http://dati.senato.it/
     graph_uri_blacklist:
-      - localhost
-      - virtrdf
-      - owl#
-      - rules.skos
-      - virtrdf-label
-      - '8890'
-      - b3sifp
-      - b3sonto
-      - facets
-      - teseo
+    - localhost
+    - virtrdf
+    - owl#
+    - rules.skos
+    - virtrdf-label
+    - '8890'
+    - b3sifp
+    - b3sonto
+    - facets
+    - teseo
   verdict: go
-  note: Portale Open Data Senato. SPARQL endpoint Virtuoso (GET). Inventory via 
-    enumerazione named graphs (~98 grafi categoria/legislatura). Download 
-    CSV/JSON via POST form autenticato (non crawlabile). CC BY 3.0. Speculare a 
-    dati_camera ma senza DCAT catalog.
+  note: Portale Open Data Senato. SPARQL endpoint Virtuoso (GET). Inventory via enumerazione
+    named graphs (~98 grafi categoria/legislatura). Download CSV/JSON via POST form
+    autenticato (non crawlabile). CC BY 3.0. Speculare a dati_camera ma senza DCAT
+    catalog.
   datasets_in_use: []
 dati_cultura:
   source_kind: catalog
@@ -241,17 +237,16 @@ dati_cultura:
     method: sparql_query
     query_name: dcat_datasets
     reliability: medium
-    note: Catalogo linked-data MiC (ArCo) con metadati DCAT interrogabili via 
-      SPARQL. ~150 dataset/thesaurus nel catalogo. Pilot per inventory SPARQL 
-      oltre ISPRA.
+    note: Catalogo linked-data MiC (ArCo) con metadati DCAT interrogabili via SPARQL.
+      ~150 dataset/thesaurus nel catalogo. Pilot per inventory SPARQL oltre ISPRA.
   sparql:
     endpoint_url: https://dati.cultura.gov.it/sparql
     query_name: dcat_datasets
     limit: 5000
     timeout_seconds: 90
   verdict: go
-  note: Catalogo ArCo MiC inventariabile via SPARQL DCAT. Source-check 
-    completato con verdict catalog-watch.
+  note: Catalogo ArCo MiC inventariabile via SPARQL DCAT. Source-check completato
+    con verdict catalog-watch.
   datasets_in_use: []
 ispra_linked_data:
   source_kind: catalog
@@ -272,14 +267,14 @@ ispra_linked_data:
     query_name: dcat_datasets
     limit: 5000
   verdict: go
-  note: Catalogo linked-data ISPRA con metadati DCAT interrogabili via SPARQL. 
-    Pilot per inventory SPARQL; non sostituisce le fonti operative ISPRA già 
-    usate per pipeline tabellari.
+  note: Catalogo linked-data ISPRA con metadati DCAT interrogabili via SPARQL. Pilot
+    per inventory SPARQL; non sostituisce le fonti operative ISPRA già usate per pipeline
+    tabellari.
   datasets_in_use:
-    - ispra_consumo_suolo
-    - ispra_ru_base
-    - ispra_ru_costi_kg
-    - ispra_ru_costi_procapite
+  - ispra_consumo_suolo
+  - ispra_ru_base
+  - ispra_ru_costi_kg
+  - ispra_ru_costi_procapite
 consip_open_data:
   source_kind: catalog
   protocol: ckan
@@ -292,13 +287,13 @@ consip_open_data:
     value: 17
     method: package_list
     reliability: medium
-    note: Baseline iniziale su CKAN package_list. I source-check del 2026-04-10 
-      hanno confermato almeno due dataset primari difendibili (bandi-e-gare, 
-      consumi-convenzioni) e un support dataset chiaro (operatori-economici).
+    note: Baseline iniziale su CKAN package_list. I source-check del 2026-04-10 hanno
+      confermato almeno due dataset primari difendibili (bandi-e-gare, consumi-convenzioni)
+      e un support dataset chiaro (operatori-economici).
   verdict: go
-  note: Catalogo CKAN piccolo ma difendibile per catalog-watch. I source-check 
-    dataset-specifici hanno confermato che il catalogo contiene almeno due 
-    target primari e un support dataset utile per il filone Consip acquisti PA.
+  note: Catalogo CKAN piccolo ma difendibile per catalog-watch. I source-check dataset-specifici
+    hanno confermato che il catalogo contiene almeno due target primari e un support
+    dataset utile per il filone Consip acquisti PA.
   datasets_in_use: []
 lavoro_opendata:
   source_kind: catalog
@@ -315,13 +310,12 @@ lavoro_opendata:
     value: 83
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:ministero-del-lavoro 
-      su dati.gov.it. 83 dataset harvestati dal portale Ministero del Lavoro.
+    note: Conteggio via package_search con fq=organization:ministero-del-lavoro su
+      dati.gov.it. 83 dataset harvestati dal portale Ministero del Lavoro.
   verdict: go
-  note: Fonte via dati.gov.it (harvesting Ministero del Lavoro). Sostituisce 
-    fonte diretta dati.lavoro.gov.it che aveva WAF. 83 dataset su lavoro 
-    (rapporti attivati/cessati, missioni, qualifiche professionali, genere, 
-    settore ATECO, ripartizione geografica).
+  note: Fonte via dati.gov.it (harvesting Ministero del Lavoro). Sostituisce fonte
+    diretta dati.lavoro.gov.it che aveva WAF. 83 dataset su lavoro (rapporti attivati/cessati,
+    missioni, qualifiche professionali, genere, settore ATECO, ripartizione geografica).
   datasets_in_use: []
 mur_ustat:
   source_kind: catalog
@@ -338,15 +332,14 @@ mur_ustat:
     value: 69
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-universita-e-ricerca su dati.gov.it. 69 dataset 
-      harvestati dal portale MUR.
+    note: Conteggio via package_search con fq=organization:ministero-universita-e-ricerca
+      su dati.gov.it. 69 dataset harvestati dal portale MUR.
   verdict: go
-  note: Fonte via dati.gov.it (harvesting MUR). Sostituisce fonte diretta 
-    dati-ustat.mur.gov.it che aveva ConnectTimeout. 69 dataset su istruzione 
-    universitaria (contribuzione atenei, DSU regionale, collegi, AFAM).
+  note: Fonte via dati.gov.it (harvesting MUR). Sostituisce fonte diretta dati-ustat.mur.gov.it
+    che aveva ConnectTimeout. 69 dataset su istruzione universitaria (contribuzione
+    atenei, DSU regionale, collegi, AFAM).
   datasets_in_use:
-    - mur_contribuzione_universitaria
+  - mur_contribuzione_universitaria
 opencoesione:
   source_kind: catalog
   protocol: ckan
@@ -357,27 +350,27 @@ opencoesione:
     timeout: 180
   last_probed: '2026-06-25'
   verdict: go
-  note: "Fonte via dati.gov.it (harvesting PCM-OpenCoesione). Sostituisce accesso
+  note: 'Fonte via dati.gov.it (harvesting PCM-OpenCoesione). Sostituisce accesso
     diretto a opencoesione.gov.it (API REST instabile: 403/timeout). 561 dataset totali
     su dati.gov.it; i 3 core sono progetti, soggetti, pagamenti (CSV + Parquet). Licenza
-    CC BY 4.0. File raw su opencoesione.gov.it. Ultimo aggiornamento contenuti: 2026-02-28.\n"
+    CC BY 4.0. File raw su opencoesione.gov.it. Ultimo aggiornamento contenuti: 2026-02-28.
+
+    '
   catalog_baseline:
     captured_at: '2026-06-03'
     metric: package_count
     value: 561
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:pcm-opencoesione su 
-      dati.gov.it. 561 dataset harvestati da OpenCoesione (3 core + 558 
-      granulari per tema/ciclo/ambito).
+    note: Conteggio via package_search con fq=organization:pcm-opencoesione su dati.gov.it.
+      561 dataset harvestati da OpenCoesione (3 core + 558 granulari per tema/ciclo/ambito).
   datasets_in_use:
-    - opencoesione_progetti
+  - opencoesione_progetti
 mef_irpef:
   source_kind: catalog
   protocol: html
   observation_mode: catalog-watch
-  base_url: 
-    https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
+  base_url: https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
   last_probed: '2026-06-25'
   catalog_baseline:
     captured_at: '2026-05-03'
@@ -389,18 +382,17 @@ mef_irpef:
       totali su singola pagina statica. Nessuna sitemap ne sottopagine. Prefix: REG,
       cla, sesso, Redditi. Serie 2010-2025.'
   verdict: go
-  note: Portale MEF Dipartimento Finanze — Open Data IRPEF comunale. Dati 
-    fiscali regionali per tipo reddito, classi, sesso. Alta rilevanza civica per
-    analisi disuguaglianza e gettito regionale.
+  note: Portale MEF Dipartimento Finanze — Open Data IRPEF comunale. Dati fiscali
+    regionali per tipo reddito, classi, sesso. Alta rilevanza civica per analisi disuguaglianza
+    e gettito regionale.
   html_portal:
     topic_hint: fisco
-    homepage: 
-      https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
+    homepage: https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
     delay_seconds: 0.2
     probe_content_type: true
   datasets_in_use:
-    - irpef_comunale
-    - mef_irpef_regionale
+  - irpef_comunale
+  - mef_irpef_regionale
 opencivitas:
   source_kind: catalog
   protocol: html
@@ -413,11 +405,11 @@ opencivitas:
     value: 1084
     method: csv_magnet_area_pages_paginated
     reliability: medium
-    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback 
-      necessario per cert invalido.
+    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback necessario
+      per cert invalido.
   verdict: go
-  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL 
-    fallback attivo. ZIP con CSV/XLSX dentro.
+  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL fallback
+    attivo. ZIP con CSV/XLSX dentro.
   html_portal:
     topic_hint: trasparenza
     page_url_template: https://www.opencivitas.it/it/open-data?page={page}
@@ -427,30 +419,32 @@ opencivitas:
     delay_seconds: 0.3
     probe_content_type: true
   datasets_in_use:
-    - opencivitas_fsc_2025_rso
+  - opencivitas_fsc_2025_rso
 aifa:
   source_kind: catalog
   protocol: html
   observation_mode: catalog-watch
   base_url: https://www.aifa.gov.it/dati-aifa
   verdict: go
-  note: "Portale Open Data AIFA — CSV scaricabili senza autenticazione. Licenza CC-BY
+  note: 'Portale Open Data AIFA — CSV scaricabili senza autenticazione. Licenza CC-BY
     4.0. Inventory via area_pages (sito principale ha protezioni anti-bot). Dataset:
     liste farmaci, provvedimenti, sperimentazioni cliniche, farmacovigilanza, incarichi,
-    bandi.\n"
+    bandi.
+
+    '
   html_portal:
     topic_hint: sanita
     area_pages:
-      - https://www.aifa.gov.it/web/guest/liste-dei-farmaci
-      - https://www.aifa.gov.it/web/guest/provvedimenti-aifa
-      - https://www.aifa.gov.it/web/guest/sperimentazioni-cliniche
-      - https://www.aifa.gov.it/web/guest/farmacovigilanza-open-data
-      - https://www.aifa.gov.it/web/guest/incarichi-e-consulenze
-      - https://www.aifa.gov.it/web/guest/bandi-di-gara-e-contratti-
+    - https://www.aifa.gov.it/web/guest/liste-dei-farmaci
+    - https://www.aifa.gov.it/web/guest/provvedimenti-aifa
+    - https://www.aifa.gov.it/web/guest/sperimentazioni-cliniche
+    - https://www.aifa.gov.it/web/guest/farmacovigilanza-open-data
+    - https://www.aifa.gov.it/web/guest/incarichi-e-consulenze
+    - https://www.aifa.gov.it/web/guest/bandi-di-gara-e-contratti-
     delay_seconds: 0.5
     probe_content_type: true
   datasets_in_use:
-    - aifa_spesa_consumo
+  - aifa_spesa_consumo
   last_probed: '2026-06-25'
 dait:
   source_kind: catalog
@@ -459,11 +453,13 @@ dait:
   base_url: https://dait.interno.gov.it/contenuti/tipo/open_data
   last_probed: '2026-06-25'
   verdict: go
-  note: "DAIT — Anagrafe Amministratori locali. CSV snapshot annuali 1991-2026 + \
-    \ corrente. 41 su 42 entry sono snapshot dello stesso dataset. radar-only iniziale
-    per evitare rumore catalog inventory sui 41 snapshot.\n"
+  note: 'DAIT — Anagrafe Amministratori locali. CSV snapshot annuali 1991-2026 +  corrente.
+    41 su 42 entry sono snapshot dello stesso dataset. radar-only iniziale per evitare
+    rumore catalog inventory sui 41 snapshot.
+
+    '
   datasets_in_use:
-    - dait_amministratori_locali
+  - dait_amministratori_locali
 eligendo:
   source_kind: catalog
   protocol: html
@@ -471,11 +467,13 @@ eligendo:
   base_url: https://elezionistorico.interno.gov.it/eligendo/opendata.php
   last_probed: '2026-06-25'
   verdict: go
-  note: "Eligendo — Archivio storico elettorale del DAIT (Ministero dell'Interno).\
-    \  Risultati elettorali per comune dal 1946: Camera (19 tornate 1948-2022),  Senato
-    (19 tornate), Europee (10 tornate 1979-2024), Regionali (1970-),  Comunali, Referendum,
-    Assemblea Costituente. 312 file in ZIP/CSV. radar-only perche' l'inventario e'
-    embedded in JS, non in link HTML diretti. Issue intake #523 su dataset-incubator.\n"
+  note: 'Eligendo — Archivio storico elettorale del DAIT (Ministero dell''Interno).  Risultati
+    elettorali per comune dal 1946: Camera (19 tornate 1948-2022),  Senato (19 tornate),
+    Europee (10 tornate 1979-2024), Regionali (1970-),  Comunali, Referendum, Assemblea
+    Costituente. 312 file in ZIP/CSV. radar-only perche'' l''inventario e'' embedded
+    in JS, non in link HTML diretti. Issue intake #523 su dataset-incubator.
+
+    '
   datasets_in_use: []
 mit_opendata:
   source_kind: catalog
@@ -488,8 +486,8 @@ mit_opendata:
     MIT dati.mit.gov.it non raggiungibile da 2026-05). 70 dataset: contratti pubblici,
     incidentalità, trasporti, opere pubbliche. CC-BY-4.0.'
   datasets_in_use:
-    - mit_incidentalita_mensile
-    - mit_opere_incompiute_2020
+  - mit_incidentalita_mensile
+  - mit_opere_incompiute_2020
   inventory:
     fq: organization:ministero-infrastrutture-e-trasporti
     timeout: 180
@@ -499,22 +497,23 @@ mit_opendata:
     value: 70
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-infrastrutture-e-trasporti su dati.gov.it.
+    note: Conteggio via package_search con fq=organization:ministero-infrastrutture-e-trasporti
+      su dati.gov.it.
 openga:
   source_kind: catalog
   protocol: ckan
   observation_mode: catalog-watch
-  base_url: 
-    https://openga.giustizia-amministrativa.it/api/3/action/package_list?limit=1
+  base_url: https://openga.giustizia-amministrativa.it/api/3/action/package_list?limit=1
   last_probed: '2026-06-25'
   verdict: go
-  note: "Portale CKAN Giustizia Amministrativa — ~270 dataset su ricorsi TAR+CDS,
+  note: 'Portale CKAN Giustizia Amministrativa — ~270 dataset su ricorsi TAR+CDS,
     sentenze, ordinanze, pareri. CC-BY 4.0. Aggiornamento mensile. Si incastra con
-    civile_flussi (giustizia ordinaria).\n"
+    civile_flussi (giustizia ordinaria).
+
+    '
   datasets_in_use:
-    - openga_ricorsi_appalto
-    - openga_ricorsi_cds
+  - openga_ricorsi_appalto
+  - openga_ricorsi_cds
 giustizia_statistiche:
   source_kind: catalog
   protocol: html
@@ -522,24 +521,26 @@ giustizia_statistiche:
   base_url: https://datiestatistiche.giustizia.it/
   last_probed: '2026-06-25'
   verdict: go
-  note: "Portale statistico Ministero Giustizia — XLSX scaricabili su flussi civili/penali,
+  note: 'Portale statistico Ministero Giustizia — XLSX scaricabili su flussi civili/penali,
     clearance rate, disposition time, sorveglianza, intercettazioni, monitoraggio
-    tribunali, durata procedimenti. Include dataset già in uso dal Lab.\n"
+    tribunali, durata procedimenti. Include dataset già in uso dal Lab.
+
+    '
   html_portal:
     topic_hint: giustizia
     area_pages:
-      - https://datiestatistiche.giustizia.it/page/it/flussi-tribunali-ordinari-e-corti-di-appello
-      - https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-civile
-      - https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-penale
-      - https://datiestatistiche.giustizia.it/it/sorveglianza.page
-      - https://datiestatistiche.giustizia.it/it/intercettazioni.page
-      - https://datiestatistiche.giustizia.it/page/it/durata-dei-procedimenti-civili
-      - https://datiestatistiche.giustizia.it/page/it/monitoraggio-mensile-dei-tribunal
+    - https://datiestatistiche.giustizia.it/page/it/flussi-tribunali-ordinari-e-corti-di-appello
+    - https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-civile
+    - https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-penale
+    - https://datiestatistiche.giustizia.it/it/sorveglianza.page
+    - https://datiestatistiche.giustizia.it/it/intercettazioni.page
+    - https://datiestatistiche.giustizia.it/page/it/durata-dei-procedimenti-civili
+    - https://datiestatistiche.giustizia.it/page/it/monitoraggio-mensile-dei-tribunal
     delay_seconds: 0.3
     probe_content_type: true
   datasets_in_use:
-    - civile_flussi
-    - giustizia_penale_indicatori
+  - civile_flussi
+  - giustizia_penale_indicatori
 cortecostituzionale:
   source_kind: catalog
   protocol: html
@@ -547,9 +548,11 @@ cortecostituzionale:
   base_url: https://dati.cortecostituzionale.it/Scarica_i_dati/Scarica_i_dati
   last_probed: '2026-06-25'
   verdict: go
-  note: "Portale Open Data Corte Costituzionale — Pronunce (1956-oggi), Massime, Anagrafica
+  note: 'Portale Open Data Corte Costituzionale — Pronunce (1956-oggi), Massime, Anagrafica
     Giudici, Atti di promovimento. CSV/XML/JSON in ZIP. Agg. giornaliero. Endpoint
-    SPARQL disponibile.\n"
+    SPARQL disponibile.
+
+    '
   html_portal:
     topic_hint: giustizia
     homepage: https://dati.cortecostituzionale.it/Scarica_i_dati/Scarica_i_dati
@@ -563,44 +566,46 @@ terna_opendata:
   base_url: https://dati.terna.it/
   last_probed: '2026-06-25'
   verdict: go
-  note: "Portale Dati Terna — API Sitecore REST. 31+ dataset su energia (fabbisogno,
+  note: 'Portale Dati Terna — API Sitecore REST. 31+ dataset su energia (fabbisogno,
     generazione, trasmissione, mercato, adeguatezza). API pubblica ritorna XLSX. Già
-    in uso da pipeline Lab. Catalog-watch richiederebbe connector custom.\n"
+    in uso da pipeline Lab. Catalog-watch richiederebbe connector custom.
+
+    '
   api_discovery:
     endpoint: https://dati.terna.it/api/sitecore/dati/downloadcenter/records
     known_datasets:
-      - TotalLoad
-      - MarketLoad
-      - PeakValleyLoad
-      - DailyDataIndexes
-      - InternationalComparisons
-      - IMCEI
-      - IMSER
-      - ElectricalEnergy
-      - Market
-      - IndustrialSector
-      - ServiceSector
-      - Total
-      - ConsumptionBySource
-      - ElectricityItaly
-      - ElectricityByType
-      - ActualGeneration
-      - RenewableGeneration
-      - EnergyBalance
-      - RenewableSources
-      - NonRenewableSources
-      - Storage
-      - ElectricityBySource
-      - ProductionRenewableSources
-      - HydroPower
-      - GrossVsCO2Emissions
-      - ProductionThermal
-      - ThermalHeat
-      - CapacityRenewableSources
-      - CapacityThermal
-      - GenerationPlants
+    - TotalLoad
+    - MarketLoad
+    - PeakValleyLoad
+    - DailyDataIndexes
+    - InternationalComparisons
+    - IMCEI
+    - IMSER
+    - ElectricalEnergy
+    - Market
+    - IndustrialSector
+    - ServiceSector
+    - Total
+    - ConsumptionBySource
+    - ElectricityItaly
+    - ElectricityByType
+    - ActualGeneration
+    - RenewableGeneration
+    - EnergyBalance
+    - RenewableSources
+    - NonRenewableSources
+    - Storage
+    - ElectricityBySource
+    - ProductionRenewableSources
+    - HydroPower
+    - GrossVsCO2Emissions
+    - ProductionThermal
+    - ThermalHeat
+    - CapacityRenewableSources
+    - CapacityThermal
+    - GenerationPlants
   datasets_in_use:
-    - terna_electricity_by_source
+  - terna_electricity_by_source
 ministero_interno:
   source_kind: catalog
   protocol: ckan
@@ -616,14 +621,12 @@ ministero_interno:
     value: 38
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-dell-interno su dati.gov.it. 38 dataset su 
-      elezioni (per comune) e ANPR (popolazione).
+    note: Conteggio via package_search con fq=organization:ministero-dell-interno
+      su dati.gov.it. 38 dataset su elezioni (per comune) e ANPR (popolazione).
   verdict: go
-  note: Fonte via dati.gov.it. Dati elezioni (Politiche 2022, Comunali 2024, 
-    Europee 2024, Regionali) per comune + ANPR (popolazione residente, cambi 
-    residenza, certificati, AIRE). Alto valore civico per analisi territoriale 
-    del voto.
+  note: Fonte via dati.gov.it. Dati elezioni (Politiche 2022, Comunali 2024, Europee
+    2024, Regionali) per comune + ANPR (popolazione residente, cambi residenza, certificati,
+    AIRE). Alto valore civico per analisi territoriale del voto.
   datasets_in_use: []
 agid:
   source_kind: catalog
@@ -640,16 +643,15 @@ agid:
     value: 40
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:agenzia-per-l-italia-digitale su dati.gov.it. 40 dataset 
-      IPA (enti, PEC, domicili digitali, servizi, RTD).
+    note: Conteggio via package_search con fq=organization:agenzia-per-l-italia-digitale
+      su dati.gov.it. 40 dataset IPA (enti, PEC, domicili digitali, servizi, RTD).
   verdict: go
   note: 'Fonte via dati.gov.it. IPA — Indice delle PA: enti, unita organizzative,
     PEC, domicili digitali, responsabili transizione digitale, servizi digitali, fatturazione
     elettronica, cloud. Codice_IPA chiave di join con ANAC.'
   datasets_in_use:
-    - ipa_enti
-    - ipa_istat_mapping
+  - ipa_enti
+  - ipa_istat_mapping
 noipa_sparql:
   source_kind: catalog
   protocol: sparql
@@ -657,12 +659,11 @@ noipa_sparql:
   base_url: https://sparql-noipa.mef.gov.it/sparql
   last_probed: '2026-06-25'
   verdict: hold
-  note: NoiPA SPARQL — MEF/RGS. Dati mensili personale PA (entries-{YYYYMM}, 
-    2019-2026) + pensioni PA (entriesPensioni-{YYYYMM}, 2017-oggi). ~490k 
-    soggetti/mese. L'endpoint risponde solo in XML 
-    (application/sparql-results+xml). Inventory non funzionante finché 
-    execute_sparql() in lab-connectors non supporta XML. Radar-only in attesa di
-    parser XML o di endpoint JSON.
+  note: NoiPA SPARQL — MEF/RGS. Dati mensili personale PA (entries-{YYYYMM}, 2019-2026)
+    + pensioni PA (entriesPensioni-{YYYYMM}, 2017-oggi). ~490k soggetti/mese. L'endpoint
+    risponde solo in XML (application/sparql-results+xml). Inventory non funzionante
+    finché execute_sparql() in lab-connectors non supporta XML. Radar-only in attesa
+    di parser XML o di endpoint JSON.
   datasets_in_use: []
 mimit_rna:
   source_kind: catalog
@@ -679,9 +680,8 @@ mimit_rna:
     value: 370
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-delle-imprese-e-del-made-in-italy su 
-      dati.gov.it. 370 dataset (133 RNA Aiuti + 237 RNA Misure).
+    note: Conteggio via package_search con fq=organization:ministero-delle-imprese-e-del-made-in-italy
+      su dati.gov.it. 370 dataset (133 RNA Aiuti + 237 RNA Misure).
   verdict: go
   note: 'Fonte via dati.gov.it. RNA — Registro Nazionale Aiuti di Stato. 133 dataset
     mensili Aiuti (2017-2026, XML, ~14.500 record/mese) + 237 dataset Misure (1994-2023).
@@ -689,6 +689,8 @@ mimit_rna:
     civico: tracciamento aiuti pubblici alle imprese con beneficiario, CF, importo,
     regione, CUP.'
   datasets_in_use: []
+  source_check:
+    max_concurrency: 2
 ministero_salute:
   source_kind: catalog
   protocol: ckan
@@ -704,10 +706,9 @@ ministero_salute:
     value: 51
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:ministero-della-salute su dati.gov.it. 51 dataset 
-      (farmacie, posti letto, personale SSN, dispositivi, ASL, fitosanitari). 
-      URL raw su dati.salute.gov.it (portale in migrazione).
+    note: Conteggio via package_search con fq=organization:ministero-della-salute
+      su dati.gov.it. 51 dataset (farmacie, posti letto, personale SSN, dispositivi,
+      ASL, fitosanitari). URL raw su dati.salute.gov.it (portale in migrazione).
   verdict: go
   note: 'Fonte via dati.gov.it. Anagrafiche sanitarie nazionali: farmacie, parafarmacie,
     posti letto, personale SSN, ASL, dispositivi medici, fitosanitari. I file raw
@@ -715,10 +716,10 @@ ministero_salute:
     Complementare a dati_salute (csv_magnet) per il catalogo completo del portale
     diretto.'
   datasets_in_use:
-    - farmacie
-    - reparti_ricovero
-    - strutture_asl
-    - strutture_ricovero_asl
+  - farmacie
+  - reparti_ricovero
+  - strutture_asl
+  - strutture_ricovero_asl
 agcm:
   source_kind: catalog
   protocol: ckan
@@ -734,12 +735,14 @@ agcm:
     value: 53
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:agcm su dati.gov.it. 
-      53 dataset (rating di legalità, operazioni di concentrazione).
+    note: Conteggio via package_search con fq=organization:agcm su dati.gov.it. 53
+      dataset (rating di legalità, operazioni di concentrazione).
   verdict: go
-  note: "Fonte via dati.gov.it (AGCM). 53 dataset su concorrenza e mercato: rating
-    di legalita' (elenchi settimanali imprese con rating), operazioni di concentrazione
-    2021-2025.\n"
+  note: 'Fonte via dati.gov.it (AGCM). 53 dataset su concorrenza e mercato: rating
+    di legalita'' (elenchi settimanali imprese con rating), operazioni di concentrazione
+    2021-2025.
+
+    '
   datasets_in_use: []
 unioncamere:
   source_kind: catalog
@@ -747,8 +750,7 @@ unioncamere:
   observation_mode: catalog-watch
   base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
   inventory:
-    fq: 
-      organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
+    fq: organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
     timeout: 180
   last_probed: '2026-06-25'
   catalog_baseline:
@@ -757,16 +759,17 @@ unioncamere:
     value: 352
     method: package_search
     reliability: high
-    note: Conteggio via package_search con 
-      fq=organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
-      su dati.gov.it. 352 dataset provincia per provincia su demografia 
-      d'impresa (natimortalità, femminili, giovanili, straniere, artigiane, 
-      ATECO). ~340 provincia-specific, ~12 nazionali aggregati.
+    note: Conteggio via package_search con fq=organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
+      su dati.gov.it. 352 dataset provincia per provincia su demografia d'impresa
+      (natimortalità, femminili, giovanili, straniere, artigiane, ATECO). ~340 provincia-specific,
+      ~12 nazionali aggregati.
   verdict: go
-  note: "Fonte via dati.gov.it (Unioncamere). 352 dataset su demografia d'impresa
+  note: 'Fonte via dati.gov.it (Unioncamere). 352 dataset su demografia d''impresa
     per provincia: femminili, giovanili, straniere, artigiane, ATECO, forma giuridica.
     Dataset prevalentemente provincia-specifici (~340). ~12 dataset nazionali aggregati
-    (es. 'Italia - Imprese femminili...').\n"
+    (es. ''Italia - Imprese femminili...'').
+
+    '
   datasets_in_use: []
 pagopa:
   source_kind: catalog
@@ -783,8 +786,8 @@ pagopa:
     value: 8
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:pagopa-s-p-a su 
-      dati.gov.it. 8 dataset (transazioni pagoPA, IO App, SEND).
+    note: Conteggio via package_search con fq=organization:pagopa-s-p-a su dati.gov.it.
+      8 dataset (transazioni pagoPA, IO App, SEND).
   verdict: go
   note: 'Fonte via dati.gov.it. 8 dataset: pagoPA (transazioni per anno, mese, fascia
     importo, categoria ente), IO App (messaggi, geografia enti e servizi), SEND (notifiche

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -12,18 +12,18 @@ istat_sdmx:
     value: 4212
     method: dataflow_count
     reliability: medium
-    note: Re-baseline su endpoint esploradati (MCP ondata). Il valore 4212 e' il conteggio
-      riproducibile via MCP discover_dataflows (no keyword, no blacklist) dopo filtro
-      NonProductionDataflow. Il valore 509 era il conteggio su sdmx.istat.it (endpoint
-      diverso).
+    note: Re-baseline su endpoint esploradati (MCP ondata). Il valore 4212 e' il
+      conteggio riproducibile via MCP discover_dataflows (no keyword, no
+      blacklist) dopo filtro NonProductionDataflow. Il valore 509 era il
+      conteggio su sdmx.istat.it (endpoint diverso).
   verdict: go
   note: Endpoint SDMX ricco e ad alto valore per scouting e source-check.
   datasets_in_use:
-  - istat_gini_regionale
-  - istat_housing_crowding
-  - istat_ipab_aree
-  - istat_pil_territoriale
-  - popolazione_istat_comunale_2019_2025
+    - istat_gini_regionale
+    - istat_housing_crowding
+    - istat_ipab_aree
+    - istat_pil_territoriale
+    - popolazione_istat_comunale_2019_2025
 anac:
   source_kind: catalog
   protocol: ckan
@@ -39,15 +39,15 @@ anac:
     value: 70
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:anac su dati.gov.it. 70
-      dataset harvestati dal portale ANAC.
+    note: Conteggio via package_search con fq=organization:anac su dati.gov.it.
+      70 dataset harvestati dal portale ANAC.
   verdict: go
   note: 'Fonte via dati.gov.it (harvesting ANAC). I download raw vanno al portale
     diretto dati.anticorruzione.it con User-Agent browser (WAF blocca solo python-requests).
     70 dataset: CIG (2007-2023), SMARTCIG, OCDS, stazioni appaltanti, aggiudicatari,
     subappalti, varianti, PNRR indicatori, SOA. CC-BY-SA 4.0.'
   datasets_in_use:
-  - anac_bandi_gara
+    - anac_bandi_gara
 inps:
   source_kind: catalog
   protocol: ckan
@@ -65,19 +65,21 @@ inps:
     value: 2323
     method: package_list
     reliability: high
-    note: Inventory via package_list + package_show_sample (16 workers). current_package_list_with_resources
-      testato ma scartato per lentezza a offset alti. package_show_sample più veloce.
+    note: Inventory via package_list + package_show_sample (16 workers).
+      current_package_list_with_resources testato ma scartato per lentezza a
+      offset alti. package_show_sample più veloce.
   verdict: go
-  note: Catalogo CKAN INPS — inventory via package_list + package_show_sample (current_package_list_with_resources
-    lento a offset alti).
+  note: Catalogo CKAN INPS — inventory via package_list + package_show_sample
+    (current_package_list_with_resources lento a offset alti).
   datasets_in_use:
-  - inps_pensioni_trimestrale
-  - pensioni_pa_dag
+    - inps_pensioni_trimestrale
+    - pensioni_pa_dag
 openbdap:
   source_kind: catalog
   protocol: ckan
   observation_mode: catalog-watch
-  base_url: https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
+  base_url:
+    https://bdap-opendata.rgs.mef.gov.it/SpodCkanApi/api/3/action/package_list?limit=1
   inventory:
     timeout: 1200
     skip_package_search: true
@@ -93,17 +95,17 @@ openbdap:
     value: 3772
     method: package_list
     reliability: medium
-    note: Conteggio totale package rilevati via package_list; package_search restituisce
-      count inaffidabile.
+    note: Conteggio totale package rilevati via package_list; package_search
+      restituisce count inaffidabile.
   verdict: go
-  note: Catalogo CKAN molto ricco; osservazione iniziale stretta a livello inventario
-    senza intake o monitor diffuso.
+  note: Catalogo CKAN molto ricco; osservazione iniziale stretta a livello
+    inventario senza intake o monitor diffuso.
   datasets_in_use:
-  - bdap_anagrafe_enti
-  - bdap_entrate_stato
-  - bdap_lea
-  - bdap_spese_stato
-  - dipendenti_pubblici
+    - bdap_anagrafe_enti
+    - bdap_entrate_stato
+    - bdap_lea
+    - bdap_spese_stato
+    - dipendenti_pubblici
 inail_opendata:
   source_kind: portal
   protocol: aem
@@ -111,9 +113,10 @@ inail_opendata:
   base_url: https://dati.inail.it/
   last_probed: '2026-06-25'
   verdict: go
-  note: Portale AEM con Open API documentate. Superficie operativa reale = catalogo
-    AEM + Open API, non CKAN standard (logo nel footer fuorviante). Baseline inventariale
-    non ancora difendibile; tenere in radar-only finche' non definito un metodo stabile.
+  note: Portale AEM con Open API documentate. Superficie operativa reale =
+    catalogo AEM + Open API, non CKAN standard (logo nel footer fuorviante).
+    Baseline inventariale non ancora difendibile; tenere in radar-only finche'
+    non definito un metodo stabile.
   datasets_in_use: []
 mim_opendata:
   source_kind: catalog
@@ -131,20 +134,21 @@ mim_opendata:
       Personale, Valutazione, Edilizia, Adozioni). 1116 link CSV/XLS. Prefix: ALU=300,
       EDI=282, SCU=132. Nessuna sitemap disponibile.'
   verdict: go
-  note: Portale Ministero Istruzione — csv_magnet scan via area_pages (no sitemap).
+  note: Portale Ministero Istruzione — csv_magnet scan via area_pages (no
+    sitemap).
   html_portal:
     topic_hint: istruzione
     area_pages:
-    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole
-    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Studenti
-    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Personale%20Scuola
-    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Sistema%20Nazionale%20di%20Valutazione
-    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Edilizia%20Scolastica
-    - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Adozioni%20libri%20di%20testo
+      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole
+      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Studenti
+      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Personale%20Scuola
+      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Sistema%20Nazionale%20di%20Valutazione
+      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Edilizia%20Scolastica
+      - https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Adozioni%20libri%20di%20testo
     delay_seconds: 0.3
   datasets_in_use:
-  - mim_alunni_corso_eta
-  - mim_anagrafica_scuole_statali
+    - mim_alunni_corso_eta
+    - mim_anagrafica_scuole_statali
 dati_camera:
   source_kind: catalog
   protocol: sparql
@@ -160,26 +164,26 @@ dati_camera:
     method: sparql_query
     query_name: camera_dcat
     reliability: medium
-    note: Baseline fissata con query custom Camera perché il catalogo usa proprietà
-      DC 1.1 Elements per titolo e descrizione.
+    note: Baseline fissata con query custom Camera perché il catalogo usa
+      proprietà DC 1.1 Elements per titolo e descrizione.
   sparql:
     endpoint_url: https://dati.camera.it/sparql
     query_name: camera_dcat
     limit: 5000
     timeout_seconds: 60
     query: "PREFIX dcat: <http://www.w3.org/ns/dcat#>\nPREFIX dc: <http://purl.org/dc/elements/1.1/>\n\
-      PREFIX dct: <http://purl.org/dc/terms/>\nSELECT DISTINCT ?dataset ?title ?description\
-      \ ?modified ?landingPage\nWHERE {\n  ?dataset a dcat:Dataset .\n  OPTIONAL {\
-      \ ?dataset dc:title ?title . }\n  OPTIONAL { ?dataset dc:description ?description\
-      \ . }\n  OPTIONAL { ?dataset dct:modified ?modified . }\n  OPTIONAL { ?dataset\
-      \ dcat:landingPage ?landingPage . }\n}\nORDER BY ?dataset\nLIMIT 5000\n"
+      PREFIX dct: <http://purl.org/dc/terms/>\nSELECT DISTINCT ?dataset ?title ?description
+      ?modified ?landingPage\nWHERE {\n  ?dataset a dcat:Dataset .\n  OPTIONAL { ?dataset
+      dc:title ?title . }\n  OPTIONAL { ?dataset dc:description ?description . }\n\
+      \  OPTIONAL { ?dataset dct:modified ?modified . }\n  OPTIONAL { ?dataset dcat:landingPage
+      ?landingPage . }\n}\nORDER BY ?dataset\nLIMIT 5000\n"
   verdict: go
-  note: Catalogo linked-data Camera inventariabile via query SPARQL custom. Il template
-    DCAT generico non valorizza titolo e descrizione perché l'endpoint usa dc:title
-    e dc:description.
+  note: Catalogo linked-data Camera inventariabile via query SPARQL custom. Il
+    template DCAT generico non valorizza titolo e descrizione perché l'endpoint
+    usa dc:title e dc:description.
   datasets_in_use:
-  - camera_deputati_legislature
-  - camera_votazioni_sparql
+    - camera_deputati_legislature
+    - camera_votazioni_sparql
 dati_senato:
   source_kind: catalog
   protocol: sparql
@@ -187,8 +191,8 @@ dati_senato:
   base_url: https://dati.senato.it/sparql
   inventory:
     timeout: 600
-    timeout_reason: 99 query SPARQL (1 discover + 98 schema enrich × 15 pred). stimate
-      5s/query su Virtuoso. 99 × 5 × 1.2 = 594s
+    timeout_reason: 99 query SPARQL (1 discover + 98 schema enrich × 15 pred).
+      stimate 5s/query su Virtuoso. 99 × 5 × 1.2 = 594s
   last_probed: '2026-06-25'
   catalog_baseline:
     captured_at: '2026-05-31'
@@ -197,9 +201,9 @@ dati_senato:
     method: named_graphs
     query_name: named_graphs
     reliability: medium
-    note: Baseline via enumerazione named graphs SPARQL. ~98 grafi organizzati per
-      categoria (composizione, ddl, votazioni, emendamenti, ecc.) e legislatura (01-19).
-      Fonte non ha DCAT catalog.
+    note: Baseline via enumerazione named graphs SPARQL. ~98 grafi organizzati
+      per categoria (composizione, ddl, votazioni, emendamenti, ecc.) e
+      legislatura (01-19). Fonte non ha DCAT catalog.
   sparql:
     endpoint_url: https://dati.senato.it/sparql
     inventory_mode: named_graphs
@@ -208,21 +212,21 @@ dati_senato:
     timeout_seconds: 300
     graph_uri_prefix: http://dati.senato.it/
     graph_uri_blacklist:
-    - localhost
-    - virtrdf
-    - owl#
-    - rules.skos
-    - virtrdf-label
-    - '8890'
-    - b3sifp
-    - b3sonto
-    - facets
-    - teseo
+      - localhost
+      - virtrdf
+      - owl#
+      - rules.skos
+      - virtrdf-label
+      - '8890'
+      - b3sifp
+      - b3sonto
+      - facets
+      - teseo
   verdict: go
-  note: Portale Open Data Senato. SPARQL endpoint Virtuoso (GET). Inventory via enumerazione
-    named graphs (~98 grafi categoria/legislatura). Download CSV/JSON via POST form
-    autenticato (non crawlabile). CC BY 3.0. Speculare a dati_camera ma senza DCAT
-    catalog.
+  note: Portale Open Data Senato. SPARQL endpoint Virtuoso (GET). Inventory via
+    enumerazione named graphs (~98 grafi categoria/legislatura). Download
+    CSV/JSON via POST form autenticato (non crawlabile). CC BY 3.0. Speculare a
+    dati_camera ma senza DCAT catalog.
   datasets_in_use: []
 dati_cultura:
   source_kind: catalog
@@ -237,16 +241,17 @@ dati_cultura:
     method: sparql_query
     query_name: dcat_datasets
     reliability: medium
-    note: Catalogo linked-data MiC (ArCo) con metadati DCAT interrogabili via SPARQL.
-      ~150 dataset/thesaurus nel catalogo. Pilot per inventory SPARQL oltre ISPRA.
+    note: Catalogo linked-data MiC (ArCo) con metadati DCAT interrogabili via
+      SPARQL. ~150 dataset/thesaurus nel catalogo. Pilot per inventory SPARQL
+      oltre ISPRA.
   sparql:
     endpoint_url: https://dati.cultura.gov.it/sparql
     query_name: dcat_datasets
     limit: 5000
     timeout_seconds: 90
   verdict: go
-  note: Catalogo ArCo MiC inventariabile via SPARQL DCAT. Source-check completato
-    con verdict catalog-watch.
+  note: Catalogo ArCo MiC inventariabile via SPARQL DCAT. Source-check
+    completato con verdict catalog-watch.
   datasets_in_use: []
 ispra_linked_data:
   source_kind: catalog
@@ -267,14 +272,14 @@ ispra_linked_data:
     query_name: dcat_datasets
     limit: 5000
   verdict: go
-  note: Catalogo linked-data ISPRA con metadati DCAT interrogabili via SPARQL. Pilot
-    per inventory SPARQL; non sostituisce le fonti operative ISPRA già usate per pipeline
-    tabellari.
+  note: Catalogo linked-data ISPRA con metadati DCAT interrogabili via SPARQL.
+    Pilot per inventory SPARQL; non sostituisce le fonti operative ISPRA già
+    usate per pipeline tabellari.
   datasets_in_use:
-  - ispra_consumo_suolo
-  - ispra_ru_base
-  - ispra_ru_costi_kg
-  - ispra_ru_costi_procapite
+    - ispra_consumo_suolo
+    - ispra_ru_base
+    - ispra_ru_costi_kg
+    - ispra_ru_costi_procapite
 consip_open_data:
   source_kind: catalog
   protocol: ckan
@@ -287,13 +292,13 @@ consip_open_data:
     value: 17
     method: package_list
     reliability: medium
-    note: Baseline iniziale su CKAN package_list. I source-check del 2026-04-10 hanno
-      confermato almeno due dataset primari difendibili (bandi-e-gare, consumi-convenzioni)
-      e un support dataset chiaro (operatori-economici).
+    note: Baseline iniziale su CKAN package_list. I source-check del 2026-04-10
+      hanno confermato almeno due dataset primari difendibili (bandi-e-gare,
+      consumi-convenzioni) e un support dataset chiaro (operatori-economici).
   verdict: go
-  note: Catalogo CKAN piccolo ma difendibile per catalog-watch. I source-check dataset-specifici
-    hanno confermato che il catalogo contiene almeno due target primari e un support
-    dataset utile per il filone Consip acquisti PA.
+  note: Catalogo CKAN piccolo ma difendibile per catalog-watch. I source-check
+    dataset-specifici hanno confermato che il catalogo contiene almeno due
+    target primari e un support dataset utile per il filone Consip acquisti PA.
   datasets_in_use: []
 lavoro_opendata:
   source_kind: catalog
@@ -310,12 +315,13 @@ lavoro_opendata:
     value: 83
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:ministero-del-lavoro su
-      dati.gov.it. 83 dataset harvestati dal portale Ministero del Lavoro.
+    note: Conteggio via package_search con fq=organization:ministero-del-lavoro
+      su dati.gov.it. 83 dataset harvestati dal portale Ministero del Lavoro.
   verdict: go
-  note: Fonte via dati.gov.it (harvesting Ministero del Lavoro). Sostituisce fonte
-    diretta dati.lavoro.gov.it che aveva WAF. 83 dataset su lavoro (rapporti attivati/cessati,
-    missioni, qualifiche professionali, genere, settore ATECO, ripartizione geografica).
+  note: Fonte via dati.gov.it (harvesting Ministero del Lavoro). Sostituisce
+    fonte diretta dati.lavoro.gov.it che aveva WAF. 83 dataset su lavoro
+    (rapporti attivati/cessati, missioni, qualifiche professionali, genere,
+    settore ATECO, ripartizione geografica).
   datasets_in_use: []
 mur_ustat:
   source_kind: catalog
@@ -332,14 +338,15 @@ mur_ustat:
     value: 69
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:ministero-universita-e-ricerca
-      su dati.gov.it. 69 dataset harvestati dal portale MUR.
+    note: Conteggio via package_search con
+      fq=organization:ministero-universita-e-ricerca su dati.gov.it. 69 dataset
+      harvestati dal portale MUR.
   verdict: go
-  note: Fonte via dati.gov.it (harvesting MUR). Sostituisce fonte diretta dati-ustat.mur.gov.it
-    che aveva ConnectTimeout. 69 dataset su istruzione universitaria (contribuzione
-    atenei, DSU regionale, collegi, AFAM).
+  note: Fonte via dati.gov.it (harvesting MUR). Sostituisce fonte diretta
+    dati-ustat.mur.gov.it che aveva ConnectTimeout. 69 dataset su istruzione
+    universitaria (contribuzione atenei, DSU regionale, collegi, AFAM).
   datasets_in_use:
-  - mur_contribuzione_universitaria
+    - mur_contribuzione_universitaria
 opencoesione:
   source_kind: catalog
   protocol: ckan
@@ -350,27 +357,27 @@ opencoesione:
     timeout: 180
   last_probed: '2026-06-25'
   verdict: go
-  note: 'Fonte via dati.gov.it (harvesting PCM-OpenCoesione). Sostituisce accesso
+  note: "Fonte via dati.gov.it (harvesting PCM-OpenCoesione). Sostituisce accesso
     diretto a opencoesione.gov.it (API REST instabile: 403/timeout). 561 dataset totali
     su dati.gov.it; i 3 core sono progetti, soggetti, pagamenti (CSV + Parquet). Licenza
-    CC BY 4.0. File raw su opencoesione.gov.it. Ultimo aggiornamento contenuti: 2026-02-28.
-
-    '
+    CC BY 4.0. File raw su opencoesione.gov.it. Ultimo aggiornamento contenuti: 2026-02-28.\n"
   catalog_baseline:
     captured_at: '2026-06-03'
     metric: package_count
     value: 561
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:pcm-opencoesione su dati.gov.it.
-      561 dataset harvestati da OpenCoesione (3 core + 558 granulari per tema/ciclo/ambito).
+    note: Conteggio via package_search con fq=organization:pcm-opencoesione su
+      dati.gov.it. 561 dataset harvestati da OpenCoesione (3 core + 558
+      granulari per tema/ciclo/ambito).
   datasets_in_use:
-  - opencoesione_progetti
+    - opencoesione_progetti
 mef_irpef:
   source_kind: catalog
   protocol: html
   observation_mode: catalog-watch
-  base_url: https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
+  base_url:
+    https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
   last_probed: '2026-06-25'
   catalog_baseline:
     captured_at: '2026-05-03'
@@ -382,17 +389,18 @@ mef_irpef:
       totali su singola pagina statica. Nessuna sitemap ne sottopagine. Prefix: REG,
       cla, sesso, Redditi. Serie 2010-2025.'
   verdict: go
-  note: Portale MEF Dipartimento Finanze — Open Data IRPEF comunale. Dati fiscali
-    regionali per tipo reddito, classi, sesso. Alta rilevanza civica per analisi disuguaglianza
-    e gettito regionale.
+  note: Portale MEF Dipartimento Finanze — Open Data IRPEF comunale. Dati
+    fiscali regionali per tipo reddito, classi, sesso. Alta rilevanza civica per
+    analisi disuguaglianza e gettito regionale.
   html_portal:
     topic_hint: fisco
-    homepage: https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
+    homepage:
+      https://www1.finanze.gov.it/finanze/analisi_stat/public/index.php?opendata=yes
     delay_seconds: 0.2
     probe_content_type: true
   datasets_in_use:
-  - irpef_comunale
-  - mef_irpef_regionale
+    - irpef_comunale
+    - mef_irpef_regionale
 opencivitas:
   source_kind: catalog
   protocol: html
@@ -405,11 +413,11 @@ opencivitas:
     value: 1084
     method: csv_magnet_area_pages_paginated
     reliability: medium
-    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback necessario
-      per cert invalido.
+    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback
+      necessario per cert invalido.
   verdict: go
-  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL fallback
-    attivo. ZIP con CSV/XLSX dentro.
+  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL
+    fallback attivo. ZIP con CSV/XLSX dentro.
   html_portal:
     topic_hint: trasparenza
     page_url_template: https://www.opencivitas.it/it/open-data?page={page}
@@ -419,32 +427,30 @@ opencivitas:
     delay_seconds: 0.3
     probe_content_type: true
   datasets_in_use:
-  - opencivitas_fsc_2025_rso
+    - opencivitas_fsc_2025_rso
 aifa:
   source_kind: catalog
   protocol: html
   observation_mode: catalog-watch
   base_url: https://www.aifa.gov.it/dati-aifa
   verdict: go
-  note: 'Portale Open Data AIFA — CSV scaricabili senza autenticazione. Licenza CC-BY
+  note: "Portale Open Data AIFA — CSV scaricabili senza autenticazione. Licenza CC-BY
     4.0. Inventory via area_pages (sito principale ha protezioni anti-bot). Dataset:
     liste farmaci, provvedimenti, sperimentazioni cliniche, farmacovigilanza, incarichi,
-    bandi.
-
-    '
+    bandi.\n"
   html_portal:
     topic_hint: sanita
     area_pages:
-    - https://www.aifa.gov.it/web/guest/liste-dei-farmaci
-    - https://www.aifa.gov.it/web/guest/provvedimenti-aifa
-    - https://www.aifa.gov.it/web/guest/sperimentazioni-cliniche
-    - https://www.aifa.gov.it/web/guest/farmacovigilanza-open-data
-    - https://www.aifa.gov.it/web/guest/incarichi-e-consulenze
-    - https://www.aifa.gov.it/web/guest/bandi-di-gara-e-contratti-
+      - https://www.aifa.gov.it/web/guest/liste-dei-farmaci
+      - https://www.aifa.gov.it/web/guest/provvedimenti-aifa
+      - https://www.aifa.gov.it/web/guest/sperimentazioni-cliniche
+      - https://www.aifa.gov.it/web/guest/farmacovigilanza-open-data
+      - https://www.aifa.gov.it/web/guest/incarichi-e-consulenze
+      - https://www.aifa.gov.it/web/guest/bandi-di-gara-e-contratti-
     delay_seconds: 0.5
     probe_content_type: true
   datasets_in_use:
-  - aifa_spesa_consumo
+    - aifa_spesa_consumo
   last_probed: '2026-06-25'
 dait:
   source_kind: catalog
@@ -453,13 +459,11 @@ dait:
   base_url: https://dait.interno.gov.it/contenuti/tipo/open_data
   last_probed: '2026-06-25'
   verdict: go
-  note: 'DAIT — Anagrafe Amministratori locali. CSV snapshot annuali 1991-2026 +  corrente.
-    41 su 42 entry sono snapshot dello stesso dataset. radar-only iniziale per evitare
-    rumore catalog inventory sui 41 snapshot.
-
-    '
+  note: "DAIT — Anagrafe Amministratori locali. CSV snapshot annuali 1991-2026 + \
+    \ corrente. 41 su 42 entry sono snapshot dello stesso dataset. radar-only iniziale
+    per evitare rumore catalog inventory sui 41 snapshot.\n"
   datasets_in_use:
-  - dait_amministratori_locali
+    - dait_amministratori_locali
 eligendo:
   source_kind: catalog
   protocol: html
@@ -467,13 +471,11 @@ eligendo:
   base_url: https://elezionistorico.interno.gov.it/eligendo/opendata.php
   last_probed: '2026-06-25'
   verdict: go
-  note: 'Eligendo — Archivio storico elettorale del DAIT (Ministero dell''Interno).  Risultati
-    elettorali per comune dal 1946: Camera (19 tornate 1948-2022),  Senato (19 tornate),
-    Europee (10 tornate 1979-2024), Regionali (1970-),  Comunali, Referendum, Assemblea
-    Costituente. 312 file in ZIP/CSV. radar-only perche'' l''inventario e'' embedded
-    in JS, non in link HTML diretti. Issue intake #523 su dataset-incubator.
-
-    '
+  note: "Eligendo — Archivio storico elettorale del DAIT (Ministero dell'Interno).\
+    \  Risultati elettorali per comune dal 1946: Camera (19 tornate 1948-2022),  Senato
+    (19 tornate), Europee (10 tornate 1979-2024), Regionali (1970-),  Comunali, Referendum,
+    Assemblea Costituente. 312 file in ZIP/CSV. radar-only perche' l'inventario e'
+    embedded in JS, non in link HTML diretti. Issue intake #523 su dataset-incubator.\n"
   datasets_in_use: []
 mit_opendata:
   source_kind: catalog
@@ -486,8 +488,8 @@ mit_opendata:
     MIT dati.mit.gov.it non raggiungibile da 2026-05). 70 dataset: contratti pubblici,
     incidentalità, trasporti, opere pubbliche. CC-BY-4.0.'
   datasets_in_use:
-  - mit_incidentalita_mensile
-  - mit_opere_incompiute_2020
+    - mit_incidentalita_mensile
+    - mit_opere_incompiute_2020
   inventory:
     fq: organization:ministero-infrastrutture-e-trasporti
     timeout: 180
@@ -497,23 +499,22 @@ mit_opendata:
     value: 70
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:ministero-infrastrutture-e-trasporti
-      su dati.gov.it.
+    note: Conteggio via package_search con
+      fq=organization:ministero-infrastrutture-e-trasporti su dati.gov.it.
 openga:
   source_kind: catalog
   protocol: ckan
   observation_mode: catalog-watch
-  base_url: https://openga.giustizia-amministrativa.it/api/3/action/package_list?limit=1
+  base_url:
+    https://openga.giustizia-amministrativa.it/api/3/action/package_list?limit=1
   last_probed: '2026-06-25'
   verdict: go
-  note: 'Portale CKAN Giustizia Amministrativa — ~270 dataset su ricorsi TAR+CDS,
+  note: "Portale CKAN Giustizia Amministrativa — ~270 dataset su ricorsi TAR+CDS,
     sentenze, ordinanze, pareri. CC-BY 4.0. Aggiornamento mensile. Si incastra con
-    civile_flussi (giustizia ordinaria).
-
-    '
+    civile_flussi (giustizia ordinaria).\n"
   datasets_in_use:
-  - openga_ricorsi_appalto
-  - openga_ricorsi_cds
+    - openga_ricorsi_appalto
+    - openga_ricorsi_cds
 giustizia_statistiche:
   source_kind: catalog
   protocol: html
@@ -521,26 +522,24 @@ giustizia_statistiche:
   base_url: https://datiestatistiche.giustizia.it/
   last_probed: '2026-06-25'
   verdict: go
-  note: 'Portale statistico Ministero Giustizia — XLSX scaricabili su flussi civili/penali,
+  note: "Portale statistico Ministero Giustizia — XLSX scaricabili su flussi civili/penali,
     clearance rate, disposition time, sorveglianza, intercettazioni, monitoraggio
-    tribunali, durata procedimenti. Include dataset già in uso dal Lab.
-
-    '
+    tribunali, durata procedimenti. Include dataset già in uso dal Lab.\n"
   html_portal:
     topic_hint: giustizia
     area_pages:
-    - https://datiestatistiche.giustizia.it/page/it/flussi-tribunali-ordinari-e-corti-di-appello
-    - https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-civile
-    - https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-penale
-    - https://datiestatistiche.giustizia.it/it/sorveglianza.page
-    - https://datiestatistiche.giustizia.it/it/intercettazioni.page
-    - https://datiestatistiche.giustizia.it/page/it/durata-dei-procedimenti-civili
-    - https://datiestatistiche.giustizia.it/page/it/monitoraggio-mensile-dei-tribunal
+      - https://datiestatistiche.giustizia.it/page/it/flussi-tribunali-ordinari-e-corti-di-appello
+      - https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-civile
+      - https://datiestatistiche.giustizia.it/page/it/clearance-rate-e-disposition-time-penale
+      - https://datiestatistiche.giustizia.it/it/sorveglianza.page
+      - https://datiestatistiche.giustizia.it/it/intercettazioni.page
+      - https://datiestatistiche.giustizia.it/page/it/durata-dei-procedimenti-civili
+      - https://datiestatistiche.giustizia.it/page/it/monitoraggio-mensile-dei-tribunal
     delay_seconds: 0.3
     probe_content_type: true
   datasets_in_use:
-  - civile_flussi
-  - giustizia_penale_indicatori
+    - civile_flussi
+    - giustizia_penale_indicatori
 cortecostituzionale:
   source_kind: catalog
   protocol: html
@@ -548,11 +547,9 @@ cortecostituzionale:
   base_url: https://dati.cortecostituzionale.it/Scarica_i_dati/Scarica_i_dati
   last_probed: '2026-06-25'
   verdict: go
-  note: 'Portale Open Data Corte Costituzionale — Pronunce (1956-oggi), Massime, Anagrafica
+  note: "Portale Open Data Corte Costituzionale — Pronunce (1956-oggi), Massime, Anagrafica
     Giudici, Atti di promovimento. CSV/XML/JSON in ZIP. Agg. giornaliero. Endpoint
-    SPARQL disponibile.
-
-    '
+    SPARQL disponibile.\n"
   html_portal:
     topic_hint: giustizia
     homepage: https://dati.cortecostituzionale.it/Scarica_i_dati/Scarica_i_dati
@@ -566,46 +563,44 @@ terna_opendata:
   base_url: https://dati.terna.it/
   last_probed: '2026-06-25'
   verdict: go
-  note: 'Portale Dati Terna — API Sitecore REST. 31+ dataset su energia (fabbisogno,
+  note: "Portale Dati Terna — API Sitecore REST. 31+ dataset su energia (fabbisogno,
     generazione, trasmissione, mercato, adeguatezza). API pubblica ritorna XLSX. Già
-    in uso da pipeline Lab. Catalog-watch richiederebbe connector custom.
-
-    '
+    in uso da pipeline Lab. Catalog-watch richiederebbe connector custom.\n"
   api_discovery:
     endpoint: https://dati.terna.it/api/sitecore/dati/downloadcenter/records
     known_datasets:
-    - TotalLoad
-    - MarketLoad
-    - PeakValleyLoad
-    - DailyDataIndexes
-    - InternationalComparisons
-    - IMCEI
-    - IMSER
-    - ElectricalEnergy
-    - Market
-    - IndustrialSector
-    - ServiceSector
-    - Total
-    - ConsumptionBySource
-    - ElectricityItaly
-    - ElectricityByType
-    - ActualGeneration
-    - RenewableGeneration
-    - EnergyBalance
-    - RenewableSources
-    - NonRenewableSources
-    - Storage
-    - ElectricityBySource
-    - ProductionRenewableSources
-    - HydroPower
-    - GrossVsCO2Emissions
-    - ProductionThermal
-    - ThermalHeat
-    - CapacityRenewableSources
-    - CapacityThermal
-    - GenerationPlants
+      - TotalLoad
+      - MarketLoad
+      - PeakValleyLoad
+      - DailyDataIndexes
+      - InternationalComparisons
+      - IMCEI
+      - IMSER
+      - ElectricalEnergy
+      - Market
+      - IndustrialSector
+      - ServiceSector
+      - Total
+      - ConsumptionBySource
+      - ElectricityItaly
+      - ElectricityByType
+      - ActualGeneration
+      - RenewableGeneration
+      - EnergyBalance
+      - RenewableSources
+      - NonRenewableSources
+      - Storage
+      - ElectricityBySource
+      - ProductionRenewableSources
+      - HydroPower
+      - GrossVsCO2Emissions
+      - ProductionThermal
+      - ThermalHeat
+      - CapacityRenewableSources
+      - CapacityThermal
+      - GenerationPlants
   datasets_in_use:
-  - terna_electricity_by_source
+    - terna_electricity_by_source
 ministero_interno:
   source_kind: catalog
   protocol: ckan
@@ -621,12 +616,14 @@ ministero_interno:
     value: 38
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:ministero-dell-interno
-      su dati.gov.it. 38 dataset su elezioni (per comune) e ANPR (popolazione).
+    note: Conteggio via package_search con
+      fq=organization:ministero-dell-interno su dati.gov.it. 38 dataset su
+      elezioni (per comune) e ANPR (popolazione).
   verdict: go
-  note: Fonte via dati.gov.it. Dati elezioni (Politiche 2022, Comunali 2024, Europee
-    2024, Regionali) per comune + ANPR (popolazione residente, cambi residenza, certificati,
-    AIRE). Alto valore civico per analisi territoriale del voto.
+  note: Fonte via dati.gov.it. Dati elezioni (Politiche 2022, Comunali 2024,
+    Europee 2024, Regionali) per comune + ANPR (popolazione residente, cambi
+    residenza, certificati, AIRE). Alto valore civico per analisi territoriale
+    del voto.
   datasets_in_use: []
 agid:
   source_kind: catalog
@@ -643,15 +640,16 @@ agid:
     value: 40
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:agenzia-per-l-italia-digitale
-      su dati.gov.it. 40 dataset IPA (enti, PEC, domicili digitali, servizi, RTD).
+    note: Conteggio via package_search con
+      fq=organization:agenzia-per-l-italia-digitale su dati.gov.it. 40 dataset
+      IPA (enti, PEC, domicili digitali, servizi, RTD).
   verdict: go
   note: 'Fonte via dati.gov.it. IPA — Indice delle PA: enti, unita organizzative,
     PEC, domicili digitali, responsabili transizione digitale, servizi digitali, fatturazione
     elettronica, cloud. Codice_IPA chiave di join con ANAC.'
   datasets_in_use:
-  - ipa_enti
-  - ipa_istat_mapping
+    - ipa_enti
+    - ipa_istat_mapping
 noipa_sparql:
   source_kind: catalog
   protocol: sparql
@@ -659,11 +657,12 @@ noipa_sparql:
   base_url: https://sparql-noipa.mef.gov.it/sparql
   last_probed: '2026-06-25'
   verdict: hold
-  note: NoiPA SPARQL — MEF/RGS. Dati mensili personale PA (entries-{YYYYMM}, 2019-2026)
-    + pensioni PA (entriesPensioni-{YYYYMM}, 2017-oggi). ~490k soggetti/mese. L'endpoint
-    risponde solo in XML (application/sparql-results+xml). Inventory non funzionante
-    finché execute_sparql() in lab-connectors non supporta XML. Radar-only in attesa
-    di parser XML o di endpoint JSON.
+  note: NoiPA SPARQL — MEF/RGS. Dati mensili personale PA (entries-{YYYYMM},
+    2019-2026) + pensioni PA (entriesPensioni-{YYYYMM}, 2017-oggi). ~490k
+    soggetti/mese. L'endpoint risponde solo in XML
+    (application/sparql-results+xml). Inventory non funzionante finché
+    execute_sparql() in lab-connectors non supporta XML. Radar-only in attesa di
+    parser XML o di endpoint JSON.
   datasets_in_use: []
 mimit_rna:
   source_kind: catalog
@@ -673,6 +672,8 @@ mimit_rna:
   inventory:
     fq: organization:ministero-delle-imprese-e-del-made-in-italy
     timeout: 180
+  source_check:
+    max_concurrency: 2
   last_probed: '2026-06-25'
   catalog_baseline:
     captured_at: '2026-05-24'
@@ -680,8 +681,9 @@ mimit_rna:
     value: 370
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:ministero-delle-imprese-e-del-made-in-italy
-      su dati.gov.it. 370 dataset (133 RNA Aiuti + 237 RNA Misure).
+    note: Conteggio via package_search con
+      fq=organization:ministero-delle-imprese-e-del-made-in-italy su
+      dati.gov.it. 370 dataset (133 RNA Aiuti + 237 RNA Misure).
   verdict: go
   note: 'Fonte via dati.gov.it. RNA — Registro Nazionale Aiuti di Stato. 133 dataset
     mensili Aiuti (2017-2026, XML, ~14.500 record/mese) + 237 dataset Misure (1994-2023).
@@ -689,8 +691,6 @@ mimit_rna:
     civico: tracciamento aiuti pubblici alle imprese con beneficiario, CF, importo,
     regione, CUP.'
   datasets_in_use: []
-  source_check:
-    max_concurrency: 2
 ministero_salute:
   source_kind: catalog
   protocol: ckan
@@ -706,9 +706,10 @@ ministero_salute:
     value: 51
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:ministero-della-salute
-      su dati.gov.it. 51 dataset (farmacie, posti letto, personale SSN, dispositivi,
-      ASL, fitosanitari). URL raw su dati.salute.gov.it (portale in migrazione).
+    note: Conteggio via package_search con
+      fq=organization:ministero-della-salute su dati.gov.it. 51 dataset
+      (farmacie, posti letto, personale SSN, dispositivi, ASL, fitosanitari).
+      URL raw su dati.salute.gov.it (portale in migrazione).
   verdict: go
   note: 'Fonte via dati.gov.it. Anagrafiche sanitarie nazionali: farmacie, parafarmacie,
     posti letto, personale SSN, ASL, dispositivi medici, fitosanitari. I file raw
@@ -716,10 +717,10 @@ ministero_salute:
     Complementare a dati_salute (csv_magnet) per il catalogo completo del portale
     diretto.'
   datasets_in_use:
-  - farmacie
-  - reparti_ricovero
-  - strutture_asl
-  - strutture_ricovero_asl
+    - farmacie
+    - reparti_ricovero
+    - strutture_asl
+    - strutture_ricovero_asl
 agcm:
   source_kind: catalog
   protocol: ckan
@@ -735,14 +736,12 @@ agcm:
     value: 53
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:agcm su dati.gov.it. 53
-      dataset (rating di legalità, operazioni di concentrazione).
+    note: Conteggio via package_search con fq=organization:agcm su dati.gov.it.
+      53 dataset (rating di legalità, operazioni di concentrazione).
   verdict: go
-  note: 'Fonte via dati.gov.it (AGCM). 53 dataset su concorrenza e mercato: rating
-    di legalita'' (elenchi settimanali imprese con rating), operazioni di concentrazione
-    2021-2025.
-
-    '
+  note: "Fonte via dati.gov.it (AGCM). 53 dataset su concorrenza e mercato: rating
+    di legalita' (elenchi settimanali imprese con rating), operazioni di concentrazione
+    2021-2025.\n"
   datasets_in_use: []
 unioncamere:
   source_kind: catalog
@@ -750,7 +749,8 @@ unioncamere:
   observation_mode: catalog-watch
   base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
   inventory:
-    fq: organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
+    fq:
+      organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
     timeout: 180
   last_probed: '2026-06-25'
   catalog_baseline:
@@ -759,17 +759,16 @@ unioncamere:
     value: 352
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
-      su dati.gov.it. 352 dataset provincia per provincia su demografia d'impresa
-      (natimortalità, femminili, giovanili, straniere, artigiane, ATECO). ~340 provincia-specific,
-      ~12 nazionali aggregati.
+    note: Conteggio via package_search con
+      fq=organization:unione-italiana-delle-camere-di-commercio-industria-artigianato-e-agricoltura
+      su dati.gov.it. 352 dataset provincia per provincia su demografia
+      d'impresa (natimortalità, femminili, giovanili, straniere, artigiane,
+      ATECO). ~340 provincia-specific, ~12 nazionali aggregati.
   verdict: go
-  note: 'Fonte via dati.gov.it (Unioncamere). 352 dataset su demografia d''impresa
+  note: "Fonte via dati.gov.it (Unioncamere). 352 dataset su demografia d'impresa
     per provincia: femminili, giovanili, straniere, artigiane, ATECO, forma giuridica.
     Dataset prevalentemente provincia-specifici (~340). ~12 dataset nazionali aggregati
-    (es. ''Italia - Imprese femminili...'').
-
-    '
+    (es. 'Italia - Imprese femminili...').\n"
   datasets_in_use: []
 pagopa:
   source_kind: catalog
@@ -786,8 +785,8 @@ pagopa:
     value: 8
     method: package_search
     reliability: high
-    note: Conteggio via package_search con fq=organization:pagopa-s-p-a su dati.gov.it.
-      8 dataset (transazioni pagoPA, IO App, SEND).
+    note: Conteggio via package_search con fq=organization:pagopa-s-p-a su
+      dati.gov.it. 8 dataset (transazioni pagoPA, IO App, SEND).
   verdict: go
   note: 'Fonte via dati.gov.it. 8 dataset: pagoPA (transazioni per anno, mese, fascia
     importo, categoria ente), IO App (messaggi, geografia enti e servizi), SEND (notifiche

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+import threading
 import time
 import urllib.parse
 import xml.etree.ElementTree as ET
@@ -82,6 +83,14 @@ DEFAULT_IN = INVENTORY_PARQUET_PATH
 DEFAULT_OUT = CHECK_PARQUET_PATH
 
 MAX_WORKERS = 16
+
+# Richieste concorrenti massime per fonte.
+# Se un server risponde lentamente o blocca richieste multiple
+# (es. MIMIT RNA: 85 XML circuit_open per eccesso di concorrenza),
+# questo limite evita di sovraccaricarlo.
+# Il pool globale MAX_WORKERS resta 16 — il semaforo per fonte
+# garantisce che nessuna fonte usi piu' di N worker alla volta.
+MAX_CONCURRENT_PER_SOURCE = 3
 _NO_SDMX_YEARS = False  # set via --no-sdmx-years flag
 
 
@@ -754,13 +763,39 @@ def run_bulk_check(
 
     _BULK_CHECK_TIMEOUT = 900  # 15 minuti per batch source-check (safety net)
     pool = ThreadPoolExecutor(max_workers=workers)
+
+    # Per-source concurrency limit: registry puo' specificare
+    # source_check.max_concurrency (es. MIMIT RNA = 2).
+    # Default = workers globali (nessun limite aggiuntivo).
+    source_concurrency: dict[str, int] = {}
+    for sid, meta in registry.items():
+        sc_cfg = meta.get("source_check", {})
+        if isinstance(sc_cfg, dict):
+            source_concurrency[sid] = int(sc_cfg.get("max_concurrency", workers))
+        else:
+            source_concurrency[sid] = workers
+    source_semaphores: dict[str, threading.Semaphore] = {}
+
+    def _check_row_limited(
+        row: Any,
+        check_ts: str,
+        registry: dict,
+        client: HttpClient,
+    ) -> dict:
+        sid = str(row.get("source_id", ""))
+        sem = source_semaphores.setdefault(
+            sid, threading.Semaphore(source_concurrency.get(sid, workers))
+        )
+        with sem:
+            return _check_row(row, check_ts, registry, client)
+
     try:
         # Usa enumerate per avere un indice posizionale garantito come int.
         # df.iterrows() restituisce un indice generico (Hashable) che mypy
         # non accetta per df.loc/df.iloc — con enumerate pos abbiamo int certo.
         future_to_idx = {}
         for pos, (_idx, row) in enumerate(df.iterrows()):
-            f = pool.submit(_check_row, row, check_ts, registry, client)
+            f = pool.submit(_check_row_limited, row, check_ts, registry, client)
             future_to_idx[f] = pos
             sid = str(row.get("source_id", ""))
             source_first_submit.setdefault(sid, time.time())

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -83,14 +83,6 @@ DEFAULT_IN = INVENTORY_PARQUET_PATH
 DEFAULT_OUT = CHECK_PARQUET_PATH
 
 MAX_WORKERS = 16
-
-# Richieste concorrenti massime per fonte.
-# Se un server risponde lentamente o blocca richieste multiple
-# (es. MIMIT RNA: 85 XML circuit_open per eccesso di concorrenza),
-# questo limite evita di sovraccaricarlo.
-# Il pool globale MAX_WORKERS resta 16 — il semaforo per fonte
-# garantisce che nessuna fonte usi piu' di N worker alla volta.
-MAX_CONCURRENT_PER_SOURCE = 3
 _NO_SDMX_YEARS = False  # set via --no-sdmx-years flag
 
 
@@ -767,11 +759,13 @@ def run_bulk_check(
     # Per-source concurrency limit: registry puo' specificare
     # source_check.max_concurrency (es. MIMIT RNA = 2).
     # Default = workers globali (nessun limite aggiuntivo).
+    # Valori < 1 vengono bloccati a 1 per evitare deadlock.
     source_concurrency: dict[str, int] = {}
     for sid, meta in registry.items():
         sc_cfg = meta.get("source_check", {})
         if isinstance(sc_cfg, dict):
-            source_concurrency[sid] = int(sc_cfg.get("max_concurrency", workers))
+            val = int(sc_cfg.get("max_concurrency", workers))
+            source_concurrency[sid] = max(1, val)
         else:
             source_concurrency[sid] = workers
     source_semaphores: dict[str, threading.Semaphore] = {}

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -472,7 +472,75 @@ def test_http_circuit_breaker_blocks_host_after_failures(monkeypatch) -> None:
         )
 
 
-# ── SPARQL format override ──────────────────────────────────────────────────
+# ── Per-source concurrency limit ──────────────────────────────────────────────
+
+
+@pytest.mark.contract
+def test_run_bulk_check_per_source_concurrency(monkeypatch) -> None:
+    """run_bulk_check rispetta max_concurrency per fonte."""
+    import threading
+
+    import pandas as pd
+    from bulk_source_check import run_bulk_check
+    from lab_connectors.http import HttpClient, HttpResult
+
+    # DataFrame fake con 10 item per 2 fonti
+    df = pd.DataFrame(
+        [{"source_id": "fonte_lenta", "item_id": f"a{i}"} for i in range(10)]
+        + [{"source_id": "fonte_rapida", "item_id": f"b{i}"} for i in range(10)]
+    )
+
+    # Registry fake: fonte_lenta ha max_concurrency=2
+    import yaml
+
+    fake_reg_yaml = """
+fonte_lenta:
+  protocol: html
+  base_url: https://slow.test
+  source_check:
+    max_concurrency: 2
+fonte_rapida:
+  protocol: html
+  base_url: https://fast.test
+"""
+    fake_reg = yaml.safe_load(fake_reg_yaml)
+
+    # Istanti concorrenti per fonte
+    in_flight: dict[str, int] = {}
+    lock = threading.Lock()
+    max_seen: dict[str, int] = {}
+
+    class _OkResp:
+        headers = {"Content-Type": "text/plain"}
+        url = "https://test.test/file"
+        status_code = 200
+
+    def _tracked_head(self, url, **kwargs):
+        sid = "fonte_lenta" if "slow" in url else "fonte_rapida"
+        with lock:
+            in_flight[sid] = in_flight.get(sid, 0) + 1
+            max_seen[sid] = max(max_seen.get(sid, 0), in_flight[sid])
+        import time
+
+        time.sleep(0.05)  # simula lavoro
+        with lock:
+            in_flight[sid] -= 1
+        return HttpResult(response=_OkResp(), err=None)
+
+    monkeypatch.setattr(HttpClient, "head", _tracked_head)
+    monkeypatch.setattr("bulk_source_check._load_registry", lambda: fake_reg)
+
+    results = run_bulk_check(df, workers=4)
+    assert len(results) == 20, f"expected 20, got {len(results)}"
+
+    # fonte_lenta: massimo 2 concorrenti
+    assert max_seen.get("fonte_lenta", 0) <= 2, (
+        f"fonte_lenta ha avuto {max_seen.get('fonte_lenta')} concorrenti (max 2)"
+    )
+    # fonte_rapida: nessun limite esplicito, usa workers=4
+    assert max_seen.get("fonte_rapida", 0) <= 4, (
+        f"fonte_rapida ha avuto {max_seen.get('fonte_rapida')} concorrenti (max 4)"
+    )
 
 
 # ── _extract_year_values_from_sample ──────────────────────────────────────────


### PR DESCRIPTION
## Problema

MIMIT RNA ha 85 file XML tutti funzionanti singolarmente (HTTP 200 XML). Ma il source_check con 16 workers in parallelo invia tutte le richieste insieme → il server `rna.gov.it` blocca (83/85 circuit_open).

openBDAP ha un problema simile: 3456 timeout su porta 80, ma già risolto dall'HTTPS fallback (toolkit v1.41.x).

## Fix

Aggiunto **semaforo per fonte** in `run_bulk_check()`. Ogni fonte può avere al massimo N richieste concorrenti, configurato nel registry:

```yaml
mimit_rna:
  source_check:
    max_concurrency: 2   # massimo 2 richieste parallele al server RNA
```

Se non specificato, usa `MAX_WORKERS` (16) — nessun cambiamento di comportamento per le altre fonti.

## Cosa cambia

| File | Cosa |
|------|------|
| `scripts/bulk_source_check.py` | `import threading`, wrapper `_check_row_limited` con semaforo per source_id |
| `data/radar/sources_registry.yaml` | `mimit_rna.source_check.max_concurrency: 2` |

## Altri candidati

Analizzando il parquet GCS, MIMIT RNA è l'unico caso certo di rate limiting (100% circuit_open su probe singolarmente funzionanti). openBDAP è risolto dall'HTTPS fallback. unioncamere e openga hanno % basse (13-24%) — da monitorare.

## Verifica

- `pytest tests/test_compliance_scores.py tests/test_radar_check.py` — 26 test ✅
