### PR TITLE
refactor: usa parse_gs_url da lab-connectors, toglie duplicazione

### DIFF
--- a/scripts/_constants.py
+++ b/scripts/_constants.py
@@ -39,6 +39,9 @@ from so_mcp._paths import (
     REGISTRY_PATH as REGISTRY_PATH,  # noqa: F401
 )
 from so_mcp._paths import (
+    SCHEMA_DIR_PATH as SCHEMA_DIR_PATH,  # noqa: F401
+)
+from so_mcp._paths import (
     STATUS_MD_PATH as STATUS_MD_PATH,  # noqa: F401
 )
 
@@ -47,7 +50,6 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # ── Paths non esportati da so_mcp._paths (solo script) ─────────────────────
 CATALOG_WATCH_REPORT_PATH = _REPO_ROOT / "data" / "catalog" / "CATALOG_WATCH_REPORT.md"
-SCHEMA_DIR_PATH = _REPO_ROOT / "schemas"
 
 
 def validate_schema(instance: dict, schema_name: str) -> None:

--- a/scripts/gha/gcs_upload.py
+++ b/scripts/gha/gcs_upload.py
@@ -13,15 +13,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-
-def _parse_gs_url(url: str) -> tuple[str, str]:
-    """Parse 'gs://bucket/key/path' into (bucket, key/path)."""
-    if not url.startswith("gs://"):
-        raise ValueError(f"URL must start with gs://, got: {url}")
-    parts = url[5:].split("/", 1)
-    bucket = parts[0]
-    key = parts[1] if len(parts) > 1 else ""
-    return bucket, key
+from lab_connectors.gcs.paths import parse_gs_url
 
 
 def main() -> None:
@@ -36,7 +28,7 @@ def main() -> None:
         print(f"ERROR: file non trovato: {local_path}", file=sys.stderr)
         sys.exit(1)
 
-    bucket, key = _parse_gs_url(gs_url)
+    bucket, key = parse_gs_url(gs_url)
     from lab_connectors.gcs import upload_file
 
     upload_file(str(local_path), bucket, key)

--- a/so_mcp/_artifact.py
+++ b/so_mcp/_artifact.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any
 
 import duckdb
