### PR TITLE
feat: inail_opendata da radar-only (AEM) a catalog-watch (CKAN via dati.gov.it)

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -107,16 +107,17 @@ openbdap:
     - bdap_spese_stato
     - dipendenti_pubblici
 inail_opendata:
-  source_kind: portal
-  protocol: aem
-  observation_mode: radar-only
-  base_url: https://dati.inail.it/
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
+  inventory:
+    fq: organization:inail
+    timeout: 180
   last_probed: '2026-06-25'
   verdict: go
-  note: Portale AEM con Open API documentate. Superficie operativa reale =
-    catalogo AEM + Open API, non CKAN standard (logo nel footer fuorviante).
-    Baseline inventariale non ancora difendibile; tenere in radar-only finche'
-    non definito un metodo stabile.
+  note: Fonte via dati.gov.it. 102 dataset INAIL su infortuni sul lavoro e malattie
+    professionali. Complementare al portale diretto dati.inail.it (protocollo AEM).
   datasets_in_use: []
 mim_opendata:
   source_kind: catalog


### PR DESCRIPTION
## Sintesi

Rimpiazza la vecchia fonte `inail_opendata` (protocol: aem, radar-only) con una nuova via `dati.gov.it` (protocol: ckan, catalog-watch). 102 dataset con source-check funzionante.

## Perché

Il portale diretto INAIL (AEM) non è inventariabile senza un collector custom. Ma INAIL pubblica 102 dataset su dati.gov.it con organization `inail` — possiamo usarli subito.

## Verifica

```
python scripts/run_source.py inail_opendata

RADAR:       GREEN 0.5s
INVENTORY:   102 item 2.4s
SOURCE-CHECK: 102/102 raggiungibili ✅
Preview CSV: 20/102, PAQA medio 93
TOTALE:      19.1s
```

## Note

Il rename da `inail_opendata` a sé stesso è voluto: mantiene lo stesso source_id per backward compat con data-advocacy e artifact esistenti.