### PR TITLE
fix: preview CSV non tentate per fonti CKAN via dati.gov.it (inventory senza resource URL)

### DIFF
--- a/scripts/bulk_source_check.py
+++ b/scripts/bulk_source_check.py
@@ -231,13 +231,24 @@ def _apply_encoding_to_enrich(r: dict, row: pd.Series, base: dict) -> dict:
 
 
 def _enrich_ckan(row: pd.Series, base: dict, client: HttpClient | None = None) -> dict | None:
-    """Re-fetch package_show se inventory non ha format E title."""
+    """Re-fetch package_show se inventory non ha format, title o URL risorsa."""
     if base["protocol"] != "ckan" or not base["base_url"] or not base["item_name"]:
         return None
     if not base["has_valid_slug"]:
         return None
-    if base["inv_format_has_valid"] and base["inv_title"]:
+    # L'inventory può avere format e title ma resource URL vuoto (es. CKAN
+    # via dati.gov.it package_search che non estrae il URL diretto).
+    # In tal caso serve package_show per recuperare il link al file CSV/XLS.
+    # Nota: distribution_url può essere RDF/XML, non il file dati — usiamo
+    # solo row.url (resource URL diretto) per decidere se serve re-fetch.
+    # Skip re-fetch per formati non previewabili (ZIP, PDF, RDF) —
+    # la package_show aggiungerla solo metadata, non URL utili.
+    if base["inv_format_has_valid"] and base["inv_title"] and row.get("url"):
         return None  # inventory già ricco — skip re-fetch
+    _previewable = {"CSV", "TSV", "XLSX", "XLS", "JSON"}
+    _inv_fmt = (base.get("inv_format") or "").upper()
+    if not any(f in _inv_fmt for f in _previewable):
+        return None  # formato non previewabile — skip re-fetch
 
     api_base_url = row.get("api_base_url")
     base_api = (
@@ -245,8 +256,9 @@ def _enrich_ckan(row: pd.Series, base: dict, client: HttpClient | None = None) -
         if isinstance(api_base_url, str) and api_base_url.startswith("http")
         else base["base_url"]
     )
-    parsed = urllib.parse.urlparse(base_api)
-    portal_url = f"{parsed.scheme}://{parsed.netloc}"
+    # Estrai il base path del portale CKAN (es.
+    # https://dati.gov.it/opendata/api/3/action/package_list → https://dati.gov.it/opendata)
+    portal_url = base_api.split("/api/")[0] if "/api/" in base_api else base_api
     pkg = _toolkit_ckan_package(portal_url, base["item_name"], client=client)
     if pkg:
         return _parse_ckan_package(pkg)

--- a/scripts/source_check_analyze.py
+++ b/scripts/source_check_analyze.py
@@ -230,23 +230,35 @@ def _parse_ckan_package(pkg: dict) -> dict:
     resource_url = None
     resource_format = None
     _FILE_EXTS = (".csv", ".xlsx", ".xls", ".json", ".zip", ".parquet", ".xml")
-    direct_url = None
-    direct_fmt = None
+
+    # Priority 1: risorsa dichiarata CSV (format esplicito, anche se URL
+    # non ha estensione .csv — es. dati.inail.it usa path /csv senza punto)
     for res in resources:
+        fmt = (res.get("format") or "").upper()
         u = res.get("url") or ""
-        if not u.startswith("http"):
-            continue
-        low_url = u.lower()
-        if any(ext in low_url for ext in _FILE_EXTS):
-            direct_url = u
-            direct_fmt = res.get("format") or None
-            break
-        if resource_url is None:
+        if fmt == "CSV" and u.startswith("http"):
             resource_url = u
-            resource_format = res.get("format") or None
-    if direct_url:
-        resource_url = direct_url
-        resource_format = direct_fmt
+            resource_format = fmt
+            break
+    else:
+        # Priority 2: URL con estensione file riconoscibile
+        direct_url = None
+        direct_fmt = None
+        for res in resources:
+            u = res.get("url") or ""
+            if not u.startswith("http"):
+                continue
+            low_url = u.lower()
+            if any(ext in low_url for ext in _FILE_EXTS):
+                direct_url = u
+                direct_fmt = res.get("format") or None
+                break
+            if resource_url is None:
+                resource_url = u
+                resource_format = res.get("format") or None
+        if direct_url:
+            resource_url = direct_url
+            resource_format = direct_fmt
 
     # 3. Estrazione temporale da extras (standard CKAN)
     extras = {e["key"]: e["value"] for e in (pkg.get("extras") or []) if isinstance(e, dict)}

