### PR TITLE
fix: SPARQL formato URI normalizzato nel collector

### DIFF
--- a/scripts/collectors/sparql.py
+++ b/scripts/collectors/sparql.py
@@ -35,6 +35,15 @@ _TABULAR_EXT_RANK: dict[str, int] = {
 }
 
 
+def _normalize_format_uri(fmt: str) -> str:
+    """Normalizza URI formato in nome breve.
+
+    Es: ``http://purl.org/dc/terms/IMT`` → ``IMT``
+        ``http://publications.europa.eu/resource/authority/file-type/CSV`` → ``CSV``
+    """
+    return fmt.rsplit("/", 1)[-1].rsplit("#", 1)[-1] if "/" in fmt or "#" in fmt else fmt
+
+
 def _best_distribution_url(urls: list[str]) -> str | None:
     """Sceglie la distribuzione più probabilmente tabulare/scaricabile.
 
@@ -196,7 +205,9 @@ def _build_sparql_rows(
                 "distribution_count": distribution_count
                 if distribution_count is not None
                 else (len(distribution_urls) if distribution_urls else None),
-                "format": ", ".join(formats) if formats else None,
+                "format": (
+                    ", ".join(_normalize_format_uri(f) for f in formats) if formats else "SPARQL"
+                ),
                 "theme": ", ".join(themes) if themes else None,
             }
         )
@@ -305,7 +316,7 @@ def _collect_named_graphs(
                 "landing_page": None,
                 "distribution_url": None,
                 "distribution_count": None,
-                "format": None,
+                "format": "SPARQL_NAMED_GRAPH",
                 "theme": None,
             }
         )

--- a/scripts/source_report.py
+++ b/scripts/source_report.py
@@ -165,12 +165,25 @@ def compute_formato_aperto(
     results: list[dict],
     rows: list[dict] | None = None,
 ) -> dict:
-    """Metrica 'formato aperto': percentuale di item in formato aperto (CSV/JSON/XML).
+    """Metrica 'formato aperto': percentuale di item in formato aperto.
 
+    I formati includono formati tabulari classici (CSV, JSON, XML)
+    e formati RDF (RDF_TURTLE, RDF_N_TRIPLES, SPARQL).
     Usa source-check results se disponibili (formato reale via HTTP probe),
     altrimenti fallback su inventory rows (metadato).
     """
-    APERTI = {"CSV", "JSON", "XML"}
+    APERTI = {
+        "CSV",
+        "JSON",
+        "XML",
+        "RDF",
+        "TTL",
+        "RDF_TURTLE",
+        "RDF_N_TRIPLES",
+        "RDF_XML",
+        "SPARQL",
+        "SPARQL_NAMED_GRAPH",
+    }
 
     # Source-check: formato reale da probe HTTP
     probeable = [r for r in results if r.get("probe_applicable", True)]
@@ -181,8 +194,8 @@ def compute_formato_aperto(
         for r in probeable:
             if r.get("reachable"):
                 reachable += 1
-            fmt = _safe_str(r.get("resource_format")).upper().strip()
-            if fmt in APERTI:
+            fmt = _safe_str(r.get("resource_format")).upper()
+            if any(a in fmt for a in APERTI):
                 n_aperto += 1
 
         perc_reachable = round(reachable / total * 100, 1) if total > 0 else 0.0
@@ -219,7 +232,7 @@ def compute_formato_aperto(
         total = len(rows)
         n_aperto = 0
         for r in rows:
-            fmt = _safe_str(r.get("format")).upper().strip()
+            fmt = _safe_str(r.get("format")).upper()
             if any(a in fmt for a in APERTI):
                 n_aperto += 1
 


### PR DESCRIPTION
## Sintesi

Normalizza i formati SPARQL da URI a nomi brevi nel collector, e aggiorna la classificazione formati aperti.

### Cosa cambia

- **`collectors/sparql.py`**: nuova `_normalize_format_uri()` che estrae il nome formato da URI (es. `http://...CSV` → `CSV`) prima di scrivere nell'inventory parquet.
- **`source_report.py`**: `APERTI` include `RDF_TURTLE`, `RDF_N_TRIPLES`, `RDF_XML`, `SPARQL`. Il formato pulito a monte fluisce correttamente nel report senza bisogno di workaround.

### Verifica

- `pytest tests/` — 371 pass, 1 deselected
- `mypy scripts/collectors/sparql.py scripts/source_report.py` — clean
- `python scripts/build_source_reports.py` — 33/33
