### PR TITLE
refactor: health scores su 4 assi (rimossi HVD e FOIA)

### DIFF
--- a/scripts/build_compliance_scores.py
+++ b/scripts/build_compliance_scores.py
@@ -2,7 +2,7 @@
 """
 Produce open_data_health_scores.json per ogni fonte monitorata.
 
-Punteggio su 6 assi (0-100) basato su dati gia' disponibili in SO.
+Punteggio su 4 assi (0-100) basato su dati gia' disponibili in SO.
 Ogni asse e' "computed" (dati reali verificati) o "missing"
 (dato non disponibile, escluso dal punteggio). Niente stime.
 
@@ -42,12 +42,10 @@ DEFAULT_OUT = OPEN_DATA_HEALTH_SCORES_PATH
 
 # Pesi per ogni asse
 PESI: dict[str, int] = {
-    "formato_aperto": 3,
-    "raggiungibilita": 2,
+    "formato_aperto": 4,
+    "raggiungibilita": 3,
     "licenza_aperta": 1,
     "presenza_datigovit": 2,
-    "hvd_compliance": 3,
-    "accessibilita_foia": 1,
 }
 
 ASSI = {
@@ -55,8 +53,6 @@ ASSI = {
     "raggiungibilita": {"label": "B — Raggiungibilita'", "max": 100},
     "licenza_aperta": {"label": "C — Licenza aperta", "max": 100},
     "presenza_datigovit": {"label": "D — Presenza dati.gov.it", "max": 100},
-    "hvd_compliance": {"label": "E — HVD compliance", "max": 100},
-    "accessibilita_foia": {"label": "F — Accessibilita' FOIA", "max": 100},
 }
 
 
@@ -104,11 +100,11 @@ def _load_inventory_format_stats(path: Path) -> dict[str, dict]:
 
 
 def _load_inventory_license_stats(path: Path) -> dict[str, dict]:
-    """Legge inventory parquet e classifica licenze e HVD per fonte.
+    """Legge inventory parquet e classifica licenze per fonte.
 
-    Restituisce dict: source_id → {"license_open_pct": 0-100, "has_hvd": bool}.
-    Se le colonne license_id/hvd_category non esistono ancora nel parquet
-    (generato prima di questo PR), torna vuoto senza errori.
+    Restituisce dict: source_id → {"license_open_pct": 0-100}.
+    Se la colonna license_id non esiste ancora nel parquet
+    (generato prima di questo fix), torna vuoto senza errori.
     """
     if not path.exists():
         return {}
@@ -130,22 +126,20 @@ def _load_inventory_license_stats(path: Path) -> dict[str, dict]:
             f"""
             SELECT source_id,
                    COUNT(*) as total,
-                   SUM(CASE WHEN LOWER(license_id) LIKE '%cc-by%' OR LOWER(license_id) LIKE '%cc-zero%' OR LOWER(license_id) LIKE '%cc0%' OR LOWER(license_id) LIKE '%odbl%' OR LOWER(license_id) LIKE '%iodl%' OR LOWER(license_id) = 'other-open' OR LOWER(license_title) LIKE '%creative commons%' OR LOWER(license_title) LIKE '%iodl%' THEN 1 ELSE 0 END) as licenze_aperte,
-                   SUM(CASE WHEN hvd_category IS NOT NULL AND hvd_category != '' THEN 1 ELSE 0 END) as con_hvd
+                   SUM(CASE WHEN LOWER(license_id) LIKE '%cc-by%' OR LOWER(license_id) LIKE '%cc-zero%' OR LOWER(license_id) LIKE '%cc0%' OR LOWER(license_id) LIKE '%odbl%' OR LOWER(license_id) LIKE '%iodl%' OR LOWER(license_id) = 'other-open' OR LOWER(license_title) LIKE '%creative commons%' OR LOWER(license_title) LIKE '%iodl%' THEN 1 ELSE 0 END) as licenze_aperte
             FROM '{path}'
             WHERE protocol = 'ckan'
             GROUP BY source_id
         """
         ).fetchall()
         stats = {}