--- a/scripts/source_check_analyze.py
+++ b/scripts/source_check_analyze.py
@@ -231,12 +231,12 @@ def _parse_ckan_package(pkg: dict) -> dict:
     resource_format = None
     _FILE_EXTS = (".csv", ".xlsx", ".xls", ".json", ".zip", ".parquet", ".xml")
 
-    # Priority 1: risorsa dichiarata CSV (format esplicito, anche se URL
-    # non ha estensione .csv — es. dati.inail.it usa path /csv senza punto)
+    # Priority 1: risorsa dichiarata CSV/TSV (format esplicito, anche se URL
+    # non ha estensione .csv/.tsv — es. dati.inail.it usa path /csv senza punto)
     for res in resources:
         fmt = (res.get("format") or "").upper()
         u = res.get("url") or ""
-        if fmt == "CSV" and u.startswith("http"):
+        if fmt in ("CSV", "TSV") and u.startswith("http"):
             resource_url = u
             resource_format = fmt
             break

--- a/scripts/source_check_fetch.py
+++ b/scripts/source_check_fetch.py
@@ -49,6 +49,11 @@ _DEFAULT_HTTP_TIMEOUT: tuple[int, int] = (5, 10)
 _DEFAULT_HTTP_RETRIES = 2
 _DEFAULT_CIRCUIT_THRESHOLD = 3
 
