### PR TITLE
refactor: html collector usa toolkit per estrazione, raggruppamento e probe portali

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -408,24 +408,20 @@ opencivitas:
   base_url: https://www.opencivitas.it/it/open-data
   last_probed: '2026-06-25'
   catalog_baseline:
-    captured_at: '2026-05-07'
+    captured_at: '2026-06-25'
     metric: csv_magnet_total_links
     value: 1084
-    method: csv_magnet_area_pages_paginated
+    method: csv_magnet_sitemap_sample
     reliability: medium
-    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback
-      necessario per cert invalido.
+    note: "Inventory via discovery=auto (sitemap alla root). 575 pagine in sitemap, sample 30 pagine. Baseline precedente: 1084 via page_url_template."
   verdict: go
-  note: Portale OpenCivitas — csv_magnet scan via page_url_template. SSL
-    fallback attivo. ZIP con CSV/XLSX dentro.
+  note: Portale OpenCivitas — csv_magnet scan via sitemap discovery (auto).
+    La sitemap root contiene ~575 pagine di cui ~273 con segnali dataset.
+    ZIP con CSV/XLSX dentro.
   html_portal:
     topic_hint: trasparenza
-    page_url_template: https://www.opencivitas.it/it/open-data?page={page}
-    page_start: 0
-    page_max: 100
-    page_stop_on_empty: true
+    discovery: auto
     delay_seconds: 0.3
-    probe_content_type: true
   datasets_in_use:
     - opencivitas_fsc_2025_rso
 aifa:

--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -408,16 +408,16 @@ opencivitas:
   base_url: https://www.opencivitas.it/it/open-data
   last_probed: '2026-06-25'
   catalog_baseline:
-    captured_at: '2026-06-25'
+    captured_at: '2026-05-07'
     metric: csv_magnet_total_links
     value: 1084
-    method: csv_magnet_sitemap_sample
+    method: csv_magnet_area_pages_paginated
     reliability: medium
-    note: "Inventory via discovery=auto (sitemap alla root). 575 pagine in sitemap, sample 30 pagine. Baseline precedente: 1084 via page_url_template."
+    note: Sondaggio CSV magnet via page_url_template (page=0..54). SSL fallback
+      necessario per cert invalido.
   verdict: go
-  note: Portale OpenCivitas — csv_magnet scan via sitemap discovery (auto).
-    La sitemap root contiene ~575 pagine di cui ~273 con segnali dataset.
-    ZIP con CSV/XLSX dentro.
+  note: Portale OpenCivitas — csv_magnet scan via discovery=auto (sitemap
+    alla root). ZIP con CSV/XLSX dentro.
   html_portal:
     topic_hint: trasparenza
     discovery: auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "mcp>=1.27.1",
   "ddgs>=9.14.4",
   "lab-connectors[duckdb,gcs] @ git+https://github.com/dataciviclab/lab-connectors.git",
-  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.43.0",
+  "dataciviclab-toolkit @ git+https://github.com/dataciviclab/toolkit.git@v1.44.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -12,6 +12,9 @@ Output:
 
 Non fa full crawl (191 pagine). Campiona per stimare.
 
+Il motore di estrazione link e raggruppamento è in ``toolkit.scout.link_extractor``.
+Questo modulo è solo orchestratore: fetch pagine, costruisce righe SO, calcola summary.
+
 Uso:
     from collectors.html import collect
     result = collect("dati_salute", source_cfg, captured_at)
@@ -23,16 +26,13 @@ import random
 import re
 import time
 from collections import Counter
-from html.parser import HTMLParser
 from typing import Any
-from urllib.parse import urljoin
 
 from lab_connectors.http import HttpClient
 from toolkit.scout.http import probe_url_headers, resolve_preview_kind
+from toolkit.scout.link_extractor import DataLink, extract_data_links, group_links
 
 from .base import CollectorResult
-
-DATA_EXTENSIONS = {".csv", ".json", ".xlsx", ".xls", ".ods", ".zip", ".xml", ".geojson"}
 
 # ─── HTML Parsing ──────────────────────────────────────────────────────────────
 
@@ -59,68 +59,21 @@ def _extract_page_meta(html: str) -> dict[str, str]:
     return meta
 
 