-        for sid, total, licenze_aperte, con_hvd in rows:
+        for sid, total, licenze_aperte in rows:
             stats[sid] = {
                 "total": int(total),
                 "licenze_aperte": int(licenze_aperte),
                 "perc_licenza_aperta": round(int(licenze_aperte) / int(total) * 100, 1)
                 if int(total) > 0
                 else 0.0,
-                "has_hvd": int(con_hvd) > 0,
             }
         return stats
     except Exception as exc:
@@ -224,17 +218,13 @@ def _build_inventory_stats(source_id: str, rows: list[dict]) -> dict[str, dict]:
 
 
 def _build_license_stats(source_id: str, rows: list[dict]) -> dict[str, dict]:
-    """Aggrega inventory rows in memoria → same shape di _load_inventory_license_stats.
-
-    Stessa logica di licenza_aperta e HVD della versione parquet.
-    """
+    """Aggrega inventory rows in memoria → same shape di _load_inventory_license_stats."""
     ckan_rows = [r for r in rows if (r.get("protocol") or "").lower() == "ckan"]
     total = len(ckan_rows)
     if total == 0:
         return {}
 
     licenze_aperte = 0
-    con_hvd = 0
     for r in ckan_rows:
         lid = (r.get("license_id") or "").lower()
         ltitle = (r.get("license_title") or "").lower()
@@ -251,16 +241,11 @@ def _build_license_stats(source_id: str, rows: list[dict]) -> dict[str, dict]:
         if is_open:
             licenze_aperte += 1
 
-        hvd = str(r.get("hvd_category") or "").strip()
-        if hvd:
-            con_hvd += 1
-
     return {
         source_id: {
             "total": total,
             "licenze_aperte": licenze_aperte,
             "perc_licenza_aperta": round(licenze_aperte / total * 100, 1) if total > 0 else 0.0,
-            "has_hvd": con_hvd > 0,
         }
     }
 
@@ -529,24 +514,6 @@ def _datigovit_score(source_info: dict) -> tuple[float, str]:
     return (0.0, "missing")
 
 