+# Preview client condiviso: timeout più generoso, SENZA circuit breaker.
+# I timeout su Range GET (file grossi, server lenti) sono normali.
+# Creato al primo uso, riusato per tutte le preview nello stesso processo.
+_preview_client: HttpClient | None = None
+
 SDMX_NS = {
     "message": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message",
     "structure": "http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure",
@@ -115,6 +120,14 @@ def configure_source_check_http(
 # ``_circuit_after_result``, ``_tracked_http_head`` e ``_tracked_http_get``
 # sono state rimosse — usare ``client.head()`` / ``client.get()`` direttamente.
 # ═══════════════════════════════════════════════════════════════════════════════
+
+
+def close_preview_client() -> None:
+    """Chiude il preview client condiviso, se aperto."""
+    global _preview_client
+    if _preview_client is not None:
+        _preview_client.close()
+        _preview_client = None
 
 
 # ── Probe principale (usato da bulk_source_check) ────────────────────────────
@@ -301,6 +314,13 @@ def _fetch_data_preview(
 
     Delega a ``toolkit.profile.preview.preview_url`` che fa HEAD → Range GET
     → sniff → DuckDB profile → infer in un colpo solo.
+
+    NOTA: Quando ``client`` ha ``circuit_threshold > 0`` (default 3) e viene
+    passato, la preview crea comunque un HttpClient dedicato SENZA circuit
+    breaker. I timeout su Range GET (file grossi, server lenti) sono normali
+    e non indicano host down. Per evitare che il CB blocchi le preview dopo
+    pochi timeout, verifica ``client._circuit_threshold`` e seleziona un
+    client appropriato.
     """
     import json as _json
 
@@ -311,9 +331,28 @@ def _fetch_data_preview(
 
     from toolkit.profile.preview import preview_url
 
+    # Preview client condiviso (modulo): timeout più generoso e SENZA circuit
+    # breaker. I timeout su Range GET (file grossi, server lenti) sono normali
+    # e non indicano host down. Il client è creato una volta e riusato per
+    # tutte le preview nello stesso processo (connection pooling).
+    global _preview_client
+    if _preview_client is None:
+        from lab_connectors.http.client import HttpClient as _HC
+
+        base_timeout = client.timeout if client else (5, 10)
+        if isinstance(base_timeout, (int, float)):
+            preview_timeout = (int(base_timeout), int(base_timeout * 3))
+        else:
+            preview_timeout = (base_timeout[0], max(base_timeout[1], 30))
+        _preview_client = _HC(
+            timeout=preview_timeout,
+            max_retries=1,
+            circuit_threshold=0,
+        )
+
     p = preview_url(
         url,
-        client=client,
+        client=_preview_client,
         known_encoding=known_encoding,
         known_delim=known_delim,
         known_decimal=known_decimal,

--- a/tests/test_bulk_source_check.py
+++ b/tests/test_bulk_source_check.py
@@ -299,8 +299,8 @@ def test_parse_ckan_package_prefers_file_url() -> None:
     assert result["resource_format"] == "CSV"
 
 
-def test_parse_ckan_package_fallback_first_http_url() -> None:
-    """Without file extensions, must fallback to first HTTP URL."""
+def test_parse_ckan_package_prefers_declared_csv_over_first_http() -> None:
+    """CSV format esplicito senza .csv nell'URL deve prevalere sul primo HTTP."""
     from source_check_analyze import _parse_ckan_package
 
     pkg = {
@@ -310,7 +310,22 @@ def test_parse_ckan_package_fallback_first_http_url() -> None:
         ]
     }
     result = _parse_ckan_package(pkg)
-    assert result["resource_url"] == "https://portal.it/api/action?id=123"
+    assert result["resource_url"] == "https://portal.it/download/file"
+    assert result["resource_format"] == "CSV"
+
+
+def test_parse_ckan_package_fallback_no_previewable_format() -> None:
+    """Nessun formato previewabile, nessuna estensione → fallback primo HTTP."""
+    from source_check_analyze import _parse_ckan_package
+
+    pkg = {
+        "resources": [
+            {"url": "https://portal.it/api/page", "format": "html"},
+            {"url": "/local/rdf.xml", "format": "RDF"},
+        ]
+    }
+    result = _parse_ckan_package(pkg)
+    assert result["resource_url"] == "https://portal.it/api/page"
 
 
 # ── XLS falso: TSV/Latin-1 fallback ─────────────────────────────────────


### PR DESCRIPTION
## Problema reale

Le preview CSV venivano tentate solo per una frazione degli item che dichiarano formato CSV nell'inventory. Per `inail_opendata`: 20/102, invece di 63/63.

Tre cause cumulative, tutte necessarie per il risultato:

### 1. `_enrich_ckan`: portal_url troncava path prefix API

```python
# prima:
parsed = urllib.parse.urlparse(base_api)  # https://dati.gov.it/opendata/...
portal_url = f"{parsed.scheme}://{parsed.netloc}"  # https://dati.gov.it (!)
```

`package_show` chiamato su `dati.gov.it` (404) invece di `dati.gov.it/opendata` (200). L'enrichment falliva e restituiva `inventory_only` senza resource URL.

**Fix**: estrarre `portal_url` con path prefix via `split('/api/')`.

### 2. `_parse_ckan_package`: preferiva estensione `.csv` nell'URL

IN\\.IL usa URL tipo `.../downloads/dataset/csv` (senza `.csv`). Il pattern `any(ext in low_url for ext in _FILE_EXTS)` non matchava. La prima risorsa del package (RDF/XML) veniva scelta invece di CSV.

**Fix**: priorità a formato dichiarato `CSV`, poi estensione URL come fallback.

### 3. `_fetch_data_preview`: ereditava circuit breaker del probe

Il client HTTP condiviso aveva `circuit_threshold=3`. Dopo 3 timeout su Range GET (file grossi/server lenti su `dati.inail.it`), il circuito si apriva e tutte le preview successive venivano saltate.

**Fix**: preview client condiviso a livello di modulo, SENZA circuit breaker, con timeout read 30s e connection pooling.

## Verifica

| Fonte | Prima | Dopo |
|---|---|---|
| `inail_opendata` | 20/102 | 63/63 ✅ |
| `pagopa` | (non testato) | 11/11 ✅ |

```
python scripts/run_source.py inail_opendata
Preview CSV: 63/102
Raggiungibili: 102/102 (100.0%)
TOTALE 46.2s
```

## Test

```
pytest tests/test_run_source.py -v  # 4 passed
```

## Rischio residuo

- `_enrich_ckan` ora fa `package_show` per ogni item CKAN senza `row.url` (inventory incompleto). Per `inail_opendata` sono 102 richieste extra. Tempo totale: 19s → 46s. Accettabile per la completezza.
- Il preview client condiviso (`_preview_client`) non viene chiuso automaticamente. Serve `close_preview_client()` esplicito dopo la run.

## Seguito

- Valutare se il preview client va chiuso automaticamente in `run_source.py` alla fine della run.
- Per fonti con inventory già ricco di URL (es. HTML collector), `_enrich_ckan` non fa re-fetch — comportamento invariato.