### PR TITLE
refactor: rimosso estimated dallo scoring — solo computed/missing

### DIFF
--- a/scripts/build_compliance_scores.py
+++ b/scripts/build_compliance_scores.py
@@ -3,9 +3,8 @@
 Produce open_data_health_scores.json per ogni fonte monitorata.
 
 Punteggio su 6 assi (0-100) basato su dati gia' disponibili in SO.
-Artifact bridge verso data-advocacy: ogni asse indica se il dato e'
-"computed" (da dati reali), "estimated" (default in assenza di info certa)
-o "missing" (dato non disponibile, escluso dal punteggio).
+Ogni asse e' "computed" (dati reali verificati) o "missing"
+(dato non disponibile, escluso dal punteggio). Niente stime.
 
 Avvertenza: i punteggi sono diagnostici, non certificativi. Un punteggio
 basso significa "abbiamo pochi dati o segnali di criticita'", non
@@ -411,7 +410,7 @@ def _formato_score(
     if inventory_stats and source_id in inventory_stats:
         stats = inventory_stats[source_id]
         perc = stats["perc_aperto"]
-        fonte = "computed" if stats["copertura"] >= 50.0 else "parziale"
+        fonte = "computed"
         if perc >= 95.0:
             return (90.0, fonte)
         elif perc >= 80.0:
@@ -431,18 +430,8 @@ def _formato_score(
         if "CSV" in detail:
             return (75.0, "computed")
 
-    # ── 4. Stima per protocollo (pessimista) ──────────────────────────
-    protocol_scores_pessimista = {
-        "sdmx": 70.0,  # SDMX e' sempre XML strutturato
-        "sparql": 65.0,  # SPARQL REST — presumibilmente RDF
-        "ckan": 30.0,  # CKAN non dice nulla sul formato reale
-        "aem": 45.0,
-        "rest": 45.0,
-        "html": 35.0,
-    }
-    score = protocol_scores_pessimista.get(protocol, 25.0)
-    source_type = "estimated"
-    return (score, source_type)
+    # ── 4. Nessun dato — asse non conteggiato ──────────────────────
+    return (0.0, "missing")
 
 
 def _raggiungibilita_score(
@@ -475,7 +464,7 @@ def _raggiungibilita_score(
 
     # ── 2. Radar: portale reachability ──────────────────────────────────
     if radar_entry is None:
-        return (50.0, "estimated")
+        return (0.0, "missing")
 
     status = radar_entry.get("status", "GREEN")
     note = radar_entry.get("note") or ""
@@ -496,7 +485,7 @@ def _raggiungibilita_score(
             return (15.0, "computed")
         return (20.0, "computed")
 
-    return (50.0, "estimated")
+    return (0.0, "missing")
 
 
 def _licenza_score(
@@ -515,8 +504,8 @@ def _licenza_score(
         elif perc > 0:
             return (40.0, "computed")
         else:
-            return (50.0, "estimated")
-    return (50.0, "estimated")
+            return (0.0, "missing")
+    return (0.0, "missing")
 
 
 def _datigovit_score(source_info: dict) -> tuple[float, str]:
@@ -537,7 +526,7 @@ def _datigovit_score(source_info: dict) -> tuple[float, str]:
         return (80.0, "computed")
     if "/odapi/" in base_url:
         return (80.0, "computed")
-    return (50.0, "estimated")
+    return (0.0, "missing")
 
 
 def _hvd_score(
@@ -644,10 +633,7 @@ def build_scores(
 
         totale = round(numeratore / denominatore, 1) if denominatore > 0 else 0.0
 
-        # Livello dal minimo degli assi (non-missing).
-        # Gli assi "estimated" (stime prudenziali) non possono tirare giu'
-        # il livello sotto "medio" — solo gli assi "computed"/"parziale"
-        # (dati reali) possono determinare "debole" o "carente".
+        # Livello dal minimo degli assi computed (missing esclusi).
         _ORDINE_LIVELLI = {"buono": 0, "medio": 1, "debole": 2, "carente": 3}
 
         def _livello_asse(score: float) -> str:
@@ -663,11 +649,7 @@ def build_scores(
         for val, src, _key in assi_info:
             if src == "missing":
                 continue
-            livello_asse = _livello_asse(val)
-            if src in ("estimated",):
-                # Le stime non tirano giu' il livello
-                livello_asse = min(livello_asse, "medio", key=lambda x: _ORDINE_LIVELLI.get(x, 0))
-            livelli_assi.append(livello_asse)
+            livelli_assi.append(_livello_asse(val))
 
         livello = (
             max(livelli_assi, key=lambda x: _ORDINE_LIVELLI.get(x, 0)) if livelli_assi else "medio"
@@ -703,12 +685,15 @@ def build_scores(
                 azione = "verifica raggiungibilita' (FOIA se persiste)"
             else:
                 azione = "verifica umana"
-        elif totale < 70 and formato < 40:
+        elif totale < 70 and f_src == "computed" and formato < 40:
             azione = "segnalazione DCD (formato chiuso — verificare)"
-        elif totale < 70 and raggiung < 30:
+        elif totale < 70 and r_src == "computed" and raggiung < 30:
             azione = "verifica raggiungibilita'"
         else:
             azione = "monitoraggio"
+
+        # Quanti assi hanno dati reali (trasparenza per l'utente)
+        assi_computed = sum(1 for _, src, _ in assi_info if src == "computed")
 
         entry = {
             "source_id": source_id,
@@ -717,6 +702,7 @@ def build_scores(
             "livello": livello,
             "azione_raccomandata": azione,
             "flag_urgenza": flags,
+            "assi_computed": assi_computed,
             "assi": {
                 "formato_aperto": {"score": formato, "fonte": f_src},
                 "raggiungibilita": {"score": raggiung, "fonte": r_src},

--- a/tests/test_compliance_scores.py
+++ b/tests/test_compliance_scores.py
@@ -68,7 +68,7 @@ class TestBuildComplianceScores:
             for k, v in assi.items():
                 assert "score" in v
                 assert "fonte" in v
-                assert v["fonte"] in ("computed", "estimated", "missing")
+                assert v["fonte"] in ("computed", "missing")
                 assert 0 <= v["score"] <= 100
 
         # Verifica distribuzione
@@ -109,7 +109,7 @@ class TestBuildComplianceScores:
 
     @pytest.mark.contract
     def test_formato_score_copertura_parziale(self):
-        """Asse A: copertura < 50% → parziale, non computed."""
+        """Asse A: copertura bassa ma dati reali → computed."""
         inv = {
             "openbdap": {
                 "total": 3825,
@@ -121,21 +121,20 @@ class TestBuildComplianceScores:
         }
         score, fonte = _formato_score("ckan", [], inv, "openbdap")
         assert score == 90.0
-        assert fonte == "parziale"  # non "computed" perche' copertura < 50%
+        assert fonte == "computed"
 
     @pytest.mark.contract
     def test_formato_score_senza_inventory(self):
-        """Asse A: senza inventory, usa fallback protocol (pessimista)."""
+        """Asse A: nessun dato → missing (non conteggiato)."""
         score, fonte = _formato_score("ckan", [], None, "ignota")
-        assert score == 30.0  # fallback CKAN pessimistico
-        assert fonte == "estimated"
+        assert score == 0.0
+        assert fonte == "missing"
         score2, fonte2 = _formato_score("html", [], None, "ignota")
-        assert score2 == 35.0  # fallback HTML pessimistico
-        assert fonte2 == "estimated"
-        # SDMX resta affidabile (sempre XML)
+        assert score2 == 0.0
+        assert fonte2 == "missing"
         score3, fonte3 = _formato_score("sdmx", [], None, "ignota")
-        assert score3 == 70.0
-        assert fonte3 == "estimated"
+        assert score3 == 0.0
+        assert fonte3 == "missing"
 
     @pytest.mark.contract
     def test_formato_score_da_source_check(self):
@@ -216,14 +215,17 @@ class TestBuildComplianceScores:
         assert "FOIA" in entry["azione_raccomandata"]
 
     @pytest.mark.contract
-    def test_build_scores_estimated_non_tira_giu(self):
-        """Assi estimated non possono portare il livello sotto 'medio'."""
+    def test_build_scores_senza_dati(self):
+        """Nessun dato su nessun asse → tutti missing, livello fallback medio."""
         registry = {"fonte_test": {"protocol": "html"}}
         result = build_scores(registry, [], None, {}, {}, {})
         entry = result["scores"][0]
-        # Presenza_datigovit e' 50 estimated (soglia debole), ma non deve tirare giu
-        # Il livello dovrebbe essere almeno medio perche' estimated e' cap a medio
-        assert entry["livello"] in ("medio",), f"livello={entry['livello']}, atteso medio"
+        # Tutti gli assi sono missing → totale=0, livello=medio (fallback)
+        assert entry["totale"] == 0.0
+        assert entry["livello"] == "medio"
+        assert entry["assi_computed"] == 0
+        for k, v in entry["assi"].items():
+            assert v["fonte"] == "missing", f"{k} dovrebbe essere missing"
 
     @pytest.mark.contract
     def test_licenza_score_da_inventory(self):
@@ -250,7 +252,7 @@ class TestBuildComplianceScores:
             "f3": {"total": 10, "licenze_aperte": 0, "perc_licenza_aperta": 0.0, "has_hvd": False}
         }
         s3, f3 = _licenza_score("ckan", inv3, "f3")
-        assert s3 == 50.0 and f3 == "estimated"
+        assert s3 == 0.0 and f3 == "missing"
 
     @pytest.mark.contract
     def test_hvd_score_da_inventory(self):
@@ -445,17 +447,17 @@ class TestBuilderFunctions:
 
     @pytest.mark.contract
     def test_datigovit_portale_diretto(self):
-        """Fonte su portale dedicato → estimated."""
+        """Fonte su portale dedicato → missing."""
         score, fonte = _datigovit_score({"base_url": "https://dati.terna.it/"})
-        assert score == 50.0
-        assert fonte == "estimated"
+        assert score == 0.0
+        assert fonte == "missing"
 
     @pytest.mark.contract
     def test_datigovit_sparql(self):
-        """Endpoint SPARQL → estimated."""
+        """Endpoint SPARQL → missing."""
         score, fonte = _datigovit_score({"base_url": "https://dati.camera.it/sparql"})
-        assert score == 50.0
-        assert fonte == "estimated"
+        assert score == 0.0
+        assert fonte == "missing"
 
 
 class TestLoadSourceCheckStats:


### PR DESCRIPTION
## Sintesi

Rimosso lo stato `estimated` dal tri-state dello scoring. Ora ogni asse è `computed` (dati verificati) o `missing` (non conteggiato). Niente stime, niente default 50, niente "estimated non può tirare giù".

## Cosa cambia

- `_formato_score()`, `_raggiungibilita_score()`, `_licenza_score()`, `_datigovit_score()`: tutte le return `estimated` diventano `missing`
- Rimosso `protocol_scores_pessimista`: CKAN=30, HTML=35, SPARQL=65, SDMX=70, ecc.
- Rimossa logica "estimated non può tirare il livello sotto medio"
- Nessuna stima: se non hai dati, l'asse non conteggia

## Effetto

| Prima | Dopo |
|---|---|
| Fonte senza source-check: formato_aperto=30 estimated | formato_aperto=missing → escluso |
| Fonte senza radar: raggiungibilita=50 estimated | raggiungibilita=missing → escluso |
| Fonte non aggregata: datigovit=50 estimated | datigovit=missing → escluso |
| Score basato su 6 assi di cui 3 stimati | Score basato solo sugli assi con dati reali |

Più onesto: se non abbiamo verificato un asse, non lo conteggiamo.

## Verifica

- `pytest tests/`: 29 test ✅
- `mypy scripts/ so_mcp/`: 0 errori ✅
- `ruff check .`: 0 errori ✅