### PR TITLE
feat: run_source.py parallelo, timing summary, granularità da colonne CSV

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -87,7 +87,7 @@ openbdap:
     package_show_sample: true
     package_show_max_workers: 8
     package_show_timeout: 10
-    sample_size: 5000
+    sample_size: 25
   last_probed: '2026-06-25'
   catalog_baseline:
     captured_at: '2026-04-02'

--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -65,6 +65,7 @@ from source_check_fetch import (
     _fetch_sdmx_years,
     _fetch_sparql_count,
     _http_head_with_retry,
+    _infer_granularity_from_columns,
     configure_source_check_http,
 )
 from toolkit.scout.http import (
@@ -626,6 +627,21 @@ def _check_row(
                 year_max = preview["year_max"]
             # Campi profiling: SEMPRE popolati (encoding, delim, mapping, ecc.)
             preview_meta = _preview_meta_from_enrich(preview)
+
+            # Inferenza granularità dalle colonne del CSV (più affidabile del titolo)
+            if granularity in (None, "non_determinato"):
+                raw_cols = preview.get("columns") or preview_meta.get("columns")
+                if isinstance(raw_cols, str):
+                    try:
+                        import json as _json
+
+                        raw_cols = _json.loads(raw_cols)
+                    except Exception:
+                        raw_cols = None
+                if isinstance(raw_cols, list) and len(raw_cols) > 0:
+                    from_cols = _infer_granularity_from_columns(raw_cols)
+                    if from_cols and from_cols != "non_determinato":
+                        granularity = from_cols
 
     # Se l'enrich ha gia' chiamato _fetch_data_preview ma non siamo rientrati
     # nel blocco sopra (perche' granularita' era gia' determinata),

--- a/scripts/run_source.py
+++ b/scripts/run_source.py
@@ -134,6 +134,8 @@ def _source_check(source_id: str, cfg: dict, rows: list[dict]) -> list[dict]:
         print("  SKIP: nessun item da controllare")
         return []
 
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
     from scripts.bulk_source_check import _check_row
     from scripts.source_check_fetch import configure_source_check_http
 
@@ -142,11 +144,17 @@ def _source_check(source_id: str, cfg: dict, rows: list[dict]) -> list[dict]:
     reg = load_registry()
     client = configure_source_check_http()  # client condiviso — circuit breaker unico
 
-    results = []
-    for row in rows:
-        r = _check_row(row, check_ts, reg, client)  # type: ignore[arg-type]
-        if r is not None:
-            results.append(r)
+    # Workers: rispetta max_concurrency dalla registry (es. MIMIT RNA = 2)
+    sc_cfg = cfg.get("source_check", {}) or {}
+    max_workers = max(1, int(sc_cfg.get("max_concurrency", 10)))
+    max_workers = min(max_workers, len(rows)) if rows else max_workers
+    results: list[dict] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_check_row, row, check_ts, reg, client): row for row in rows}  # type: ignore[arg-type]
+        for future in as_completed(futures):
+            r = future.result()
+            if r is not None:
+                results.append(r)
 
     total = len(results)
     reachable = sum(1 for r in results if r.get("reachable"))
@@ -199,6 +207,12 @@ def _source_check(source_id: str, cfg: dict, rows: list[dict]) -> list[dict]:
         if no_year:
             flags.append(f"anni:{no_year}/{total}")
         print(f"  ⚠️  Needs review: {', '.join(flags)}")
+
+    # Metriche probe: media per item (con workers attivi)
+    has_no_url = sum(1 for r in results if not r.get("url_checked"))
+    if has_no_url:
+        print(f"  ℹ️  Senza URL: {has_no_url}/{total}")
+    print(f"  Worker: {max_workers}")
 
     problematic = [r for r in results if not r.get("reachable")]
     if problematic:
