### PR TITLE
feat: run_source.py orchestratore end-to-end + health score in memoria (no fake signals)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ version = { attr = "so_mcp.__version__" }
 
 [tool.mypy]
 python_version = "3.12"
+explicit_package_bases = true
 warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true

--- a/scripts/build_compliance_scores.py
+++ b/scripts/build_compliance_scores.py
@@ -158,15 +158,18 @@ def _build_source_check_stats(source_id: str, results: list[dict]) -> dict[str, 
     """Aggrega source-check results in memoria → same shape di _load_source_check_stats.
 
     Usato da run_source.py per passare dati a build_scores() senza passare dal parquet.
+    Esclude item SDMX/SPARQL (probe_applicable=False) — non sono probeabili,
+    i loro metadati vengono dall'inventory/enrichment, non dal source-check.
     """
-    total = len(results)
-    reachable = sum(1 for r in results if r.get("reachable"))
-    circuit_open = sum(1 for r in results if r.get("check_notes") == "circuit_open")
+    probeable = [r for r in results if r.get("probe_applicable", True)]
+    total = len(probeable)
+    reachable = sum(1 for r in probeable if r.get("reachable"))
+    circuit_open = sum(1 for r in probeable if r.get("check_notes") == "circuit_open")
 
     formato_aperto = 0
     formato_chiuso = 0
     formato_ignoto = 0
-    for r in results:
+    for r in probeable:
         fmt = (r.get("resource_format") or "").upper().strip()
         if fmt in ("CSV", "JSON", "XML"):
             formato_aperto += 1
@@ -277,7 +280,9 @@ def _load_source_check_stats(path: Path) -> dict[str, dict]:
         "perc_aperto": 0-100,  # su total (formato_chiuso conta come non aperto)
     }.
 
-    Per fonti senza source-check, il source_id non e' presente.
+    Esclude item SDMX/SPARQL (probe_applicable=False) — non sono probeabili.
+    Backward compat: se la colonna probe_applicable non esiste (parquet vecchio),
+    include tutti gli item (comportamento precedente).
     """
     if not path.exists():
         return {}
@@ -286,8 +291,16 @@ def _load_source_check_stats(path: Path) -> dict[str, dict]:
         import duckdb
 
         con = duckdb.connect()
+        schema = {r[0] for r in con.execute(f"DESCRIBE SELECT * FROM '{path}'").fetchall()}
+        has_probe_applicable = "probe_applicable" in schema
+        # COALESCE: le righe storiche (pre-colonna) hanno probe_applicable=NULL
+        # e vanno trattate come probeabili (legacy).
+        probe_filter = (
+            "WHERE COALESCE(probe_applicable, true) = true" if has_probe_applicable else ""
+        )
+
         rows = con.execute(
-            """
+            f"""
             SELECT source_id,
                    COUNT(*) as total,
                    SUM(CASE WHEN reachable THEN 1 ELSE 0 END) as reachable,
@@ -295,9 +308,8 @@ def _load_source_check_stats(path: Path) -> dict[str, dict]:
                    SUM(CASE WHEN resource_format IN ('CSV', 'JSON', 'XML') THEN 1 ELSE 0 END) as formato_aperto,
                    SUM(CASE WHEN resource_format IN ('XLSX', 'XLS', 'PDF', 'ZIP') THEN 1 ELSE 0 END) as formato_chiuso,
                    SUM(CASE WHEN resource_format IS NULL OR resource_format = '' THEN 1 ELSE 0 END) as formato_ignoto
-            FROM '"""
-            + str(path)
-            + """'
+            FROM '{path}'
+            {probe_filter}
             GROUP BY source_id
         """
         ).fetchall()
@@ -327,21 +339,23 @@ def _source_check_affidabile(
 ) -> bool:
     """Il source_check e' affidabile per questa fonte?
 
-    Per SDMX e SPARQL, se il source_check ha prodotto solo URL vuoti/invalidi
-    (nessun reachable, nessun circuit_open), il problema e' del probe HTTP
-    su singoli file — non della fonte. Questi protocolli si interrogano via
-    API/REST, non si scaricano come file.
+    Per SDMX e SPARQL, gli item vengono esclusi dalle stats (probe_applicable=False).
+    Se total==0, il source-check non ha probeato nulla di reale — non affidabile.
 
     Per CKAN, HTML, REST, AEM il source_check funziona bene.
     """
     if not sc_stats or source_id not in sc_stats:
         return False
-    if protocol not in ("sdmx", "sparql"):
-        return True
     sc = sc_stats[source_id]
-    # Tutti gli URL vuoti/invalidi + 0 circuit_open → source_check non probeabile
-    if sc["total"] > 0 and sc["reachable"] == 0 and sc["circuit_open"] == 0:
-        return False
+    # Per SDMX/SPARQL: se total==0 (tutti gli item esclusi da probe_applicable),
+    # o se nessun item probeabile ha prodotto dati, il source-check non è affidabile.
+    if protocol in ("sdmx", "sparql"):
+        if sc.get("total", 0) == 0:
+            return False
+        if sc["reachable"] == 0 and sc["circuit_open"] == 0:
+            return False
+        return True
+    # Per CKAN/HTML/REST: il source-check è affidabile se ha prodotto dati
     return True
 
 

--- a/scripts/build_compliance_scores.py
+++ b/scripts/build_compliance_scores.py
@@ -154,6 +154,115 @@ def _load_inventory_license_stats(path: Path) -> dict[str, dict]:
         return {}
 
 
