### PR TITLE
feat(registry): noipa_sparql hold→go — parser XML SPARQL disponibile

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -649,16 +649,20 @@ agid:
 noipa_sparql:
   source_kind: catalog
   protocol: sparql
-  observation_mode: radar-only
+  observation_mode: catalog-watch
   base_url: https://sparql-noipa.mef.gov.it/sparql
   last_probed: '2026-06-25'
-  verdict: hold
-  note: NoiPA SPARQL — MEF/RGS. Dati mensili personale PA (entries-{YYYYMM},
-    2019-2026) + pensioni PA (entriesPensioni-{YYYYMM}, 2017-oggi). ~490k
-    soggetti/mese. L'endpoint risponde solo in XML
-    (application/sparql-results+xml). Inventory non funzionante finché
-    execute_sparql() in lab-connectors non supporta XML. Radar-only in attesa di
-    parser XML o di endpoint JSON.
+  verdict: go
+  note: |
+    NoiPA SPARQL — MEF/RGS. Dati mensili personale PA
+    (entries-{YYYYMM}, 2019-2026) + pensioni PA (entriesPensioni-{YYYYMM},
+    2017-oggi). ~509k soggetti/mese, 39 predicati (ente, comparto, qualifica,
+    ritenute previdenziali/IRPEF, detrazioni, assenze, genere, eta', residenza).
+    POST bloccato (403), solo GET funziona. XML SPARQL parsato da
+    lab-connectors via _parse_sparql_xml() dal 2026-06-25.
+    I named graph usano URI completi:
+    https://sparql-noipa.mef.gov.it/entries-YYYYMM
+    (usare prefix="https://sparql-noipa.mef.gov.it/entries-" in discover_graphs).
   datasets_in_use: []
 mimit_rna:
   source_kind: catalog


### PR DESCRIPTION
## Cosa

Aggiorna `noipa_sparql` nel sources_registry.yaml da `hold` a `go`.

## Perché

lab-connectors PR [#64](https://github.com/dataciviclab/lab-connectors/pull/64) (merged) ha aggiunto `_parse_sparql_xml()` che parsifica `application/sparql-results+xml`. L'endpoint NoiPA risponde solo in XML (Virtuoso) — ora è utilizzabile.

## Modifiche

- `verdict`: `hold` → `go`
- `observation_mode`: `radar-only` → `catalog-watch`
- Nota aggiornata: 39 predicati, ~509k soggetti/mese, 89 grafi (2019-01 → 2026-05), URI completi dei named graph per discover_graphs()