-def _hvd_score(
-    license_stats: dict | None = None,
-    source_id: str = "",
-) -> tuple[float, str]:
-    """E — HVD compliance. Computed da inventory se disponibile."""
-    if license_stats and source_id in license_stats:
-        if license_stats[source_id]["has_hvd"]:
-            return (80.0, "computed")
-        # Sappiamo che non ha HVD (inventory ha la colonna, e' vuota)
-        return (50.0, "computed")
-    return (50.0, "missing")
-
-
-def _foia_access_score() -> tuple[float, str]:
-    """F — Accessibilita' FOIA. Dipende da anagrafica in data-advocacy."""
-    return (50.0, "missing")
-
-
 def _flag_urgenza(
     source_id: str,
     source_check_stats: dict | None = None,
@@ -612,8 +579,6 @@ def build_scores(
         )
         lic, l_src = _licenza_score(protocol, license_stats, source_id)
         dgov, d_src = _datigovit_score(info)
-        hvd, h_src = _hvd_score(license_stats, source_id)
-        foia, fo_src = _foia_access_score()
 
         # Punteggio ponderato — assi "missing" esclusi dal denominatore
         assi_info = [
@@ -621,8 +586,6 @@ def build_scores(
             (raggiung, r_src, "raggiungibilita"),
             (lic, l_src, "licenza_aperta"),
             (dgov, d_src, "presenza_datigovit"),
-            (hvd, h_src, "hvd_compliance"),
-            (foia, fo_src, "accessibilita_foia"),
         ]
         numeratore = 0.0
         denominatore = 0
@@ -714,8 +677,6 @@ def build_scores(
                 "raggiungibilita": {"score": raggiung, "fonte": r_src},
                 "licenza_aperta": {"score": lic, "fonte": l_src},
                 "presenza_datigovit": {"score": dgov, "fonte": d_src},
-                "hvd_compliance": {"score": hvd, "fonte": h_src},
-                "accessibilita_foia": {"score": foia, "fonte": fo_src},
             },
         }
         scores_list.append(entry)

--- a/scripts/run_source.py
+++ b/scripts/run_source.py
@@ -343,7 +343,8 @@ def _report_markdown(
     if health_entry:
         print(f"\n### Health score: {health_entry['totale']}/100 ({health_entry['livello']})")
         print(f"- **Azione**: {health_entry['azione_raccomandata']}")
-        print(f"- **Assi computed**: {health_entry.get('assi_computed', 0)}/5")
+        max_assi = len(health_entry.get("assi", {}))
+        print(f"- **Assi computed**: {health_entry.get('assi_computed', 0)}/{max_assi}")
         print()
         print("| Asse | Score | Fonte |")
         print("|---|---|---|")

--- a/tests/test_compliance_scores.py
+++ b/tests/test_compliance_scores.py
@@ -22,7 +22,6 @@ from scripts.build_compliance_scores import (
     _datigovit_score,
     _flag_urgenza,
     _formato_score,
-    _hvd_score,
     _licenza_score,
     _load_source_check_stats,
     _raggiungibilita_score,
@@ -62,8 +61,6 @@ class TestBuildComplianceScores:
             assert "raggiungibilita" in assi
             assert "licenza_aperta" in assi
             assert "presenza_datigovit" in assi
-            assert "hvd_compliance" in assi
-            assert "accessibilita_foia" in assi
 
             for k, v in assi.items():
                 assert "score" in v
@@ -236,42 +233,18 @@ class TestBuildComplianceScores:
                 "total": 10,
                 "licenze_aperte": 10,
                 "perc_licenza_aperta": 100.0,
-                "has_hvd": False,
             }
         }
         s, f = _licenza_score("ckan", inv, "f1")
         assert s == 85.0 and f == "computed"
         # other-open (deve essere riconosciuto come aperto)
-        inv2 = {
-            "f2": {"total": 5, "licenze_aperte": 5, "perc_licenza_aperta": 100.0, "has_hvd": False}
-        }
+        inv2 = {"f2": {"total": 5, "licenze_aperte": 5, "perc_licenza_aperta": 100.0}}
         s2, f2 = _licenza_score("ckan", inv2, "f2")
         assert s2 == 85.0 and f2 == "computed"
         # 0 licenze (nessun dato)
-        inv3 = {
-            "f3": {"total": 10, "licenze_aperte": 0, "perc_licenza_aperta": 0.0, "has_hvd": False}
-        }
+        inv3 = {"f3": {"total": 10, "licenze_aperte": 0, "perc_licenza_aperta": 0.0}}
         s3, f3 = _licenza_score("ckan", inv3, "f3")
         assert s3 == 0.0 and f3 == "missing"
-
-    @pytest.mark.contract
-    def test_hvd_score_da_inventory(self):
-        """Asse E: HVD presente, assente, colonna mancante."""
-        # HVD presente
-        inv = {
-            "f1": {"total": 10, "licenze_aperte": 10, "perc_licenza_aperta": 100.0, "has_hvd": True}
-        }
-        s, f = _hvd_score(inv, "f1")
-        assert s == 80.0 and f == "computed"
-        # Colonna presente ma nessun HVD
-        inv2 = {
-            "f2": {"total": 10, "licenze_aperte": 0, "perc_licenza_aperta": 0.0, "has_hvd": False}
-        }
-        s2, f2 = _hvd_score(inv2, "f2")
-        assert s2 == 50.0 and f2 == "computed"
-        # Colonna mancante (license_stats=None)
-        s3, f3 = _hvd_score(None, "f3")
-        assert s3 == 50.0 and f3 == "missing"
 
     @staticmethod
     def _load_yaml(path: Path) -> dict:
@@ -369,28 +342,25 @@ class TestBuilderFunctions:
 
     @pytest.mark.pure_unit
     def test_license_stats_misto(self):
-        """Licenze aperte, HVD, misto."""
+        """Licenze aperte, misto."""
         rows = [
             {
                 "protocol": "ckan",
                 "license_id": "cc-by-4.0",
                 "license_title": "Creative Commons",
-                "hvd_category": "http://data.europa.eu/bna/c_ac64a52d",
             },
             {
                 "protocol": "ckan",
                 "license_id": "cc-zero",
                 "license_title": "CC0",
-                "hvd_category": "",
             },
             {
                 "protocol": "ckan",
                 "license_id": "other-open",
                 "license_title": "Other Open",
-                "hvd_category": "",
             },
-            {"protocol": "ckan", "license_id": "", "license_title": "", "hvd_category": ""},
-            {"protocol": "sparql", "license_id": "", "license_title": "", "hvd_category": ""},
+            {"protocol": "ckan", "license_id": "", "license_title": ""},
+            {"protocol": "sparql", "license_id": "", "license_title": ""},
         ]
         stats = _build_license_stats("fonte", rows)
         assert "fonte" in stats
@@ -398,19 +368,17 @@ class TestBuilderFunctions:
         assert s["total"] == 4  # solo CKAN
         assert s["licenze_aperte"] == 3  # cc-by, cc-zero, other-open
         assert s["perc_licenza_aperta"] == 75.0
-        assert s["has_hvd"] is True  # almeno una row con HVD
 
     @pytest.mark.pure_unit
     def test_license_stats_nessuna_licenza(self):
-        """Nessuna licenza aperta, nessun HVD."""
+        """Nessuna licenza aperta."""
         rows = [
-            {"protocol": "ckan", "license_id": "", "license_title": "", "hvd_category": ""},
+            {"protocol": "ckan", "license_id": "", "license_title": ""},
         ]
         stats = _build_license_stats("fonte", rows)
         s = stats["fonte"]
         assert s["licenze_aperte"] == 0
         assert s["perc_licenza_aperta"] == 0.0
-        assert s["has_hvd"] is False
 
     @pytest.mark.pure_unit
     def test_license_stats_vuoto(self):


### PR DESCRIPTION
## Sintesi

Health score delle fonti passa da 6 a 4 assi: rimossi `hvd_compliance` e `accessibilita_foia`. I pesi sono stati riequilibrati: `formato_aperto` 3→4, `raggiungibilita` 2→3. Pulita la logica `hvd_category` dalle funzioni di license stats (non più consumata).

## Contesto collegato

Nessuna issue

## Cosa cambia

- [ ] Nuova fonte o modifica registro (sources_registry.yaml)
- [ ] Source-check o inventory-triage
- [x] Modifica script (radar, inventory, source-check, MCP)
- [ ] Modifica funnel o criteri di osservazione
- [ ] Workflow CI (radar.yml, observatory.yml)
- [ ] Skills o MCP tools
- [ ] Documentazione
- [ ] Altro

## Checklist

### Se modifichi script o MCP

- [x] `pytest tests/` passa — 25 test, tutti verdi
- [ ] `ruff check .` passa
- [ ] `mypy scripts/ so_mcp/` passa
- [ ] Comando manuale verificato (es. `python scripts/radar_check.py --source <id>`)

## Verifica

- `python -m pytest tests/test_compliance_scores.py -v` → 25/25 pass
- I pesi aggiornati modificano i punteggi esistenti (il peso relativo di `formato_aperto` sale)

- [x] Perimetro stretto: una PR = un tema o un fix
- [x] Issue collegata o motivazione dell'assenza

## Note per chi revisiona

**Cambio di contratto**: l'output `open_data_health_scores.json` perde `entry["assi"]["hvd_compliance"]` e `entry["assi"]["accessibilita_foia"]`. È già stato propagato a `data-advocacy` (PR gemella nello stesso branch `fix/compliance-4-assi`).

Richiudi un'occhiata ai nuovi pesi: `formato_aperto` sale a 4 e `raggiungibilita` a 3, mentre `hvd_compliance` (peso 3) e `accessibilita_foia` (peso 1) spariscono. L'effetto netto è che il formato aperto conta di più nel punteggio finale.