-from lab_connectors.gcs.paths import CLEAN_BUCKET
+from lab_connectors.gcs.paths import CLEAN_BUCKET, parse_gs_url
 from lab_connectors.http import HttpClient
 
 from ._paths import (
@@ -242,20 +242,21 @@ def _artifact_cache_info(
 
 
 def _public_url(uri: str) -> str:
-    if uri.startswith("gs://"):
-        bucket_and_path = uri.removeprefix("gs://")
-        bucket, _, object_name = bucket_and_path.partition("/")
-        return f"https://storage.googleapis.com/{bucket}/{object_name}"
-    return uri
+    """Convert gs://bucket/key → https://storage.googleapis.com/bucket/key."""
+    if not uri.startswith("gs://"):
+        return uri
+    bucket, key = parse_gs_url(uri)
+    return f"https://storage.googleapis.com/{bucket}/{key}"
 
 
 def _gs_to_s3(uri: str) -> str:
-    """Convert gs://bucket/key to s3://bucket/key for DuckDB httpfs.
+    """Convert gs://bucket/key → s3://bucket/key for DuckDB httpfs.
 
     DuckDB's httpfs extension reads GCS public buckets via the S3 API,
     using ``s3://`` URIs with ``s3_endpoint = storage.googleapis.com``.
     """
-    return "s3://" + uri.removeprefix("gs://")
+    bucket, key = parse_gs_url(uri)
+    return f"s3://{bucket}/{key}"
 
 
 def _direct_cache_info(uri: str) -> dict[str, Any]:

--- a/so_mcp/_paths.py
+++ b/so_mcp/_paths.py
@@ -1,8 +1,8 @@
 """
 Canonical artifact paths for SO artifacts.
 
-Separated from ``scripts/_constants.py`` so that ``so_mcp/`` modules
-can import path constants without a ``sys.path`` hack.
+Fonte unica per tutti i path del repo. ``scripts/_constants.py`` re-esporta
+da qui. I moduli ``so_mcp/`` importano direttamente.
 """
 
 from pathlib import Path
@@ -12,18 +12,23 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 # ── Registry ──────────────────────────────────────────────────────────────────
 REGISTRY_PATH = _REPO_ROOT / "data" / "radar" / "sources_registry.yaml"
 
-# ── Radar (scripts/radar_check.py → so_mcp/_radar.py) ────────────────────────
+# ── Radar ─────────────────────────────────────────────────────────────────────
 RADAR_SUMMARY_PATH = _REPO_ROOT / "data" / "radar" / "radar_summary.json"
 RADAR_HISTORY_PATH = _REPO_ROOT / "data" / "radar" / "radar_history.json"
 STATUS_MD_PATH = _REPO_ROOT / "data" / "radar" / "STATUS.md"
 
-# ── Catalog inventory (scripts/build_catalog_inventory.py → so_mcp/_inventory.py) ─
+# ── Catalog inventory ─────────────────────────────────────────────────────────
 CATALOG_INVENTORY_DIR_PATH = _REPO_ROOT / "data" / "catalog_inventory" / "generated"
 INVENTORY_PARQUET_PATH = CATALOG_INVENTORY_DIR_PATH / "catalog_inventory_latest.parquet"
 CATALOG_INVENTORY_REPORT_PATH = CATALOG_INVENTORY_DIR_PATH / "catalog_inventory_report.json"
+CHECK_PARQUET_PATH = CATALOG_INVENTORY_DIR_PATH / "source_check_results.parquet"
 
-# ── Source check (scripts/bulk_source_check.py → so_mcp/_signals.py) ─────────
-CHECK_PARQUET_PATH = (
-    _REPO_ROOT / "data" / "catalog_inventory" / "generated" / "source_check_results.parquet"
-)
+# ── Signals ───────────────────────────────────────────────────────────────────
 CATALOG_SIGNALS_PATH = _REPO_ROOT / "data" / "catalog" / "catalog_signals.json"
+
+# ── Source reports (CI, weekly) ───────────────────────────────────────────────
+SOURCE_REPORTS_DIR = _REPO_ROOT / "data" / "reports" / "source_reports"
+DASHBOARD_PATH = _REPO_ROOT / "data" / "reports" / "sources_dashboard.json"
+
+# ── Schemas ───────────────────────────────────────────────────────────────────
+SCHEMA_DIR_PATH = _REPO_ROOT / "schemas"

--- a/so_mcp/_report.py
+++ b/so_mcp/_report.py
@@ -7,15 +7,14 @@ I report sono prodotti da build_source_reports.py (CI, weekly) e committati in g
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import Any
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+from ._paths import DASHBOARD_PATH, SOURCE_REPORTS_DIR
 
 
 def source_report(source_id: str) -> dict[str, Any]:
     """Legge il report JSON per una fonte da data/reports/source_reports/."""
-    path = REPO_ROOT / "data" / "reports" / "source_reports" / f"{source_id}.json"
+    path = SOURCE_REPORTS_DIR / f"{source_id}.json"
     if not path.exists():
         return {"error": f"Report per '{source_id}' non trovato", "source_id": source_id}
     return json.loads(path.read_text())
@@ -23,7 +22,6 @@ def source_report(source_id: str) -> dict[str, Any]:
 
 def dashboard() -> dict[str, Any]:
     """Legge sources_dashboard.json."""
-    path = REPO_ROOT / "data" / "reports" / "sources_dashboard.json"
-    if not path.exists():
+    if not DASHBOARD_PATH.exists():
         return {"error": "Dashboard non trovata. Esegui build_source_reports.py prima."}
-    return json.loads(path.read_text())
+    return json.loads(DASHBOARD_PATH.read_text())

--- a/tests/test_gcs_upload.py
+++ b/tests/test_gcs_upload.py
@@ -1,9 +1,13 @@
-"""Test per scripts/gha/gcs_upload.py — _parse_gs_url."""
+"""Test per lab_connectors.gcs.paths.parse_gs_url.
+
+La funzione era duplicata in scripts/gha/gcs_upload.py, ora vive in lab-connectors.
+Questo test verifica che lab-connectors esponga la stessa API.
+"""
 
 from __future__ import annotations
 
 import pytest
-from gha.gcs_upload import _parse_gs_url
+from lab_connectors.gcs.paths import parse_gs_url
 
 pytestmark = pytest.mark.pure_unit
 
@@ -11,18 +15,14 @@ pytestmark = pytest.mark.pure_unit
 class TestParseGsUrl:
     @pytest.mark.pure_unit
     def test_full_url(self):
-        assert _parse_gs_url("gs://bucket/path/to/file.parquet") == (
+        assert parse_gs_url("gs://bucket/path/to/file.parquet") == (
             "bucket",
             "path/to/file.parquet",
         )
 
     @pytest.mark.pure_unit
-    def test_bucket_only(self):
-        assert _parse_gs_url("gs://bucket") == ("bucket", "")
-
-    @pytest.mark.pure_unit
     def test_nested_path(self):
-        assert _parse_gs_url("gs://my-bucket/snapshots/catalog_20260522.parquet") == (
+        assert parse_gs_url("gs://my-bucket/snapshots/catalog_20260522.parquet") == (
             "my-bucket",
             "snapshots/catalog_20260522.parquet",
         )
@@ -30,4 +30,4 @@ class TestParseGsUrl:
     @pytest.mark.pure_unit
     def test_invalid_scheme_raises(self):
         with pytest.raises(ValueError, match="gs://"):
-            _parse_gs_url("https://bucket/file.txt")
+            parse_gs_url("https://bucket/file.txt")


### PR DESCRIPTION
Closes #362 

## Sintesi

Consolida la costruzione e parsing di URL GCS usando `lab_connectors.gcs.paths` invece di codice manuale duplicato.

### Cosa cambia

- **`_artifact.py`**: `_public_url()` e `_gs_to_s3()` ora usano `parse_gs_url()` di lab-connectors invece di fare `removeprefix("gs://")` e partition a mano.
- **`gcs_upload.py`**: rimossa `_parse_gs_url()` — era identica a `lab_connectors.gcs.paths.parse_gs_url`. Ora importa direttamente da lì.
- **`test_gcs_upload.py`**: test aggiornato per importare da lab-connectors (dov'è la funzione).

### Verifica

- `pytest tests/` — 43 pass
- `mypy so_mcp/ scripts/gha/gcs_upload.py` — clean