@@ -281,6 +295,7 @@ def _health_score(
 
 def main() -> int:
     import argparse
+    import time as _time
 
     parser = argparse.ArgumentParser(description="End-to-end per una fonte")
     parser.add_argument("source", help="source_id dalla registry")
@@ -301,24 +316,58 @@ def main() -> int:
     print(f"  {args.source}  ({cfg.get('protocol', '?')})")
     print(f"{'=' * 55}\n")
 
+    timing: dict[str, float | str] = {}
+    t_start = _time.time()
+
     # 1. RADAR
     if not args.no_radar:
+        t0 = _time.time()
         _radar(args.source, cfg)
+        timing["RADAR"] = round(_time.time() - t0, 1)
+    else:
+        timing["RADAR"] = "skip"
 
     # 2. INVENTORY
     rows = []
     if not args.no_inventory:
+        t0 = _time.time()
         rows = _inventory(args.source, cfg)
+        timing["INVENTORY"] = round(_time.time() - t0, 1)
+    else:
+        timing["INVENTORY"] = "skip"
 
     # 3. SOURCE-CHECK
     results = []
     if not args.no_sourcecheck:
+        t0 = _time.time()
         results = _source_check(args.source, cfg, rows)
+        timing["SOURCE-CHECK"] = round(_time.time() - t0, 1)
+    else:
+        timing["SOURCE-CHECK"] = "skip"
 
-    # 4. HEALTH SCORE (riceve rows e results in memoria → niente fake signals)
+    # 4. HEALTH SCORE
     if not args.no_health:
+        t0 = _time.time()
         _health_score(args.source, cfg, rows=rows, results=results)
+        timing["HEALTH"] = round(_time.time() - t0, 1)
+    else:
+        timing["HEALTH"] = "skip"
 
+    timing["TOTALE"] = round(_time.time() - t_start, 1)
+
+    # Riepilogo tempi
+    print(f"\n{'─' * 50}")
+    print("  ⏱  RIEPILOGO TEMPI")
+    print(f"{'─' * 50}")
+    for fase in ("RADAR", "INVENTORY", "SOURCE-CHECK", "HEALTH"):
+        v = timing[fase]
+        if isinstance(v, str):
+            print(f"    {fase:<15} {v}")
+        else:
+            c = "🟢" if v < 10 else "🟡" if v < 60 else "🔴"
+            print(f"    {fase:<15} {v:>6.1f}s  {c}")
+    print(f"    {'─' * 15}")
+    print(f"    {'TOTALE':<15} {timing['TOTALE']:>6.1f}s")
     print(f"\n✔  Fine — {args.source}")
     return 0
 


### PR DESCRIPTION
## Sintesi

Miglioramenti a run_source.py (source-check parallelo, timing summary) + inferenza granularità dalle colonne dei preview CSV.

## Cosa cambia

- [ ] Nuova fonte o modifica registro
- [x] Source-check o inventory-triage
- [x] Modifica script (radar, inventory, source-check, MCP)
- [ ] Workflow CI
- [ ] Documentazione
- [x] Altro (configurazione inventory)

### Dettaglio

**`scripts/run_source.py`**
- Source-check parallelo con `ThreadPoolExecutor` (default 10 workers, rispetta `max_concurrency` della registry)
- MIMIT RNA (max_concurrency=2): source-check parallelo con 2 workers ✅
- Timing summary per fase con soglie 🟢🟡🔴
- Mostra numero workers nell'output

**`scripts/bulk_source_check.py`**
- Inferenza granularità dalle colonne del preview CSV quando disponibili (es. colonna `Comune` → granularità comunale)
- Più affidabile del titolo, costo zero (dati già raccolti da PAQA)

**`data/radar/sources_registry.yaml`**
- openbdap: `sample_size: 5000→25` (inventory 9 min → 13s)

## Confronto performance

| Fonte | Item | PRIMA (sequenziale) | DOPO (parallelo) |
|---|---|---|---|
| ANAC | 70 | 46.5s 🔴 | **11.5s 🟢** |
| unioncamere | 371 | — | **86.1s** |
| openga | 436 | — | **112.3s** |

## Checklist

- [x] `pytest tests/` passa
- [x] `ruff check .` passa
- [ ] `mypy scripts/ so_mcp/` — non verificato
- [x] Test manuale su ANAC, unioncamere, openga, mimit_rna

## Note per chi revisiona

- La granularità da colonne preview è nel ramo `csv_preview` di `_check_row()`, scatta solo quando il preview CSV ha colonne e la granularità non è già determinata
- openbdap sample_size 5000→25: 3831 item via package_list + 25 arricchiti via package_show. Per source-check basta l'URL