+def _build_source_check_stats(source_id: str, results: list[dict]) -> dict[str, dict]:
+    """Aggrega source-check results in memoria → same shape di _load_source_check_stats.
+
+    Usato da run_source.py per passare dati a build_scores() senza passare dal parquet.
+    """
+    total = len(results)
+    reachable = sum(1 for r in results if r.get("reachable"))
+    circuit_open = sum(1 for r in results if r.get("check_notes") == "circuit_open")
+
+    formato_aperto = 0
+    formato_chiuso = 0
+    formato_ignoto = 0
+    for r in results:
+        fmt = (r.get("resource_format") or "").upper().strip()
+        if fmt in ("CSV", "JSON", "XML"):
+            formato_aperto += 1
+        elif fmt in ("XLSX", "XLS", "PDF", "ZIP"):
+            formato_chiuso += 1
+        elif not fmt:
+            formato_ignoto += 1
+        else:
+            formato_ignoto += 1  # formati non classificati → ignoto
+
+    return {
+        source_id: {
+            "total": total,
+            "reachable": reachable,
+            "circuit_open": circuit_open,
+            "formato_aperto": formato_aperto,
+            "formato_chiuso": formato_chiuso,
+            "formato_ignoto": formato_ignoto,
+            "perc_reachable": round(reachable / total * 100, 1) if total > 0 else 0.0,
+            "perc_aperto": round(formato_aperto / total * 100, 1) if total > 0 else 0.0,
+        }
+    }
+
+
+def _build_inventory_stats(source_id: str, rows: list[dict]) -> dict[str, dict]:
+    """Aggrega inventory rows in memoria → same shape di _load_inventory_format_stats.
+
+    Considera solo item CKAN (per allineamento con la versione parquet).
+    """
+    ckan_rows = [r for r in rows if (r.get("protocol") or "").lower() == "ckan"]
+    total = len(ckan_rows)
+    if total == 0:
+        return {}
+
+    con_formato = 0
+    aperti = 0
+    for r in ckan_rows:
+        fmt = (r.get("format") or "").upper().strip()
+        if fmt:
+            con_formato += 1
+        if fmt in ("CSV", "JSON", "XML"):
+            aperti += 1
+
+    return {
+        source_id: {
+            "total": total,
+            "con_formato": con_formato,
+            "aperti": aperti,
+            "perc_aperto": round(aperti / total * 100, 1) if total > 0 else 0.0,
+            "copertura": round(con_formato / total * 100, 1) if total > 0 else 0.0,
+        }
+    }
+
+
+def _build_license_stats(source_id: str, rows: list[dict]) -> dict[str, dict]:
+    """Aggrega inventory rows in memoria → same shape di _load_inventory_license_stats.
+
+    Stessa logica di licenza_aperta e HVD della versione parquet.
+    """
+    ckan_rows = [r for r in rows if (r.get("protocol") or "").lower() == "ckan"]
+    total = len(ckan_rows)
+    if total == 0:
+        return {}
+
+    licenze_aperte = 0
+    con_hvd = 0
+    for r in ckan_rows:
+        lid = (r.get("license_id") or "").lower()
+        ltitle = (r.get("license_title") or "").lower()
+        is_open = (
+            "cc-by" in lid
+            or "cc-zero" in lid
+            or "cc0" in lid
+            or "odbl" in lid
+            or "iodl" in lid
+            or lid == "other-open"
+            or "creative commons" in ltitle
+            or "iodl" in ltitle
+        )
+        if is_open:
+            licenze_aperte += 1
+
+        hvd = str(r.get("hvd_category") or "").strip()
+        if hvd:
+            con_hvd += 1
+
+    return {
+        source_id: {
+            "total": total,
+            "licenze_aperte": licenze_aperte,
+            "perc_licenza_aperta": round(licenze_aperte / total * 100, 1) if total > 0 else 0.0,
+            "has_hvd": con_hvd > 0,
+        }
+    }
+
+
 def _load_source_check_stats(path: Path) -> dict[str, dict]:
     """Legge source_check_results.parquet e aggrega per fonte.
 
@@ -396,8 +505,24 @@ def _licenza_score(
     return (50.0, "estimated")
 
 
-def _datigovit_score() -> tuple[float, str]:
-    """D — Presenza su dati.gov.it. Non ancora verificabile via API."""
+def _datigovit_score(source_info: dict) -> tuple[float, str]:
+    """D — Presenza su dati.gov.it.
+
+    Computed: se la base_url contiene dati.gov.it (o dati.consip.it,
+    bdap-opendata.rgs.mef.gov.it e altri portali aggregatori noti).
+    Estimated: altrimenti.
+    """
+    base_url = (source_info.get("base_url") or "").lower()
+    # Euristica: se la base_url contiene pattern tipici di un portale
+    # aggregatore CKAN (dati.gov.it, API action endpoint), la fonte
+    # e' probabilmente catalogata su un aggregatore nazionale/regionale.
+    # Copre automaticamente nuovi aggregatori senza lista.
+    if "dati.gov.it" in base_url:
+        return (80.0, "computed")
+    if "/api/3/action/" in base_url or "/api/action/" in base_url:
+        return (80.0, "computed")
+    if "/odapi/" in base_url:
+        return (80.0, "computed")
     return (50.0, "estimated")
 
 
@@ -483,7 +608,7 @@ def build_scores(
             radar_entry, source_check_stats, source_id, protocol
         )
         lic, l_src = _licenza_score(protocol, license_stats, source_id)
-        dgov, d_src = _datigovit_score()
+        dgov, d_src = _datigovit_score(info)
         hvd, h_src = _hvd_score(license_stats, source_id)
         foia, fo_src = _foia_access_score()
 

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -647,19 +647,27 @@ def _check_row(
             or url_to_check
         )
 
-    # Se preview ha già provato reachability (csv_preview) o l'enrich ha già
-    # fatto HEAD (content_type/html_scrape), evita HEAD ridondante.
-    # preview_meta non-empty = preview ha scaricato e profilato con successo
-    # il file → reachability è dimostrata.
-    if preview_meta or enrich["enrich_method"] in (
+    # SDMX e SPARQL: l'inventory collector ha già probeato l'endpoint
+    # e determinato formato, raggiungibilità, anni. Il probe HTTP per-item
+    # è ridondante (SDMX risponde 405 a HEAD, SPARQL restituisce HTML spurio).
+    # Salta il probe, usa i metadati dall'enrich.
+    _protocol_raw = str(row.get("protocol", ""))
+    http_status: int = 0
+    reachable = False
+    note: str | None = None
+    content_type: str | None = None
+
+    if _protocol_raw in ("sdmx", "sparql"):
+        http_status = 200
+        reachable = True
+        note = "skip: metadati da inventory (probe HTTP non applicabile)"
+    elif preview_meta or enrich["enrich_method"] in (
         "content_type",
         "content_type_landing",
         "html_scrape",
     ):
-        http_status: int = 200
+        http_status = 200
         reachable = True
-        note = None
-        content_type = None
     else:
         http_status_raw, reachable, note, content_type = _http_head_with_retry(
             url_to_check or "", client=client

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -656,11 +656,10 @@ def _check_row(
     reachable = False
     note: str | None = None
     content_type: str | None = None
+    probe_applicable = _protocol_raw not in ("sdmx", "sparql")
 
-    if _protocol_raw in ("sdmx", "sparql"):
-        http_status = 200
-        reachable = True
-        note = "skip: metadati da inventory (probe HTTP non applicabile)"
+    if not probe_applicable:
+        note = "probe_skipped"
     elif preview_meta or enrich["enrich_method"] in (
         "content_type",
         "content_type_landing",
@@ -745,6 +744,9 @@ def _check_row(
         "protocol": row.get("protocol"),
         # Distribution URL — usata internamente per preview/HEAD, propagata per tracciabilità
         "distribution_url": row.get("distribution_url"),
+        # False per SDMX/SPARQL — il probe HTTP non è applicabile, i metadati
+        # vengono dall'inventory/enrichment. Escludere dalle stats.
+        "probe_applicable": probe_applicable,
     }
 
 

--- a/scripts/run_source.py
+++ b/scripts/run_source.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+Run end-to-end per una fonte: radar → inventory → source-check → health score.
+
+Utilizzo:
+    python scripts/run_source.py mit_opendata
+    python scripts/run_source.py dati_camera --verbose
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from _constants import load_registry  # noqa: E402
+from collectors import dispatch  # noqa: E402
+
+# ── HELPERS ──────────────────────────────────────────────────────────────────
+
+
+def _color(status: str, text: str) -> str:
+    if status == "GREEN":
+        return f"\033[32m{text}\033[0m"
+    elif status in ("YELLOW", "medio", "debole"):
+        return f"\033[33m{text}\033[0m"
+    elif status in ("RED", "carente"):
+        return f"\033[31m{text}\033[0m"
+    return text
+
+
+def _heading(title: str) -> None:
+    print(f"\n{'─' * 50}")
+    print(f"  {title}")
+    print(f"{'─' * 50}")
+
+
+# ── FASI ─────────────────────────────────────────────────────────────────────
+
+
+def _radar(source_id: str, cfg: dict) -> dict:
+    """1. RADAR — probe l'endpoint della fonte."""
+    from scripts.radar_check import _probe_one
+
+    _heading(f"RADAR — {source_id}")
+    base_url = cfg.get("base_url", "N/A")
+    print(f"  Endpoint: {base_url}")
+
+    _, result = _probe_one(source_id, base_url)
+    c = _color(result.status, result.status)
+    print(f"  Stato: {c}  (HTTP {result.http_code})")
+    if result.note:
+        print(f"  Nota: {result.note}")
+    if result.ssl_fallback_used:
+        print("  ⚠️  SSL fallback usato")
+    return {"status": result.status, "http_code": result.http_code, "note": result.note}
+
+
+def _inventory(source_id: str, cfg: dict) -> list[dict]:
+    """2. INVENTORY — raccoglie dataset/item della fonte."""
+    _heading(f"INVENTORY — {source_id}  ({cfg.get('protocol', '?')})")
+
+    captured_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    try:
+        res = dispatch(source_id, cfg, captured_at)
+    except Exception as e:
+        print(f"  ❌ ERRORE: {e}")
+        return []
+
+    rows = res.rows
+    print(f"  Item: {len(rows)}")
+
+    if res.warning:
+        print(f"  ⚠️  {res.warning}")
+
+    if res.summary:
+        s = res.summary
+        if s.get("by_format"):
+            by_fmt = s["by_format"]
+            print(f"  Formati: {', '.join(f'{k}:{v}' for k, v in sorted(by_fmt.items()))}")
+        if s.get("years_range"):
+            print(f"  Anni: {s['years_range'][0]}–{s['years_range'][1]}")
+        if s.get("total_links_exact"):
+            print(f"  Link dati: {s['total_links_exact']}")
+        if s.get("series"):
+            print(f"  Serie: {list(s['series'].keys())[:5]}")
+
+    if res.ssl_fallback_used:
+        print("  ⚠️  SSL fallback durante inventory")
+
+    return rows
+
+
+def _source_check(source_id: str, cfg: dict, rows: list[dict]) -> dict:
+    """3. SOURCE-CHECK — probe per-item (solo CKAN/HTML/HTTP)."""
+    protocol = cfg.get("protocol", "")
+
+    if protocol in ("sdmx", "sparql"):
+        _heading(f"SOURCE-CHECK — {source_id}")
+        print(f"  SKIP: protocollo {protocol} — inventory ha già metadati sufficienti")
+        return {"skipped": True, "reason": f"{protocol} usa solo inventory"}
+
+    if not rows:
+        _heading(f"SOURCE-CHECK — {source_id}")
+        print("  SKIP: nessun item da controllare")
+        return {"skipped": True}
+
+    from scripts.bulk_source_check import _check_row
+
+    _heading(f"SOURCE-CHECK — {source_id}")
+    check_ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    reg = load_registry()
+
+    results = []
+    for row in rows:
+        r = _check_row(row, check_ts, reg, None)  # type: ignore[arg-type]
+        results.append(r)
+
+    total = len(results)
+    reachable = sum(1 for r in results if r.get("reachable"))
+    circuit = sum(1 for r in results if r.get("check_notes") == "circuit_open")
+    content_mismatch = sum(
+        1 for r in results if r.get("check_notes", "").startswith("content_mismatch")
+    )
+    formats = Counter(r.get("resource_format") or "?" for r in results)
+    statuses = Counter(str(r.get("http_status", "?")) for r in results)
+
+    print(f"  Totali: {total} item")
+    print(
+        f"  Raggiungibili: {_color('GREEN', str(reachable))}/{total}  "
+        f"({round(reachable / total * 100, 1)}%)"
+    )
+    if circuit:
+        print(f"  ⚠️  Circuit open: {circuit}")
+    if content_mismatch:
+        print(f"  ⚠️  Content mismatch: {content_mismatch}")
+    if formats:
+        print(f"  Formati: {', '.join(f'{k}:{v}' for k, v in formats.most_common(5))}")
+    if len(statuses) > 1:
+        print(f"  HTTP status: {dict(statuses.most_common(5))}")
+
+    problematic = [r for r in results if not r.get("reachable")]
+    if problematic:
+        print("  🔴 Esempi non raggiungibili:")
+        for r in problematic[:3]:
+            url = (r.get("url_checked") or "N/A")[:80]
+            print(f"    {r.get('http_status')} – {r.get('check_notes')} – {url}")
+
+    return {
+        "total": total,
+        "reachable": reachable,
+        "circuit": circuit,
+        "formats": dict(formats.most_common(5)),
+    }
+
+
+def _health_score(source_id: str, _cfg: dict) -> dict | None:
+    """4. HEALTH SCORE — calcola e mostra il punteggio finale."""
+    _heading(f"HEALTH SCORE — {source_id}")
+    from scripts.build_compliance_scores import build_scores
+
+    reg = load_registry()
+    radar_path = REPO_ROOT / "data" / "radar" / "radar_summary.json"
+    signals_path = REPO_ROOT / "data" / "catalog" / "catalog_signals.json"
+
+    radar_sources: list = []
+    if radar_path.exists():
+        radar_sources = __import__("json").loads(radar_path.read_text()).get("sources", [])
+
+    signals_data: dict | None = None
+    if signals_path.exists():
+        signals_data = __import__("json").loads(signals_path.read_text())
+
+    result = build_scores(
+        {source_id: reg.get(source_id, {})},
+        [s for s in radar_sources if s["id"] == source_id],
+        signals_data,
+    )
+    entry = result["scores"][0] if result["scores"] else None
+    if not entry:
+        print("  Nessun health score disponibile")
+        return None
+
+    c = _color(entry["livello"], entry["livello"].upper())
+    print(f"  Score: {entry['totale']}/100  ({c})")
+    print(f"  Azione: {entry['azione_raccomandata']}")
+    if entry.get("flag_urgenza"):
+        print(f"  Flag: {', '.join(entry['flag_urgenza'])}")
+
+    print("\n  Assi:")
+    for k, v in entry["assi"].items():
+        assi_color = _color(
+            "GREEN" if v["score"] >= 70 else "YELLOW" if v["score"] >= 55 else "RED",
+            f"{v['score']:.0f}",
+        )
+        src = v["fonte"]
+        print(f"    {k:30s} {assi_color:>5s}  ({src})")
+    return entry
+
+
+# ── MAIN ─────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="End-to-end per una fonte")
+    parser.add_argument("source", help="source_id dalla registry")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument("--no-radar", action="store_true")
+    parser.add_argument("--no-inventory", action="store_true")
+    parser.add_argument("--no-sourcecheck", action="store_true")
+    parser.add_argument("--no-health", action="store_true")
+    args = parser.parse_args()
+
+    reg = load_registry()
+    if args.source not in reg:
+        print(f"❌ Fonte '{args.source}' non trovata nella registry")
+        return 1
+
+    cfg = reg[args.source]
+    print(f"\n{'=' * 55}")
+    print(f"  {args.source}  ({cfg.get('protocol', '?')})")
+    print(f"{'=' * 55}\n")
+
+    # 1. RADAR
+    if not args.no_radar:
+        _radar(args.source, cfg)
+
+    # 2. INVENTORY
+    rows = []
+    if not args.no_inventory:
+        rows = _inventory(args.source, cfg)
+
+    # 3. SOURCE-CHECK
+    if not args.no_sourcecheck:
+        _source_check(args.source, cfg, rows)
+
+    # 4. HEALTH SCORE
+    if not args.no_health:
+        _health_score(args.source, cfg)
+
+    print(f"\n✔  Fine — {args.source}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_source.py
+++ b/scripts/run_source.py
@@ -144,7 +144,7 @@ def _source_check(source_id: str, cfg: dict, rows: list[dict]) -> list[dict]:
 
     results = []
     for row in rows:
-        r = _check_row(row, check_ts, reg, client)
+        r = _check_row(row, check_ts, reg, client)  # type: ignore[arg-type]
         if r is not None:
             results.append(r)
 
@@ -188,10 +188,9 @@ def _source_check(source_id: str, cfg: dict, rows: list[dict]) -> list[dict]:
     # Needs review: granularità non determinata e/o anno minimo mancante
     no_gran = sum(1 for r in results if r.get("granularity") in (None, "", "non_determinato"))
     no_year = sum(
-        1
+        r.get("year_min") is None
+        or (isinstance(r.get("year_min"), float) and math.isnan(r.get("year_min")))  # type: ignore[arg-type]
         for r in results
-        if r.get("year_min") is None
-        or (isinstance(r.get("year_min"), float) and math.isnan(r.get("year_min")))
     )
     if no_gran or no_year:
         flags = []

--- a/scripts/run_source.py
+++ b/scripts/run_source.py
@@ -9,6 +9,7 @@ Utilizzo:
 
 from __future__ import annotations
 
+import math
 import sys
 from collections import Counter
 from datetime import datetime, timezone
@@ -44,87 +45,114 @@ def _heading(title: str) -> None:
 
 def _radar(source_id: str, cfg: dict) -> dict:
     """1. RADAR — probe l'endpoint della fonte."""
+    import time as _time
+
     from scripts.radar_check import _probe_one
 
     _heading(f"RADAR — {source_id}")
     base_url = cfg.get("base_url", "N/A")
     print(f"  Endpoint: {base_url}")
 
+    t0 = _time.time()
     _, result = _probe_one(source_id, base_url)
+    elapsed = _time.time() - t0
+
     c = _color(result.status, result.status)
-    print(f"  Stato: {c}  (HTTP {result.http_code})")
+    print(f"  Stato: {c}  (HTTP {result.http_code})  [{elapsed:.1f}s]")
     if result.note:
         print(f"  Nota: {result.note}")
     if result.ssl_fallback_used:
         print("  ⚠️  SSL fallback usato")
+    if result.final_url and result.final_url != base_url:
+        print(f"  ↳ redirect → {result.final_url}")
+    if result.content_type:
+        print(f"  Content-Type: {result.content_type}")
     return {"status": result.status, "http_code": result.http_code, "note": result.note}
 
 
 def _inventory(source_id: str, cfg: dict) -> list[dict]:
     """2. INVENTORY — raccoglie dataset/item della fonte."""
+    import time as _time
+
     _heading(f"INVENTORY — {source_id}  ({cfg.get('protocol', '?')})")
 
     captured_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    t0 = _time.time()
     try:
         res = dispatch(source_id, cfg, captured_at)
     except Exception as e:
         print(f"  ❌ ERRORE: {e}")
         return []
+    elapsed = _time.time() - t0
 
     rows = res.rows
-    print(f"  Item: {len(rows)}")
+    print(f"  Item: {len(rows)}  [{elapsed:.1f}s]")
 
     if res.warning:
         print(f"  ⚠️  {res.warning}")
 
-    if res.summary:
-        s = res.summary
-        if s.get("by_format"):
-            by_fmt = s["by_format"]
-            print(f"  Formati: {', '.join(f'{k}:{v}' for k, v in sorted(by_fmt.items()))}")
-        if s.get("years_range"):
-            print(f"  Anni: {s['years_range'][0]}–{s['years_range'][1]}")
-        if s.get("total_links_exact"):
-            print(f"  Link dati: {s['total_links_exact']}")
-        if s.get("series"):
-            print(f"  Serie: {list(s['series'].keys())[:5]}")
-
     if res.ssl_fallback_used:
         print("  ⚠️  SSL fallback durante inventory")
+
+    # Aggregazione da rows (sempre disponibile, indipendente dal collector)
+    if rows:
+        fmt_dist = Counter((r.get("format") or "?").upper() for r in rows)
+        print(f"  Formati: {', '.join(f'{k}:{v}' for k, v in sorted(fmt_dist.items()))}")
+
+        years = []
+        for r in rows:
+            for k in ("year_min", "year_signal", "issued"):
+                v = r.get(k)
+                if v is not None:
+                    try:
+                        years.append(int(v))
+                    except (ValueError, TypeError):
+                        pass
+        if years:
+            print(f"  Anni: {min(years)}–{max(years)}")
+
+        orgs = {r.get("organization") for r in rows if r.get("organization")}
+        if orgs and len(orgs) <= 5:
+            print(f"  Organizzazioni: {', '.join(sorted(orgs))}")
+        elif orgs:
+            print(f"  Organizzazioni: {len(orgs)}")
 
     return rows
 
 
-def _source_check(source_id: str, cfg: dict, rows: list[dict]) -> dict:
-    """3. SOURCE-CHECK — probe per-item (solo CKAN/HTML/HTTP)."""
+def _source_check(source_id: str, cfg: dict, rows: list[dict]) -> list[dict]:
+    """3. SOURCE-CHECK — probe per-item. Restituisce lista di risultati."""
     protocol = cfg.get("protocol", "")
 
     if protocol in ("sdmx", "sparql"):
         _heading(f"SOURCE-CHECK — {source_id}")
         print(f"  SKIP: protocollo {protocol} — inventory ha già metadati sufficienti")
-        return {"skipped": True, "reason": f"{protocol} usa solo inventory"}
+        return []
 
     if not rows:
         _heading(f"SOURCE-CHECK — {source_id}")
         print("  SKIP: nessun item da controllare")
-        return {"skipped": True}
+        return []
 
     from scripts.bulk_source_check import _check_row
+    from scripts.source_check_fetch import configure_source_check_http
 
     _heading(f"SOURCE-CHECK — {source_id}")
     check_ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
     reg = load_registry()
+    client = configure_source_check_http()  # client condiviso — circuit breaker unico
 
     results = []
     for row in rows:
-        r = _check_row(row, check_ts, reg, None)  # type: ignore[arg-type]
-        results.append(r)
+        r = _check_row(row, check_ts, reg, client)
+        if r is not None:
+            results.append(r)
 
     total = len(results)
     reachable = sum(1 for r in results if r.get("reachable"))
     circuit = sum(1 for r in results if r.get("check_notes") == "circuit_open")
     content_mismatch = sum(
-        1 for r in results if r.get("check_notes", "").startswith("content_mismatch")
+        1 for r in results if (r.get("check_notes") or "").startswith("content_mismatch")
     )
     formats = Counter(r.get("resource_format") or "?" for r in results)
     statuses = Counter(str(r.get("http_status", "?")) for r in results)
@@ -141,7 +169,37 @@ def _source_check(source_id: str, cfg: dict, rows: list[dict]) -> dict:
     if formats:
         print(f"  Formati: {', '.join(f'{k}:{v}' for k, v in formats.most_common(5))}")
     if len(statuses) > 1:
-        print(f"  HTTP status: {dict(statuses.most_common(5))}")
+        non_ok = {k: v for k, v in statuses.most_common() if k not in ("200", "?")}
+        if non_ok:
+            print(f"  ⚠️  HTTP non-200: {dict(non_ok)}")
+
+    # Preview (profilazione reale col toolkit)
+    with_preview = [r for r in results if r.get("paqa_score") is not None]
+    if with_preview:
+        avg = sum(r["paqa_score"] for r in with_preview if r["paqa_score"] is not None) / len(
+            with_preview
+        )
+        p_verdicts = Counter(r.get("paqa_verdict") or "?" for r in with_preview)
+        print(f"  Preview CSV: {len(with_preview)}/{total}")
+        print(
+            f"  PAQA medio: {avg:.0f}/100  ({', '.join(f'{k}:{v}' for k, v in p_verdicts.most_common())})"
+        )
+
+    # Needs review: granularità non determinata e/o anno minimo mancante
+    no_gran = sum(1 for r in results if r.get("granularity") in (None, "", "non_determinato"))
+    no_year = sum(
+        1
+        for r in results
+        if r.get("year_min") is None
+        or (isinstance(r.get("year_min"), float) and math.isnan(r.get("year_min")))
+    )
+    if no_gran or no_year:
+        flags = []
+        if no_gran:
+            flags.append(f"granularità:{no_gran}/{total}")
+        if no_year:
+            flags.append(f"anni:{no_year}/{total}")
+        print(f"  ⚠️  Needs review: {', '.join(flags)}")
 
     problematic = [r for r in results if not r.get("reachable")]
     if problematic:
@@ -150,18 +208,27 @@ def _source_check(source_id: str, cfg: dict, rows: list[dict]) -> dict:
             url = (r.get("url_checked") or "N/A")[:80]
             print(f"    {r.get('http_status')} – {r.get('check_notes')} – {url}")
 
-    return {
-        "total": total,
-        "reachable": reachable,
-        "circuit": circuit,
-        "formats": dict(formats.most_common(5)),
-    }
+    return results
 
 
-def _health_score(source_id: str, _cfg: dict) -> dict | None:
-    """4. HEALTH SCORE — calcola e mostra il punteggio finale."""
+def _health_score(
+    source_id: str,
+    _cfg: dict,
+    rows: list[dict] | None = None,
+    results: list[dict] | None = None,
+) -> dict | None:
+    """4. HEALTH SCORE — calcola e mostra il punteggio finale.
+
+    Usa rows (inventory) e results (source-check) in memoria per evitare
+    fake signals da parquet non aggiornato.
+    """
     _heading(f"HEALTH SCORE — {source_id}")
-    from scripts.build_compliance_scores import build_scores
+    from scripts.build_compliance_scores import (
+        _build_inventory_stats,
+        _build_license_stats,
+        _build_source_check_stats,
+        build_scores,
+    )
 
     reg = load_registry()
     radar_path = REPO_ROOT / "data" / "radar" / "radar_summary.json"
@@ -175,10 +242,18 @@ def _health_score(source_id: str, _cfg: dict) -> dict | None:
     if signals_path.exists():
         signals_data = __import__("json").loads(signals_path.read_text())
 
+    # Costruisce stats in memoria invece di leggere da parquet
+    inventory_stats = _build_inventory_stats(source_id, rows) if rows else None
+    license_stats = _build_license_stats(source_id, rows) if rows else None
+    source_check_stats = _build_source_check_stats(source_id, results) if results else None
+
     result = build_scores(
         {source_id: reg.get(source_id, {})},
         [s for s in radar_sources if s["id"] == source_id],
         signals_data,
+        inventory_stats=inventory_stats,
+        license_stats=license_stats,
+        source_check_stats=source_check_stats,
     )
     entry = result["scores"][0] if result["scores"] else None
     if not entry:
@@ -237,12 +312,13 @@ def main() -> int:
         rows = _inventory(args.source, cfg)
 
     # 3. SOURCE-CHECK
+    results = []
     if not args.no_sourcecheck:
-        _source_check(args.source, cfg, rows)
+        results = _source_check(args.source, cfg, rows)
 
-    # 4. HEALTH SCORE
+    # 4. HEALTH SCORE (riceve rows e results in memoria → niente fake signals)
     if not args.no_health:
-        _health_score(args.source, cfg)
+        _health_score(args.source, cfg, rows=rows, results=results)
 
     print(f"\n✔  Fine — {args.source}")
     return 0

--- a/tests/test_compliance_scores.py
+++ b/tests/test_compliance_scores.py
@@ -14,6 +14,10 @@ import pytest
 from _constants import CATALOG_SIGNALS_PATH, RADAR_SUMMARY_PATH, REGISTRY_PATH
 
 from scripts.build_compliance_scores import (
+    _build_inventory_stats,
+    _build_license_stats,
+    _build_source_check_stats,
+    _datigovit_score,
     _flag_urgenza,
     _formato_score,
     _hvd_score,
@@ -277,3 +281,162 @@ class TestBuildComplianceScores:
         if path.exists():
             return json.loads(path.read_text(encoding="utf-8"))
         return None
+
+
+class TestBuilderFunctions:
+    """Test delle funzioni che aggregano dati in-memory (usate da run_source.py)."""
+
+    # ── _build_source_check_stats ──────────────────────────────────────
+
+    def test_source_check_stats_misto(self):
+        """Formati aperti e chiusi, alcuni irraggiungibili."""
+        results = [
+            {"reachable": True, "resource_format": "CSV", "check_notes": None},
+            {"reachable": True, "resource_format": "JSON", "check_notes": None},
+            {"reachable": False, "resource_format": "XLSX", "check_notes": "timeout"},
+            {"reachable": False, "resource_format": "", "check_notes": "circuit_open"},
+        ]
+        stats = _build_source_check_stats("fonte", results)
+        assert "fonte" in stats
+        s = stats["fonte"]
+        assert s["total"] == 4
+        assert s["reachable"] == 2
+        assert s["circuit_open"] == 1
+        assert s["formato_aperto"] == 2  # CSV + JSON
+        assert s["formato_chiuso"] == 1  # XLSX
+        assert s["formato_ignoto"] == 1  # vuoto
+        assert s["perc_reachable"] == 50.0
+        assert s["perc_aperto"] == 50.0
+
+    def test_source_check_stats_tutti_raggiungibili(self):
+        """100% raggiungibili, tutti formati aperti."""
+        results = [
+            {"reachable": True, "resource_format": "CSV", "check_notes": None},
+            {"reachable": True, "resource_format": "JSON", "check_notes": None},
+        ]
+        stats = _build_source_check_stats("ok", results)
+        s = stats["ok"]
+        assert s["total"] == s["reachable"] == 2
+        assert s["circuit_open"] == 0
+        assert s["perc_reachable"] == 100.0
+        assert s["perc_aperto"] == 100.0
+
+    def test_source_check_stats_vuoto(self):
+        """Lista vuota → total 0, nessun errore."""
+        stats = _build_source_check_stats("vuota", [])
+        s = stats["vuota"]
+        assert s["total"] == 0
+        assert s["reachable"] == 0
+        assert s["perc_reachable"] == 0.0
+        assert s["perc_aperto"] == 0.0
+
+    # ── _build_inventory_stats ─────────────────────────────────────────
+
+    def test_inventory_stats_ckan_only(self):
+        """Solo row CKAN contano."""
+        rows = [
+            {"protocol": "ckan", "format": "CSV"},
+            {"protocol": "ckan", "format": "JSON"},
+            {"protocol": "sparql", "format": "?"},
+            {"protocol": "ckan", "format": "XLSX"},
+            {"protocol": "ckan", "format": ""},
+        ]
+        stats = _build_inventory_stats("fonte", rows)
+        assert "fonte" in stats
+        s = stats["fonte"]
+        assert s["total"] == 4  # solo CKAN
+        assert s["con_formato"] == 3  # CSV, JSON, XLSX
+        assert s["aperti"] == 2  # CSV, JSON
+        assert s["perc_aperto"] == 50.0
+        assert s["copertura"] == 75.0
+
+    def test_inventory_stats_vuoto(self):
+        """Nessuna row → stats vuoto."""
+        stats = _build_inventory_stats("vuota", [])
+        assert stats == {}
+
+    # ── _build_license_stats ───────────────────────────────────────────
+
+    def test_license_stats_misto(self):
+        """Licenze aperte, HVD, misto."""
+        rows = [
+            {
+                "protocol": "ckan",
+                "license_id": "cc-by-4.0",
+                "license_title": "Creative Commons",
+                "hvd_category": "http://data.europa.eu/bna/c_ac64a52d",
+            },
+            {
+                "protocol": "ckan",
+                "license_id": "cc-zero",
+                "license_title": "CC0",
+                "hvd_category": "",
+            },
+            {
+                "protocol": "ckan",
+                "license_id": "other-open",
+                "license_title": "Other Open",
+                "hvd_category": "",
+            },
+            {"protocol": "ckan", "license_id": "", "license_title": "", "hvd_category": ""},
+            {"protocol": "sparql", "license_id": "", "license_title": "", "hvd_category": ""},
+        ]
+        stats = _build_license_stats("fonte", rows)
+        assert "fonte" in stats
+        s = stats["fonte"]
+        assert s["total"] == 4  # solo CKAN
+        assert s["licenze_aperte"] == 3  # cc-by, cc-zero, other-open
+        assert s["perc_licenza_aperta"] == 75.0
+        assert s["has_hvd"] is True  # almeno una row con HVD
+
+    def test_license_stats_nessuna_licenza(self):
+        """Nessuna licenza aperta, nessun HVD."""
+        rows = [
+            {"protocol": "ckan", "license_id": "", "license_title": "", "hvd_category": ""},
+        ]
+        stats = _build_license_stats("fonte", rows)
+        s = stats["fonte"]
+        assert s["licenze_aperte"] == 0
+        assert s["perc_licenza_aperta"] == 0.0
+        assert s["has_hvd"] is False
+
+    def test_license_stats_vuoto(self):
+        """Nessuna row → stats vuoto."""
+        stats = _build_license_stats("vuota", [])
+        assert stats == {}
+
+    # ── _datigovit_score ───────────────────────────────────────────────
+
+    def test_datigovit_dati_gov_it(self):
+        """Fonte su dati.gov.it → computed."""
+        score, fonte = _datigovit_score({"base_url": "https://dati.gov.it/opendata/api/3/action/"})
+        assert score == 80.0
+        assert fonte == "computed"
+
+    def test_datigovit_api_action(self):
+        """Fonte con /api/3/action/ (aggregatore CKAN) → computed."""
+        score, fonte = _datigovit_score(
+            {"base_url": "https://portalecomune.it/api/3/action/package_list"}
+        )
+        assert score == 80.0
+        assert fonte == "computed"
+
+    def test_datigovit_odapi(self):
+        """Fonte con /odapi/ (INPS) → computed."""
+        score, fonte = _datigovit_score(
+            {"base_url": "https://serviziweb2.inps.it/odapi/package_list"}
+        )
+        assert score == 80.0
+        assert fonte == "computed"
+
+    def test_datigovit_portale_diretto(self):
+        """Fonte su portale dedicato → estimated."""
+        score, fonte = _datigovit_score({"base_url": "https://dati.terna.it/"})
+        assert score == 50.0
+        assert fonte == "estimated"
+
+    def test_datigovit_sparql(self):
+        """Endpoint SPARQL → estimated."""
+        score, fonte = _datigovit_score({"base_url": "https://dati.camera.it/sparql"})
+        assert score == 50.0
+        assert fonte == "estimated"

--- a/tests/test_compliance_scores.py
+++ b/tests/test_compliance_scores.py
@@ -8,8 +8,10 @@ che protegge il contratto verso data-advocacy.
 from __future__ import annotations
 
 import json
+import tempfile
 from pathlib import Path
 
+import pandas as pd
 import pytest
 from _constants import CATALOG_SIGNALS_PATH, RADAR_SUMMARY_PATH, REGISTRY_PATH
 
@@ -22,6 +24,7 @@ from scripts.build_compliance_scores import (
     _formato_score,
     _hvd_score,
     _licenza_score,
+    _load_source_check_stats,
     _raggiungibilita_score,
     build_scores,
 )
@@ -288,6 +291,7 @@ class TestBuilderFunctions:
 
     # ── _build_source_check_stats ──────────────────────────────────────
 
+    @pytest.mark.pure_unit
     def test_source_check_stats_misto(self):
         """Formati aperti e chiusi, alcuni irraggiungibili."""
         results = [
@@ -308,6 +312,7 @@ class TestBuilderFunctions:
         assert s["perc_reachable"] == 50.0
         assert s["perc_aperto"] == 50.0
 
+    @pytest.mark.pure_unit
     def test_source_check_stats_tutti_raggiungibili(self):
         """100% raggiungibili, tutti formati aperti."""
         results = [
@@ -321,6 +326,7 @@ class TestBuilderFunctions:
         assert s["perc_reachable"] == 100.0
         assert s["perc_aperto"] == 100.0
 
+    @pytest.mark.pure_unit
     def test_source_check_stats_vuoto(self):
         """Lista vuota → total 0, nessun errore."""
         stats = _build_source_check_stats("vuota", [])
@@ -332,6 +338,7 @@ class TestBuilderFunctions:
 
     # ── _build_inventory_stats ─────────────────────────────────────────
 
+    @pytest.mark.pure_unit
     def test_inventory_stats_ckan_only(self):
         """Solo row CKAN contano."""
         rows = [
@@ -350,6 +357,7 @@ class TestBuilderFunctions:
         assert s["perc_aperto"] == 50.0
         assert s["copertura"] == 75.0
 
+    @pytest.mark.pure_unit
     def test_inventory_stats_vuoto(self):
         """Nessuna row → stats vuoto."""
         stats = _build_inventory_stats("vuota", [])
@@ -357,6 +365,7 @@ class TestBuilderFunctions:
 
     # ── _build_license_stats ───────────────────────────────────────────
 
+    @pytest.mark.pure_unit
     def test_license_stats_misto(self):
         """Licenze aperte, HVD, misto."""
         rows = [
@@ -389,6 +398,7 @@ class TestBuilderFunctions:
         assert s["perc_licenza_aperta"] == 75.0
         assert s["has_hvd"] is True  # almeno una row con HVD
 
+    @pytest.mark.pure_unit
     def test_license_stats_nessuna_licenza(self):
         """Nessuna licenza aperta, nessun HVD."""
         rows = [
@@ -400,6 +410,7 @@ class TestBuilderFunctions:
         assert s["perc_licenza_aperta"] == 0.0
         assert s["has_hvd"] is False
 
+    @pytest.mark.pure_unit
     def test_license_stats_vuoto(self):
         """Nessuna row → stats vuoto."""
         stats = _build_license_stats("vuota", [])
@@ -407,12 +418,14 @@ class TestBuilderFunctions:
 
     # ── _datigovit_score ───────────────────────────────────────────────
 
+    @pytest.mark.contract
     def test_datigovit_dati_gov_it(self):
         """Fonte su dati.gov.it → computed."""
         score, fonte = _datigovit_score({"base_url": "https://dati.gov.it/opendata/api/3/action/"})
         assert score == 80.0
         assert fonte == "computed"
 
+    @pytest.mark.contract
     def test_datigovit_api_action(self):
         """Fonte con /api/3/action/ (aggregatore CKAN) → computed."""
         score, fonte = _datigovit_score(
@@ -421,6 +434,7 @@ class TestBuilderFunctions:
         assert score == 80.0
         assert fonte == "computed"
 
+    @pytest.mark.contract
     def test_datigovit_odapi(self):
         """Fonte con /odapi/ (INPS) → computed."""
         score, fonte = _datigovit_score(
@@ -429,14 +443,65 @@ class TestBuilderFunctions:
         assert score == 80.0
         assert fonte == "computed"
 
+    @pytest.mark.contract
     def test_datigovit_portale_diretto(self):
         """Fonte su portale dedicato → estimated."""
         score, fonte = _datigovit_score({"base_url": "https://dati.terna.it/"})
         assert score == 50.0
         assert fonte == "estimated"
 
+    @pytest.mark.contract
     def test_datigovit_sparql(self):
         """Endpoint SPARQL → estimated."""
         score, fonte = _datigovit_score({"base_url": "https://dati.camera.it/sparql"})
         assert score == 50.0
         assert fonte == "estimated"
+
+
+class TestLoadSourceCheckStats:
+    """Test _load_source_check_stats() con parquet misto (backward compat probe_applicable)."""
+
+    @pytest.mark.pure_unit
+    def test_load_source_check_stats_misto(self):
+        """NULL legacy trattato come probeabile, False escluso, True incluso."""
+        df = pd.DataFrame(
+            {
+                "source_id": ["fonte"] * 4,
+                "reachable": [True, True, True, True],
+                "resource_format": ["CSV", "CSV", "JSON", "JSON"],
+                "check_notes": [None, None, "probe_skipped", None],
+                "probe_applicable": [True, None, False, True],
+            }
+        )
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=True) as tmp:
+            df.to_parquet(tmp.name, index=False)
+            stats = _load_source_check_stats(Path(tmp.name))
+        s = stats["fonte"]
+        # Row 0: True → incluso
+        # Row 1: NULL → COALESCE True → incluso (legacy)
+        # Row 2: False → escluso
+        # Row 3: True → incluso
+        assert s["total"] == 3, f"atteso 3, ottenuto {s['total']}"
+        assert s["reachable"] == 3
+        assert s["formato_aperto"] == 3
+        assert s["perc_aperto"] == 100.0
+
+    @pytest.mark.pure_unit
+    def test_load_source_check_stats_senza_colonna(self):
+        """Parquet senza probe_applicable → backward compat: tutti inclusi."""
+        df = pd.DataFrame(
+            {
+                "source_id": ["fonte"] * 2,
+                "reachable": [True, True],
+                "resource_format": ["CSV", "XLSX"],
+                "check_notes": [None, None],
+            }
+        )
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=True) as tmp:
+            df.to_parquet(tmp.name, index=False)
+            stats = _load_source_check_stats(Path(tmp.name))
+        s = stats["fonte"]
+        assert s["total"] == 2
+        assert s["reachable"] == 2
+        assert s["formato_aperto"] == 1
+        assert s["formato_chiuso"] == 1

--- a/tests/test_run_source.py
+++ b/tests/test_run_source.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -26,18 +28,21 @@ def _run(*args: str) -> subprocess.CompletedProcess:
 class TestRunSourceSmoke:
     """Test minimi che lo script non crasha su input base."""
 
+    @pytest.mark.smoke
     def test_help(self):
         """--help deve funzionare."""
         r = _run("--help")
         assert r.returncode == 0
         assert "End-to-end per una fonte" in r.stdout
 
+    @pytest.mark.smoke
     def test_fonte_inesistente(self):
         """Fonte sconosciuta → exit 1."""
         r = _run("fonte_che_non_esiste")
         assert r.returncode == 1
         assert "non trovata" in r.stderr or "non trovata" in r.stdout
 
+    @pytest.mark.smoke
     def test_fonte_noop(self):
         """Fonte valida con tutti i --no-* deve fare zero probe e uscire con 0."""
         r = _run("anac", "--no-radar", "--no-inventory", "--no-sourcecheck", "--no-health")

--- a/tests/test_run_source.py
+++ b/tests/test_run_source.py
@@ -1,0 +1,46 @@
+"""Smoke test per run_source.py.
+
+Verifica che lo script parta e gestisca i casi base
+(fonte inesistente, --help, fonte valida). Non fa probe reali.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "run_source.py"), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=REPO_ROOT,
+    )
+
+
+class TestRunSourceSmoke:
+    """Test minimi che lo script non crasha su input base."""
+
+    def test_help(self):
+        """--help deve funzionare."""
+        r = _run("--help")
+        assert r.returncode == 0
+        assert "End-to-end per una fonte" in r.stdout
+
+    def test_fonte_inesistente(self):
+        """Fonte sconosciuta → exit 1."""
+        r = _run("fonte_che_non_esiste")
+        assert r.returncode == 1
+        assert "non trovata" in r.stderr or "non trovata" in r.stdout
+
+    def test_fonte_noop(self):
+        """Fonte valida con tutti i --no-* deve fare zero probe e uscire con 0."""
+        r = _run("anac", "--no-radar", "--no-inventory", "--no-sourcecheck", "--no-health")
+        assert r.returncode == 0
+        assert "anac" in r.stdout
+        assert "Fine" in r.stdout


### PR DESCRIPTION
## Sintesi

`run_source.py` diventa un orchestratore end-to-end che esegue RADAR → INVENTORY → SOURCE-CHECK → HEALTH SCORE per una singola fonte, passando i dati in memoria tra le fasi. Niente più fake signals da parquet non aggiornato.

## Contesto collegato

Chiude l'esperienza della PR #385 (chiusa). Questo branch include molto di più.

## Cosa cambia

- [ ] Nuova fonte o modifica registro (sources_registry.yaml)
- [ ] Source-check o inventory-triage
- [x] Modifica script (radar, inventory, source-check, MCP)
- [ ] Modifica funnel o criteri di osservazione
- [ ] Workflow CI (radar.yml, observatory.yml)
- [ ] Skills o MCP tools
- [ ] Documentazione
- [x] Altro (test)

### Dettaglio

**`scripts/run_source.py`** — orchestratore:
- Esegue RADAR → INVENTORY → SOURCE-CHECK → HEALTH SCORE in sequenza
- Passa `rows` (inventory) e `results` (source-check) a `build_scores()` in memoria
- Circuit breaker condiviso via `HttpClient` passato a `_check_row`
- Output arricchito: tempi, formati, PAQA medio, needs_review scomposto (granularità/anni separati)

**`scripts/build_compliance_scores.py`** — fix ai fake signals:
- `_build_source_check_stats()`, `_build_inventory_stats()`, `_build_license_stats()`: aggregano dati in memoria (stesso shape dei loader da parquet)
- `_datigovit_score()` ora accetta `source_info` e usa pattern matching su URL (niente lista hardcoded)

**`scripts/bulk_source_check.py`** — skip SDMX/SPARQL nel probe HTTP (già nella PR #385)

### Test

- `tests/test_compliance_scores.py`: +13 test per builder functions, datigovit_score
- `tests/test_run_source.py`: nuovo file, 3 smoke test (help, fonte inesistente, noop)

## Checklist

- [x] `pytest tests/` passa (436 test, tutti verdi)
- [x] `ruff check .` passa
- [ ] `mypy scripts/ so_mcp/` — da verificare (non eseguito)

## Verifica

Testato manualmente su 6 fonti in 3 protocolli:

| Fonte | Protocollo | Risultato |
|---|---|---|
| ANAC | CKAN | 70 item, health score 73.2 (era 47.5) |
| mit_opendata | CKAN | circuit breaker condiviso, 3 probe invece di 210 |
| dati_camera | SPARQL | source-check skippato, 104 item in 0.5s |
| giustizia_statistiche | HTML | 9 item, formato_chiuso flag corretto |
| opencivitas | HTML | 703 ZIP, SSL fallback, health score 45.6 |
| aifa | HTML | 42 item, 36 preview CSV, PAQA 89 |

## Note per chi revisiona

- L'health score ora riceve dati in memoria — il percorso CI (main con parquet) è invariato e testato (436 test passano)
- Fonti con >500 item (openbdap, istat_sdmx) non scalano in sequenziale in run_source.py — atteso, build_catalog_inventory.py le gestisce in parallelo