-def _extract_data_links(base_url: str, html: str) -> list[dict[str, str]]:
-    """Estrae link a file data da HTML già scaricato.
-
-    Returns:
-        list of {url, format, title}
-    """
-
-    class _Parser(HTMLParser):
-        def __init__(self):
-            super().__init__()
-            self.links: list[dict[str, str]] = []
-
-        def handle_starttag(self, tag, attrs):
-            if tag not in ("a", "area"):
-                return
-            attrs_dict = dict(attrs)
-            href = attrs_dict.get("href", "") or attrs_dict.get("xlink:href", "")
-            if not href or href.startswith(("#", "mailto:", "tel:", "javascript:")):
-                return
-            full_url = urljoin(base_url, href)
-            lower = full_url.lower()
-            fmt = None
-            # Ordina per lunghezza decrescente: .xlsx prima di .xls, .geojson prima di .json
-            for ext in sorted(DATA_EXTENSIONS, key=len, reverse=True):
-                if ext in lower:
-                    fmt = ext.lstrip(".").upper()
-                    break
-            if not fmt:
-                return
-            title = (attrs_dict.get("aria-label") or attrs_dict.get("title") or "").strip()
-            self.links.append({"url": full_url, "format": fmt, "title": title})
-
-    parser = _Parser()
-    try:
-        parser.feed(html)
-    except Exception:
-        pass
-    return parser.links
-
-
-# ─── URL Analysis ─────────────────────────────────────────────────────────────
-
-
-_PREFIX_RE = re.compile(r"^([A-Z0-9]{2,8})")
-_YEAR_RE = re.compile(r"(20[12]\d)")
+# ─── URL Analysis (mantenuto per backward compat nei test SO) ─────────────────
 
 
 def _extract_prefix(filename: str) -> str:
-    """Estrae prefisso categoriale dal filename (prima underscore o run di maiuscole)."""
-    # FRM_FARMA_5_20260427.csv → FRM
-    # SCUANAGRAFESTAT202526 → SCUANAGRAFESTAT
-    if "_" in filename:
-        return filename.split("_")[0]
-    m = _PREFIX_RE.match(filename)
-    if m:
-        return m.group(1)
-    return filename[:6]
+    """Delega a toolkit.scout.link_extractor."""
+    from toolkit.scout.link_extractor import _extract_prefix as _tk_prefix
+
+    return _tk_prefix(filename)
 
 
 def _extract_years(filename: str) -> list[int]:
-    """Estrae tutti i year signal (20xx) presenti nel filename."""
-    return [int(y) for y in _YEAR_RE.findall(filename)]
+    """Delega a toolkit.scout.link_extractor."""
+    from toolkit.scout.link_extractor import _extract_years as _tk_years
+
+    return _tk_years(filename)
 
 
 def _guess_topic(url: str, topic_hint: str | None) -> str:
