### PR TITLE
feat: aggiunta ART (Autorità Trasporti) al registry

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -791,6 +791,30 @@ pagopa:
     per ambito, geografia comuni, numero notifiche). Dati su digitalizzazione pagamenti
     PA e adozione piattaforme digitali (IO, SEND).'
   datasets_in_use: []
+art_opendata:
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
+  inventory:
+    fq: organization:autorita-di-regolazione-dei-trasporti
+    timeout: 180
+  last_probed: '2026-07-16'
+  catalog_baseline:
+    captured_at: '2026-07-16'
+    metric: package_count
+    value: 32
+    method: package_search
+    reliability: high
+    note: 'Conteggio via package_search con fq=organization:autorita-di-regolazione-dei-trasporti
+      su dati.gov.it. 32 dataset su trasporti (taxi/NCC, ferrovie, autostrade, aeroporti).'
+  verdict: go
+  note: 'Fonte via dati.gov.it (ART). 32 dataset CSV su trasporto ferroviario regionale
+    (ritardi, soppressioni, ricavi), taxi/NCC per comune (licenze, tariffe, importi
+    fissi 2002-2024), autostrade (traffico, pedaggi, manutenzioni, sicurezza), aeroporti,
+    interporti, trasporto marittimo. CC BY 4.0. CSV su bdt.autorita-trasporti.it.
+    Incrociabile con MIT incidentalità e ACI parco veicolare.'
+  datasets_in_use: []
 aci:
   source_kind: catalog
   protocol: ckan


### PR DESCRIPTION
## Sintesi

Aggiunta di `art_opendata` al registry SO — Autorità di Regolazione dei Trasporti, 32 dataset su dati.gov.it.

## Contesto collegato

Scouting completato: ART ha 32 dataset CSV (CC BY 4.0) su trasporto ferroviario regionale, taxi/NCC per comune, autostrade, aeroporti, interporti. File accessibili via bdt.autorita-trasporti.it senza WAF.

Vedi report completo in `_local/notes/current/2026-07-16_scouting_org_dati_gov.md`.

## Cosa cambia

- [x] Nuova fonte o modifica registro (sources_registry.yaml)
- [ ] Source-check o inventory-triage
- [ ] Modifica script (radar, inventory, source-check, MCP)
- [ ] Modifica funnel o criteri di osservazione
- [ ] Workflow CI (radar.yml, observatory.yml)
- [ ] Skills o MCP tools
- [ ] Documentazione
- [ ] Altro

## Checklist

### Se tocchi sources_registry.yaml

- [x] `radar_check.py` gestisce la nuova fonte senza errori
- [x] `observation_mode` impostato correttamente (catalog-watch)
- [x] Eventuali nuovi protocolli testati manualmente

## Verifica

24 righe aggiunte, struttura identica ad altre fonti CKAN via dati.gov.it (es. ANAC, AGCM, ACI) con `fq: organization:autorita-di-regolazione-dei-trasporti`.

## Note per chi revisiona

Dopo merge, apriremo 3 issue intake in dataset-incubator per:
- art_tariffe_taxi_corsa (D34, comune, 2008-2024)
- art_importi_fissi_taxi (D33, comune, 2002-2024)
- art_diffusione_taxi_ncc (D32, comune, 2024 snapshot)