### PR TITLE
feat: aggiunta ADM (Agenzia Dogane e Monopoli) al registry

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -839,3 +839,27 @@ aci:
     demolizione. CSV su lod.aci.it in formato tidy. Incrociabile con MIT incidentalità.'
   datasets_in_use:
     - aci_prime_iscrizioni_autovetture
+adm_opendata:
+  source_kind: catalog
+  protocol: ckan
+  observation_mode: catalog-watch
+  base_url: https://dati.gov.it/opendata/api/3/action/package_list?limit=1
+  inventory:
+    fq: organization:agenzia-delle-dogane-e-dei-monopoli
+    timeout: 180
+  last_probed: '2026-07-16'
+  catalog_baseline:
+    captured_at: '2026-07-16'
+    metric: package_count
+    value: 31
+    method: package_search
+    reliability: high
+    note: 'Conteggio via package_search con fq=organization:agenzia-delle-dogane-e-dei-monopoli
+      su dati.gov.it. 31 dataset su giochi, tabacchi, accise, personale.'
+  verdict: go
+  note: 'Fonte via dati.gov.it (ADM). 31 dataset CSV su vigilanza giochi (scommesse,
+    lotto, bingo, online, apparecchi), fiscalità giochi (raccolta, vincite, spesa),
+    conti gioco attivi per regione/età/genere, vendite tabacchi, rete vendita, accise
+    (energetici, gas, elettricità, alcolici), personale ADM. Copertura 2022-2023,
+    granularità regionale. CSV su dati.gov.it. FOIA #16 aperta per catalogo completo.'
+  datasets_in_use: []


### PR DESCRIPTION
## Sintesi

Aggiunta di `adm_opendata` al registry SO — Agenzia delle Dogane e dei Monopoli, 31 dataset su dati.gov.it.

## Contesto collegato

Scouting completato: ADM pubblica 31 dataset CSV su dati.gov.it (giochi, tabacchi, accise, personale). Copertura 2022-2023, granularità regionale. 

FOIA #16 aperta su data-advocacy per catalogo completo — ADM non ha portale proprio e pubblica molto poco rispetto alla mole di dati che dovrebbe detenere.

## Cosa cambia

- [x] Nuova fonte o modifica registro (sources_registry.yaml)

## Checklist

### Se tocchi sources_registry.yaml

- [x] `radar_check.py` gestisce la nuova fonte senza errori
- [x] `observation_mode` impostato correttamente (catalog-watch)
- [x] Eventuali nuovi protocolli testati manualmente

## Verifica

24 righe aggiunte, struttura identica ad altre fonti CKAN via dati.gov.it con `fq: organization:agenzia-delle-dogane-e-dei-monopoli`.