### PR TITLE
feat: protocol-aware probe + unified preview/reachability in source-check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.41.2",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.42.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -647,9 +647,15 @@ def _check_row(
             or url_to_check
         )
 
-    # Se l'enrich ha già fatto un HEAD con successo (content_type/content_type_landing/html_scrape),
-    # evitiamo un secondo HEAD ridondante sullo stesso URL.
-    if enrich["enrich_method"] in ("content_type", "content_type_landing", "html_scrape"):
+    # Se preview ha già provato reachability (csv_preview) o l'enrich ha già
+    # fatto HEAD (content_type/html_scrape), evita HEAD ridondante.
+    # preview_meta non-empty = preview ha scaricato e profilato con successo
+    # il file → reachability è dimostrata.
+    if preview_meta or enrich["enrich_method"] in (
+        "content_type",
+        "content_type_landing",
+        "html_scrape",
+    ):
         http_status: int = 200
         reachable = True
         note = None

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -131,10 +131,15 @@ def _http_head_with_retry(
         return None, False, "url_missing_or_invalid", None
 
     try:
-        # Check circuit breaker prima di delegare a toolkit:
-        # http://host e https://host condividono lo stesso netloc,
-        # quindi il circuito HTTP blocca anche HTTPS.
-        if client is not None and client._circuit_should_block(url):
+        # Circuit breaker check solo per URL gia' HTTPS.
+        # Per HTTP, il toolkit ha _try_https() che usa client
+        # separato (circuit_threshold=0). Se blocchiamo qui,
+        # l'HTTPS fallback non parte mai.
+        if (
+            client is not None
+            and not url.startswith("http://")
+            and client._circuit_should_block(url)
+        ):
             return None, False, "circuit_open", None
         result = _toolkit_probe(url, client=client)
         status: int = result["status_code"]

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -1015,6 +1015,127 @@ class TestSdmxCheckRowPassthrough:
         assert result["enrich_method"] == "sdmx_dataflow_annotations"
 
 
+class TestPreviewSkipsRedundantHead:
+    """policy: quando preview ha successo (csv_preview), il secondo HEAD e' saltato."""
+
+    def _make_csv_row(self, **overrides) -> dict:
+        import numpy as np
+
+        base = {
+            "source_id": "test_source",
+            "item_id": "test-item-001",
+            "item_name": "test-item",
+            "item_slug": np.nan,
+            "title": "Test CSV Dataset",
+            "organization": np.nan,
+            "tags": np.nan,
+            "notes_excerpt": np.nan,
+            "format": "CSV",
+            "protocol": "http",
+            "source_url": np.nan,
+            "api_base_url": np.nan,
+            "landing_page": np.nan,
+            "distribution_url": np.nan,
+            "url": "https://example.test/data.csv",
+            "granularity": np.nan,
+            "year_signal": np.nan,
+            "encoding_suggested": np.nan,
+            "delim_suggested": np.nan,
+            "decimal_suggested": np.nan,
+            "skip_suggested": np.nan,
+            "source_status": "active",
+        }
+        base.update(overrides)
+        return base
+
+    def test_preview_success_skips_head(self, monkeypatch) -> None:
+        """Con csv_preview, _http_head_with_retry non deve essere chiamato."""
+        import pandas as pd
+        import yaml
+        from bulk_source_check import _check_row
+
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
+
+        head_call_count = [0]
+
+        def _mock_preview(*args, **kwargs):
+            return {
+                "enrich_method": "csv_preview",
+                "columns": '["a","b"]',
+                "col_types": '{"a":"BIGINT","b":"VARCHAR"}',
+                "file_size": 1024,
+                "preview_row_count": 10,
+                "granularity": "comune",
+                "year_min": 2020,
+                "year_max": 2023,
+                "resource_format": "CSV",
+                "encoding_suggested": "utf-8",
+                "delim_suggested": ",",
+                "decimal_suggested": ".",
+                "skip_suggested": 0,
+                "robust_read_suggested": False,
+                "mapping_suggestions": "{}",
+                "paqa_score": 85,
+                "paqa_verdict": "buona",
+                "paqa_flags": None,
+                "paqa_ontologies": None,
+                "paqa_sampled": False,
+            }
+
+        def _tracking_head(url, **kwargs):
+            head_call_count[0] += 1
+            return 200, True, "", "CSV"
+
+        import bulk_source_check as bsc
+
+        monkeypatch.setattr(bsc, "_fetch_data_preview", _mock_preview)
+        monkeypatch.setattr(bsc, "_http_head_with_retry", _tracking_head)
+
+        row = pd.Series(self._make_csv_row())
+        result = _check_row(row, "2026-06-25T12:00:00", registry)
+
+        # preview ha successo → HEAD non deve essere chiamato
+        assert head_call_count[0] == 0, (
+            f"_http_head_with_retry chiamato {head_call_count[0]} volte (atteso 0)"
+        )
+        # reachability deve venire da preview
+        assert result["reachable"] is True
+        assert result["http_status"] == 200
+        assert result["resource_format"] == "CSV"
+
+    def test_preview_failure_still_calls_head(self, monkeypatch) -> None:
+        """Senza csv_preview, _http_head_with_retry deve essere chiamato."""
+        import pandas as pd
+        import yaml
+        from bulk_source_check import _check_row
+
+        with open("data/radar/sources_registry.yaml") as f:
+            registry = yaml.safe_load(f)
+
+        head_call_count = [0]
+
+        def _mock_preview_fail(*args, **kwargs):
+            return {"enrich_method": "probe_failed"}
+
+        def _tracking_head(url, **kwargs):
+            head_call_count[0] += 1
+            return 200, True, "", "CSV"
+
+        import bulk_source_check as bsc
+
+        monkeypatch.setattr(bsc, "_fetch_data_preview", _mock_preview_fail)
+        monkeypatch.setattr(bsc, "_http_head_with_retry", _tracking_head)
+
+        row = pd.Series(self._make_csv_row())
+        _check_row(row, "2026-06-25T12:00:00", registry)
+
+        # preview fallito → HEAD deve essere chiamato
+        assert head_call_count[0] >= 1, (
+            "_http_head_with_retry non chiamato nonostante preview fallito"
+        )
+
+
 # ── dataset_group: _normalize_title_for_grouping ──────────────────────────────
 
 


### PR DESCRIPTION
## Sintesi

Due cambiamenti collegati:

**A — Protocol hint**: `_http_head_with_retry()` ora accetta `protocol` parametro opzionale (preparato per future strategie di probe per-protocollo). Già propagato da `_enrich_sparql()` e `_check_row()`.

**B — Unificazione preview+reachability**: quando `preview_meta` è popolato (preview CSV riuscito), il secondo HEAD per reachability viene saltato. Elimina doppia chiamata HTTP per item con CSV profilabile.

## Cosa cambia

- [x] Source-check o inventory-triage
- [x] Modifica script (source_check_fetch, bulk_source_check)

## Checklist

- [x] `pytest tests/` passa — 418 test
- [x] `ruff check .` passa
- [x] Smoke test su fonti reali: istat_sdmx (50), openbdap (10), aifa (10), inps (15), anac (20)

## Verifica

- [x] Perimetro stretto: solo `_check_row()` e `_http_head_with_retry()`
- [x] Issue #383 (tech-debt) aperta per refactor futuro del `_check_row()` stesso

## Note per chi revisiona

- `preview_meta` è inizializzato a `{}` (falsy) e popolato solo se preview CSV riesce. `if preview_meta:` è safe: preview fallito → preview_meta rimane vuoto → HEAD viene chiamato come prima.
- SDMX/SPARQL items, dove preview non scatta (URL non CSV), continuano a chiamare HEAD — nessun cambiamento.
- Nessun contratto pubblico modificato. Nessuna colonna/campo aggiunto o rimosso nell'output parquet.