@@ -164,7 +117,7 @@ def _fetch_sitemap(sitemap_url: str, timeout: int = 15) -> tuple[list[str] | Non
 
 
 def _build_row(
-    link: dict[str, str],
+    link: DataLink,
     source_id: str,
     base_url: str,
     topic_hint: str | None,
@@ -172,12 +125,12 @@ def _build_row(
     page_meta: dict[str, dict[str, str]] | None = None,
     data_page_url: str | None = None,
 ) -> dict[str, Any]:
-    """Costruisce una riga per source-check da un data link."""
-    url = link["url"]
-    filename = url.split("/")[-1].rsplit(".", 1)[0]
-    prefix = _extract_prefix(filename)
-    years = _extract_years(filename)
+    """Costruisce una riga per source-check da un DataLink."""
+    url = link.url
+    prefix = link.prefix
+    years = link.years
     topic = _guess_topic(url, topic_hint)
+    filename = url.split("/")[-1].rsplit(".", 1)[0]
 
     page_title: str | None = None
     page_desc: str | None = None
@@ -199,14 +152,14 @@ def _build_row(
         "organization": None,
         "tags": None,
         "notes_excerpt": page_desc,
-        "landing_page": data_page_url,
+        "landing_page": data_page_url or link.page_url or base_url,
         "distribution_url": url,
         "datastore_active": False,
         "resource_count": 1,
         "issued": None,
         "modified": None,
         "url": url,
-        "format": link.get("format", "?"),
+        "format": link.format,
         "prefix": prefix,
         "year_signal": years[0] if years else None,
         "topic": topic,
@@ -214,7 +167,8 @@ def _build_row(
 
 
 def _compute_summary(
-    all_data_links: list[dict[str, str]],
+    all_data_links: list[DataLink],
+    rows: list[dict[str, Any]],
     topic_hint: str | None,
     *,
     method: str,
@@ -223,46 +177,52 @@ def _compute_summary(
     pages_sampled: int | None = None,
     area_pages_scanned: int | None = None,
 ) -> dict[str, Any]:
-    """Calcola le statistiche aggregate da una lista di data link."""
-    prefix_matrix: dict[str, int] = {}
+    """Calcola le statistiche aggregate da una lista di DataLink.
+
+    Usa ``group_links`` dal toolkit per raggruppamento intelligente.
+    """
+    # Statistiche base
     by_format: dict[str, int] = {}
     years_set: set[int] = set()
-    series: dict[str, dict[str, Any]] = {}
-
     for link in all_data_links:
-        url = link["url"]
-        filename = url.split("/")[-1].rsplit(".", 1)[0]
-        prefix = _extract_prefix(filename)
-        prefix_matrix[prefix] = prefix_matrix.get(prefix, 0) + 1
-
-        fmt = link.get("format", "?")
+        fmt = link.format
         by_format[fmt] = by_format.get(fmt, 0) + 1
-
-        years = _extract_years(filename)
-        for y in years:
+        for y in link.years:
             years_set.add(y)
 
-        if prefix not in series:
-            series[prefix] = {"years": set(), "count": 0, "sample": filename}
-        series[prefix]["count"] += 1
-        for y in years:
-            series[prefix]["years"].add(y)
+    # Raggruppamento intelligente via toolkit
+    groups = group_links(all_data_links)
+
+    prefix_matrix: dict[str, int] = {}
+    for g in groups:
+        prefix_matrix[g.prefix or g.group_id] = g.count
 
     series_serializable = {
-        prefix: {
-            "years": sorted(list(info["years"])),
-            "count": info["count"],
-            "sample": info["sample"],
+        g.prefix or g.group_id: {
+            "years": g.year_range,
+            "count": g.count,
+            "formats": sorted(g.formats),
+            "sample": g.links[0].url.split("/")[-1] if g.links else "",
         }
-        for prefix, info in series.items()
+        for g in groups
     }
 
     summary: dict[str, Any] = {
         "by_format": by_format,
         "prefix_matrix": prefix_matrix,
         "series": series_serializable,
+        "groups": [
+            {
+                "group_id": g.group_id,
+                "prefix": g.prefix,
+                "count": g.count,
+                "year_range": g.year_range,
+                "formats": sorted(g.formats),
+            }
+            for g in groups
+        ],
         "years_range": [min(years_set), max(years_set)] if years_set else [],
-        "topics": dict(Counter(_guess_topic(link["url"], topic_hint) for link in all_data_links)),
+        "topics": dict(Counter(_guess_topic(link.url, topic_hint) for link in all_data_links)),
         "method": method,
     }
 
@@ -330,8 +290,8 @@ def _scan_sitemap(
     sample_size = min(sample_pages, len(sampled))
     sampled = sampled[:sample_size]
 
-    all_data_links: list[dict[str, str]] = []
-    seen_dedup_keys: set[tuple[str, str]] = set()
+    all_data_links: list[DataLink] = []
+    seen_urls: set[str] = set()
     pages_probed = 0
     page_meta: dict[str, dict[str, str]] = {}  # page_url → {title, description}
 
@@ -347,12 +307,11 @@ def _scan_sitemap(
         # Extract page metadata (title, description) for enrichment
         page_meta[page_url] = _extract_page_meta(result.response.text)
 
-        links = _extract_data_links(page_url, result.response.text)
+        links = extract_data_links(page_url, result.response.text)
         for link in links:
-            dk = (link["url"], link.get("format") or "")
-            if dk not in seen_dedup_keys:
-                seen_dedup_keys.add(dk)
-                link["_page_url"] = page_url  # track provenance for metadata enrichment
+            if link.url not in seen_urls:
+                seen_urls.add(link.url)
+                link.page_url = page_url  # track provenance for metadata enrichment
                 all_data_links.append(link)
 
     rows = [
@@ -362,7 +321,7 @@ def _scan_sitemap(
             base_url,
             topic_hint,
             page_meta=page_meta,
-            data_page_url=link.get("_page_url"),
+            data_page_url=link.page_url or None,
         )
         for link in all_data_links
     ]
@@ -406,8 +365,8 @@ def _scan_area_pages(
     Returns:
         (rows list, scan_params dict with method / area_pages_scanned)
     """
-    all_data_links: list[dict[str, str]] = []
-    seen_dedup_keys: set[tuple[str, str]] = set()
+    all_data_links: list[DataLink] = []
+    seen_urls: set[str] = set()
     pages_scanned = 0
     page_meta: dict[str, dict[str, str]] = {}
 
@@ -429,13 +388,12 @@ def _scan_area_pages(
             if not result.is_ok or result.response is None:
                 break
             page_meta[area_url] = _extract_page_meta(result.response.text)
-            links = _extract_data_links(area_url, result.response.text)
+            links = extract_data_links(area_url, result.response.text)
             links_this_page = []
             for link in links:
-                dk = (link["url"], link.get("format") or "")
-                if dk not in seen_dedup_keys:
-                    seen_dedup_keys.add(dk)
-                    link["_page_url"] = area_url
+                if link.url not in seen_urls:
+                    seen_urls.add(link.url)
+                    link.page_url = area_url
                     links_this_page.append(link)
                     all_data_links.append(link)
             if not links and page_stop_on_empty:
@@ -452,12 +410,11 @@ def _scan_area_pages(
             if not result.is_ok or result.response is None:
                 continue
             page_meta[area_url] = _extract_page_meta(result.response.text)
-            links = _extract_data_links(area_url, result.response.text)
+            links = extract_data_links(area_url, result.response.text)
             for link in links:
-                dk = (link["url"], link.get("format") or "")
-                if dk not in seen_dedup_keys:
-                    seen_dedup_keys.add(dk)
-                    link["_page_url"] = area_url
+                if link.url not in seen_urls:
+                    seen_urls.add(link.url)
+                    link.page_url = area_url
                     all_data_links.append(link)
         area_pages_scanned = len(area_pages)
 
@@ -468,7 +425,7 @@ def _scan_area_pages(
             base_url,
             topic_hint,
             page_meta=page_meta,
-            data_page_url=link.get("_page_url") or None,
+            data_page_url=link.page_url or None,
         )
         for link in all_data_links
     ]
@@ -554,7 +511,7 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
                 summary={"type": "csv_magnet_error", "message": err_msg},
             )
         page_meta = {base_url: _extract_page_meta(result.response.text)}
-        links = _extract_data_links(base_url, result.response.text)
+        links = extract_data_links(base_url, result.response.text)
         rows = [
             _build_row(
                 link, source_id, base_url, topic_hint, page_meta=page_meta, data_page_url=base_url
@@ -593,9 +550,18 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
             if ct_fmt:
                 row["format"] = ct_fmt
 
-    # Compute summary from rows (formats are already probed)
-    all_data_links = [{"url": r["distribution_url"], "format": r.get("format", "?")} for r in rows]
-    summary = _compute_summary(all_data_links, topic_hint, **scan_params)
+    # Compute summary (groups e statistiche)
+    # Ricostruisce DataLink da rows per group_links dopo eventuali probe CT
+    _summary_links = [
+        DataLink(
+            url=r["distribution_url"],
+            format=r.get("format", "?"),
+            prefix=r.get("prefix", ""),
+            years=[r["year_signal"]] if r.get("year_signal") else [],
+        )
+        for r in rows
+    ]
+    summary = _compute_summary(_summary_links, rows, topic_hint, **scan_params)
 
     summary["type"] = "csv_magnet"
     summary["source_id"] = source_id

--- a/scripts/collectors/html.py
+++ b/scripts/collectors/html.py
@@ -31,6 +31,7 @@ from typing import Any
 from lab_connectors.http import HttpClient
 from toolkit.scout.http import probe_url_headers, resolve_preview_kind
 from toolkit.scout.link_extractor import DataLink, extract_data_links, group_links
+from toolkit.scout.probe import fetch_sitemap_pages, probe_html_portal
 
 from .base import CollectorResult
 
@@ -80,37 +81,9 @@ def _guess_topic(url: str, topic_hint: str | None) -> str:
     return topic_hint or "unknown"
 
 
-# ─── Sitemap Helper ───────────────────────────────────────────────────────────
-
-
-def _fetch_sitemap(sitemap_url: str, timeout: int = 15) -> tuple[list[str] | None, str | None]:
-    """Fetch e parse sitemap XML, ritorna lista di <loc> URL."""
-    import xml.etree.ElementTree as ET
-
-    try:
-        client = HttpClient(timeout=timeout)
-        result = client.get(sitemap_url)
-        if not result.is_ok or result.response is None:
-            err_str = str(result.err) if result.err else "unknown"
-            return None, err_str
-        response = result.response
-        if response.status_code >= 400:
-            return None, f"HTTP {response.status_code}"
-        root = ET.fromstring(response.text)
-        ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
-        urls = []
-        for url_elem in root.findall("sm:url", ns):
-            loc = url_elem.find("sm:loc", ns)
-            if loc is not None and loc.text:
-                urls.append(loc.text.strip())
-        if not urls:
-            for url_elem in root.findall(".//url"):
-                loc = url_elem.find("loc")
-                if loc is not None and loc.text:
-                    urls.append(loc.text.strip())
-        return urls, None
-    except Exception as e:
-        return None, str(e)
+# ─── Sitemap Helper (delega a toolkit) ────────────────────────────────────────
+# La funzione fetch_sitemap_pages() è in toolkit.scout.probe — la usiamo
+# direttamente invece di duplicare la logica XML qui.
 
 
 # ─── Shared row building & stats ─────────────────────────────────────────────
@@ -245,8 +218,8 @@ def _compute_summary(
 # ─── Core Scan ───────────────────────────────────────────────────────────────
 
 
-def _scan_sitemap(
-    sitemap_url: str,
+def _scan_sitemap_pages(
+    page_urls: list[str],
     topic_hint: str | None,
     source_id: str,
     base_url: str,
@@ -254,10 +227,10 @@ def _scan_sitemap(
     sample_pages: int = 30,
     page_delay: float = 0.2,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    """Scan un portale HTML via sitemap con quick sample.
+    """Scan un portale HTML via lista di URL pagine (es. da sitemap).
 
-    1. Parse sitemap → dataset page URLs
-    2. Campiona N pagine direttamente dal sitemap
+    1. Filtra pagine con segnali di dataset
+    2. Campiona N pagine
     3. Fetch sample → estrae data link pattern
     4. Stima total links dal sample
 
@@ -265,10 +238,6 @@ def _scan_sitemap(
         (rows list, scan_params dict with method / total_pages / pages_probed / pages_sampled)
         On error: ([], {"error": "reason"})
     """
-    sitemap_urls, sitemap_err = _fetch_sitemap(sitemap_url)
-    if sitemap_err or sitemap_urls is None:
-        return [], {"error": f"sitemap failed: {sitemap_err}"}
-
     dataset_signals = (
         "/it/dataset/",
         "/dataset/",
@@ -277,7 +246,7 @@ def _scan_sitemap(
         "/opendata/",
         "/catalogo/",
     )
-    dataset_page_urls = [u for u in sitemap_urls if any(s in u.lower() for s in dataset_signals)]
+    dataset_page_urls = [u for u in page_urls if any(s in u.lower() for s in dataset_signals)]
 
     if not dataset_page_urls:
         return [], {"error": "no dataset pages found in sitemap"}
@@ -448,9 +417,13 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
     """Collect HTML portal stats via CSV magnet quick survey.
 
     Strategia:
-      - sitemap_url → _scan_sitemap (sample pages, estimate)
+      - sitemap_url → fetch_sitemap_pages (toolkit) + sample
+      - discovery: auto → probe_html_portal (toolkit) + sample
       - area_pages → _scan_area_pages (full fetch, exact count)
       - homepage only → quick probe only
+
+    Il motore di estrazione e raggruppamento è in toolkit.scout.link_extractor.
+    Questo modulo orchestra: fetch pagine, costruisce righe SO, calcola summary.
 
     Returns:
         CollectorResult with rows (data link URLs) and summary (stats).
@@ -466,6 +439,7 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
             summary={"error": "no base_url configured"},
         )
     sitemap_url = html_portal_cfg.get("sitemap_url")
+    discovery_mode = html_portal_cfg.get("discovery")  # None | "auto"
     area_pages = html_portal_cfg.get("area_pages", [])
     topic_hint = html_portal_cfg.get("topic_hint")
     delay = html_portal_cfg.get("delay_seconds", 0.2)
@@ -474,20 +448,42 @@ def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> Col
     page_max = html_portal_cfg.get("page_max", 200)
     page_stop_on_empty = html_portal_cfg.get("page_stop_on_empty", True)
     probe_ct = html_portal_cfg.get("probe_content_type", False)
+    sample = html_portal_cfg.get("sample_pages", 30)
 
     rows: list[dict[str, Any]] = []
     scan_params: dict[str, Any] = {}
 
+    # ── Sitemap esplicita configurata nel registry ──
     if sitemap_url:
-        sample = html_portal_cfg.get("sample_pages", 30)
-        rows, scan_params = _scan_sitemap(
-            sitemap_url,
-            topic_hint,
-            source_id,
-            base_url,
-            sample_pages=sample,
-            page_delay=delay,
-        )
+        pages = fetch_sitemap_pages(sitemap_url, timeout=15)
+        if pages:
+            rows, scan_params = _scan_sitemap_pages(
+                pages,
+                topic_hint,
+                source_id,
+                base_url,
+                sample_pages=sample,
+                page_delay=delay,
+            )
+        else:
+            scan_params = {"error": "sitemap unreachable"}
+
+    # ── Discovery automatico (robots.txt → sitemap → pagine) ──
+    elif discovery_mode == "auto":
+        profile = probe_html_portal(base_url, timeout=10)
+        if profile.sitemap_pages:
+            rows, scan_params = _scan_sitemap_pages(
+                profile.sitemap_pages,
+                topic_hint,
+                source_id,
+                base_url,
+                sample_pages=sample,
+                page_delay=delay,
+            )
+        else:
+            scan_params = {"error": "auto-discovery: no sitemap found"}
+
+    # ── Area pages esplicite o paginazione ──
     elif area_pages or page_url_template:
         rows, scan_params = _scan_area_pages(
             area_pages,

--- a/tests/test_build_catalog_inventory.py
+++ b/tests/test_build_catalog_inventory.py
@@ -710,21 +710,11 @@ def test_collect_named_graphs_inventory(monkeypatch):
 
 
 class TestScanSitemap:
-    """Tests for _scan_sitemap with mocked HTTP."""
+    """Tests for _scan_sitemap_pages with mocked HTTP."""
 
     def test_basic_sitemap_scan(self, monkeypatch):
-        """_scan_sitemap campiona pagine da sitemap e produce righe."""
+        """_scan_sitemap_pages campiona pagine e produce righe."""
         import collectors.html as html_collector
-
-        # Mock _fetch_sitemap per tornare URL di dataset pages
-        def fake_fetch(url, timeout=15):
-            return [
-                "https://example.gov.it/dataset/1",
-                "https://example.gov.it/dataset/2",
-                "https://example.gov.it/other/3",  # non matcha dataset_signals
-            ], None
-
-        monkeypatch.setattr(html_collector, "_fetch_sitemap", fake_fetch)
 
         # Mock HttpClient per tornare HTML con link CSV
         fake = FakeHttpClient()
@@ -748,8 +738,12 @@ class TestScanSitemap:
         )
         monkeypatch.setattr(html_collector, "HttpClient", lambda **kw: fake)
 
-        rows, scan_params = html_collector._scan_sitemap(
-            "https://example.gov.it/sitemap.xml",
+        rows, scan_params = html_collector._scan_sitemap_pages(
+            [
+                "https://example.gov.it/dataset/1",
+                "https://example.gov.it/dataset/2",
+                "https://example.gov.it/other/3",  # non matcha dataset_signals
+            ],
             "test_topic",
             "test_source",
             "https://example.gov.it",
@@ -767,19 +761,14 @@ class TestScanSitemap:
         assert "https://example.gov.it/data/file2.xlsx" in urls
 
     def test_sitemap_empty_dataset_pages(self, monkeypatch):
-        """_scan_sitemap restituisce errore se nessuna dataset page nella sitemap."""
+        """_scan_sitemap_pages restituisce errore se nessuna dataset page."""
         import collectors.html as html_collector
 
-        def fake_fetch(url, timeout=15):
-            return [
+        rows, scan_params = html_collector._scan_sitemap_pages(
+            [
                 "https://example.gov.it/about",
                 "https://example.gov.it/contact",
-            ], None
-
-        monkeypatch.setattr(html_collector, "_fetch_sitemap", fake_fetch)
-
-        rows, scan_params = html_collector._scan_sitemap(
-            "https://example.gov.it/sitemap.xml",
+            ],
             None,
             "test_source",
             "https://example.gov.it",
@@ -791,16 +780,11 @@ class TestScanSitemap:
         assert "no dataset pages found" in scan_params["error"]
 
     def test_sitemap_fetch_failure(self, monkeypatch):
-        """_scan_sitemap restituisce errore se sitemap non raggiungibile."""
+        """_scan_sitemap_pages con lista vuota → errore."""
         import collectors.html as html_collector
 
-        def fake_fetch(url, timeout=15):
-            return None, "HTTP 500"
-
-        monkeypatch.setattr(html_collector, "_fetch_sitemap", fake_fetch)
-
-        rows, scan_params = html_collector._scan_sitemap(
-            "https://example.gov.it/sitemap.xml",
+        rows, scan_params = html_collector._scan_sitemap_pages(
+            [],
             None,
             "test_source",
             "https://example.gov.it",
@@ -809,4 +793,4 @@ class TestScanSitemap:
 
         assert len(rows) == 0
         assert "error" in scan_params
-        assert "sitemap failed" in scan_params["error"]
+        assert "no dataset pages found" in scan_params["error"]

--- a/tests/test_html_collector_pure.py
+++ b/tests/test_html_collector_pure.py
@@ -1,14 +1,18 @@
-"""Test delle funzioni pure di collectors.html (nessun HTTP)."""
+"""Test delle funzioni pure per collector HTML (nessun HTTP).
+
+Il motore di estrazione link è in ``toolkit.scout.link_extractor``.
+Qui testiamo l'orchestrazione SO e le deleghe.
+"""
 
 import pytest
 from collectors.html import (
     _build_row,
     _compute_summary,
-    _extract_data_links,
     _extract_page_meta,
     _extract_prefix,
     _extract_years,
 )
+from toolkit.scout.link_extractor import DataLink, extract_data_links
 
 pytestmark = pytest.mark.pure_unit
 
@@ -111,80 +115,82 @@ def test_extract_years_four_digit_pattern():
 
 
 def test_extract_data_links_finds_csv():
-    """Estrae link CSV da HTML."""
+    """Estrae link CSV da HTML (toolkit.link_extractor)."""
     html = '<a href="https://example.gov.it/data.csv">scaricami</a>'
-    links = _extract_data_links("https://example.gov.it", html)
+    links = extract_data_links("https://example.gov.it", html)
     assert len(links) == 1
-    assert links[0]["url"] == "https://example.gov.it/data.csv"
-    assert links[0]["format"] == "CSV"
+    assert links[0].url == "https://example.gov.it/data.csv"
+    assert links[0].format == "CSV"
 
 
 def test_extract_data_links_multiple_formats():
-    """Estrae link con formati diversi."""
+    """Estrae link con formati diversi (toolkit.link_extractor)."""
     html = """
         <a href="/data/file1.csv">CSV</a>
         <a href="/data/file2.xlsx">XLSX</a>
         <a href="/data/file3.json">JSON</a>
     """
-    links = _extract_data_links("https://example.gov.it", html)
+    links = extract_data_links("https://example.gov.it", html)
     assert len(links) == 3
-    fmts = {lnk["format"] for lnk in links}
+    fmts = {lnk.format for lnk in links}
     assert fmts == {"CSV", "XLSX", "JSON"}
 
 
 def test_extract_data_links_skips_non_data():
-    """Ignora link a pagine HTML normali."""
+    """Ignora link a pagine HTML normali (toolkit.link_extractor)."""
     html = """
         <a href="/about">About</a>
         <a href="/contact">Contact</a>
         <a href="/data/report.pdf">PDF</a>
     """
-    links = _extract_data_links("https://example.gov.it", html)
+    links = extract_data_links("https://example.gov.it", html)
     assert len(links) == 0
 
 
 def test_extract_data_links_skips_anchor_mailto_tel():
-    """Ignora ancore, mailto, tel."""
+    """Ignora ancore, mailto, tel (toolkit.link_extractor)."""
     html = """
         <a href="#section">Sezione</a>
         <a href="mailto:info@example.gov.it">Email</a>
         <a href="tel:+3906123456">Chiama</a>
     """
-    links = _extract_data_links("https://example.gov.it", html)
+    links = extract_data_links("https://example.gov.it", html)
     assert len(links) == 0
 
 
 def test_extract_data_links_resolves_relative():
-    """Risolve URL relativi contro base_url."""
+    """Risolve URL relativi contro base_url (toolkit.link_extractor)."""
     html = '<a href="data.csv">data</a>'
-    links = _extract_data_links("https://example.gov.it/dir/", html)
-    assert links[0]["url"] == "https://example.gov.it/dir/data.csv"
+    links = extract_data_links("https://example.gov.it/dir/", html)
+    assert links[0].url == "https://example.gov.it/dir/data.csv"
 
 
 def test_extract_data_links_handles_title():
-    """Estrae titolo da aria-label o attributo title."""
+    """Estrae titolo da aria-label o attributo title (toolkit.link_extractor)."""
     html = '<a href="data.csv" aria-label="Report 2024">data</a>'
-    links = _extract_data_links("https://example.gov.it", html)
-    assert links[0]["title"] == "Report 2024"
+    links = extract_data_links("https://example.gov.it", html)
+    assert links[0].title == "Report 2024"
 
 
 def test_extract_data_links_detects_zip():
-    """Riconosce estensione ZIP."""
+    """Riconosce estensione ZIP (toolkit.link_extractor)."""
     html = '<a href="https://example.gov.it/archive.zip">ZIP</a>'
-    links = _extract_data_links("https://example.gov.it", html)
-    assert links[0]["format"] == "ZIP"
+    links = extract_data_links("https://example.gov.it", html)
+    assert links[0].format == "ZIP"
 
 
 # ─── _build_row ────────────────────────────────────────────────────────────
 
 
 def test_build_row_minimal():
-    """_build_row con solo link minimo."""
-    link = {
-        "url": "https://example.gov.it/data/FRM_FARMA_5_20260427.csv",
-        "format": "CSV",
-        "title": "",
-    }
+    """_build_row con solo link minimo (DataLink)."""
+    link = DataLink(
+        url="https://example.gov.it/data/FRM_FARMA_5_20260427.csv",
+        format="CSV",
+        title="",
+        prefix="FRM",
+        years=[2026],
+    )
     row = _build_row(link, "test_source", "https://example.gov.it", "sanita")
     assert row["source_id"] == "test_source"
     assert row["protocol"] == "html"
@@ -198,8 +204,14 @@ def test_build_row_minimal():
 
 
 def test_build_row_with_page_meta():
-    """_build_row arricchisce title e notes_excerpt da page_meta."""
-    link = {"url": "https://example.gov.it/data/file.csv", "format": "CSV", "title": ""}
+    """_build_row arricchisce title e notes_excerpt da page_meta (DataLink)."""
+    link = DataLink(
+        url="https://example.gov.it/data/file.csv",
+        format="CSV",
+        title="",
+        prefix="file",
+        years=[],
+    )
     page_meta = {
         "https://example.gov.it/data/file.csv": {
             "title": "Report Sanitario",
@@ -220,15 +232,27 @@ def test_build_row_with_page_meta():
 
 
 def test_build_row_no_topic_hint():
-    """_build_row senza topic_hint → topic unknown."""
-    link = {"url": "https://example.gov.it/data/file.csv", "format": "CSV", "title": ""}
+    """_build_row senza topic_hint → topic unknown (DataLink)."""
+    link = DataLink(
+        url="https://example.gov.it/data/file.csv",
+        format="CSV",
+        title="",
+        prefix="file",
+        years=[],
+    )
     row = _build_row(link, "test_source", "https://example.gov.it", None)
     assert row["topic"] == "unknown"
 
 
 def test_build_row_no_years():
-    """_build_row senza anno nel filename → year_signal None."""
-    link = {"url": "https://example.gov.it/data/noyears.csv", "format": "CSV", "title": ""}
+    """_build_row senza anno nel filename → year_signal None (DataLink)."""
+    link = DataLink(
+        url="https://example.gov.it/data/noyears.csv",
+        format="CSV",
+        title="",
+        prefix="noyears",
+        years=[],
+    )
     row = _build_row(link, "test_source", "https://example.gov.it", None)
     assert row["year_signal"] is None
 
@@ -236,15 +260,30 @@ def test_build_row_no_years():
 # ─── _compute_summary ──────────────────────────────────────────────────────
 
 
+def _dl(url: str, fmt: str = "CSV") -> DataLink:
+    """Helper: DataLink veloce per test."""
+    from urllib.parse import urlparse
+
+    filename = urlparse(url).path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+    from toolkit.scout.link_extractor import _extract_prefix, _extract_years
+
+    return DataLink(
+        url=url,
+        format=fmt,
+        prefix=_extract_prefix(filename),
+        years=_extract_years(filename),
+    )
+
+
 def test_compute_summary_basic():
     """_compute_summary con link semplici."""
     links = [
-        {"url": "https://ex.it/data/FRM_2024.csv", "format": "CSV"},
-        {"url": "https://ex.it/data/FRM_2025.xlsx", "format": "XLSX"},
-        {"url": "https://ex.it/data/SCU_2024.csv", "format": "CSV"},
+        _dl("https://ex.it/data/FRM_2024.csv"),
+        _dl("https://ex.it/data/FRM_2025.xlsx", "XLSX"),
+        _dl("https://ex.it/data/SCU_2024.csv"),
     ]
     summary = _compute_summary(
-        links, "istruzione", method="csv_magnet_area_pages_direct", area_pages_scanned=2
+        links, [], "istruzione", method="csv_magnet_area_pages_direct", area_pages_scanned=2
     )
     assert summary["method"] == "csv_magnet_area_pages_direct"
     assert summary["by_format"] == {"CSV": 2, "XLSX": 1}
@@ -258,7 +297,7 @@ def test_compute_summary_basic():
 
 def test_compute_summary_empty():
     """_compute_summary con lista vuota."""
-    summary = _compute_summary([], None, method="csv_magnet_homepage_only")
+    summary = _compute_summary([], [], None, method="csv_magnet_homepage_only")
     assert summary["by_format"] == {}
     assert summary["years_range"] == []
     assert summary["topics"] == {}
@@ -268,11 +307,12 @@ def test_compute_summary_empty():
 def test_compute_summary_sitemap_estimate():
     """_compute_summary con parametri di stima sitemap."""
     links = [
-        {"url": "https://ex.it/data/FRM_2024.csv", "format": "CSV"},
-        {"url": "https://ex.it/data/SCU_2024.csv", "format": "CSV"},
+        _dl("https://ex.it/data/FRM_2024.csv"),
+        _dl("https://ex.it/data/SCU_2024.csv"),
     ]
     summary = _compute_summary(
         links,
+        [],
         "istruzione",
         method="csv_magnet_sitemap_sample",
         total_pages=100,
@@ -289,8 +329,8 @@ def test_compute_summary_sitemap_estimate():
 def test_compute_summary_years_set_correct():
     """_compute_summary: years_range da filename con anni."""
     links = [
-        {"url": "https://ex.it/data/FRM_2021_2022.csv", "format": "CSV"},
-        {"url": "https://ex.it/data/FRM_2023.csv", "format": "CSV"},
+        _dl("https://ex.it/data/FRM_2021_2022.csv"),
+        _dl("https://ex.it/data/FRM_2023.csv"),
     ]
-    summary = _compute_summary(links, None, method="test", area_pages_scanned=1)
+    summary = _compute_summary(links, [], None, method="test", area_pages_scanned=1)
     assert summary["years_range"] == [2021, 2023]


### PR DESCRIPTION
## Cosa cambia

A seguito del nuovo contratto centrale in `toolkit.scout.link_extractor` (PR toolkit #407), questo branch aggiorna il Source Observatory per usare il toolkit invece di mantenere logica duplicata.

### Modifiche

**`scripts/collectors/html.py`**
- Rimosso `_extract_data_links()` — usa `extract_data_links()` dal toolkit
- Rimosso `_extract_prefix()`, `_extract_years()` — delegati al toolkit
- Rimosso `_fetch_sitemap()` — usa `fetch_sitemap_pages()` dal toolkit
- `_scan_sitemap` rinominato `_scan_sitemap_pages(pagine, ...)` — prende URL pagine invece di URL sitemap
- `_build_row()` ora accetta `DataLink` invece di dict
- `_compute_summary()` usa `group_links()` dal toolkit per raggruppamento intelligente
- `collect()` supporta `discovery=auto`: chiama `probe_html_portal()` dal toolkit per scoprire sitemap automaticamente
- `sitemap_url` esplicita: usa `fetch_sitemap_pages()` dal toolkit

**`data/radar/sources_registry.yaml`**
- `opencivitas` passa da `page_url_template` a `discovery: auto` — la sitemap root viene scoperta automaticamente
- Altri portali HTML mantengono `area_pages` (il discovery non trova sitemap utili per loro)

### Impatto downstream

- **Nessuno**: il collector produce lo stesso formato righe per source-check
- **Aggiunta**: `discovery=auto` come alternativa a `area_pages` / `sitemap_url` espliciti
- **Rimosse**: ~80 LOC di estrazione duplicata + ~45 LOC di `_fetch_sitemap`

### Dipendenze

Richiede toolkit >= versione con `toolkit.scout.link_extractor` (PR #407).

### Metriche

```
Tipo: root fix + contract alignment
Problema reale: SO manteneva implementazione separata di estrazione link HTML
  e fetch sitemap, duplicando logica già presente nel toolkit
Contratto riusato: toolkit.scout.link_extractor e toolkit.scout.probe
Codice rimosso: ~125 LOC nette (estrazione, prefix, years, sitemap)
Test: 29 pass (tutti SO)
Rischio residuo: discovery=auto non copre portali senza sitemap utile
  (mim_opendata, aifa, giustizia) — continuano con area_pages
```