### PR TITLE
fix(inps): aggiorna al nuovo portale Open Data INPS (opendata.inps.it)

### DIFF
--- a/data/radar/sources_registry.yaml
+++ b/data/radar/sources_registry.yaml
@@ -60,22 +60,17 @@ inps:
   source_kind: catalog
   protocol: ckan
   observation_mode: catalog-watch
-  base_url: https://serviziweb2.inps.it/odapi/package_list?limit=1
+  base_url: https://opendata.inps.it/opendata/api/3/action/package_list?limit=1
   inventory:
     timeout: 180
-    package_show_sample: true
-    package_show_timeout: 5
-    sample_size: 10000
   last_probed: '2026-07-27'
   catalog_baseline:
-    captured_at: '2026-04-02'
+    captured_at: '2026-07-18'
     metric: package_count
-    value: 2323
-    method: package_list
+    value: 2499
+    method: package_search
     reliability: high
-    note: Inventory via package_list + package_show_sample (16 workers). 
-      current_package_list_with_resources testato ma scartato per lentezza a 
-      offset alti. package_show_sample più veloce.
+    note: NUOVO portale opendata.inps.it. Sostituisce il vecchio serviziweb2.inps.it/odapi/
   verdict: go
   note: Catalogo CKAN INPS — inventory via package_list + package_show_sample 
     (current_package_list_with_resources lento a offset alti).


### PR DESCRIPTION
## Cosa cambia

Aggiorna la fonte `inps` nel Source Observatory per puntare al **nuovo portale Open Data INPS** (`opendata.inps.it`) che ha sostituito il vecchio CKAN su `serviziweb2.inps.it`.

### Modifiche a `data/radar/sources_registry.yaml`

| Campo | Prima | Dopo |
|---|---|---|
| `base_url` | `serviziweb2.inps.it/odapi/...` | `opendata.inps.it/opendata/api/...` |
| `catalog_baseline.value` | 2.323 dataset | **2.499 dataset** |
| `catalog_baseline.method` | `package_list` | `package_search` |
| `inventory` | `package_show_sample: true` (lento) | rimosso |
| `note` | descriveva il vecchio portale | descrive il nuovo portale |

### Perché

- Il vecchio CKAN (`serviziweb2.inps.it/odapi/`) **non viene più aggiornato** — dati fermi al 2020, solo 4.9% dei dataset raggiungibile
- Il nuovo portale (`opendata.inps.it/opendata/`) è un **CKAN 2.9.4** con 2.499 dataset, catalogo DCAT-AP_IT, stack SDMX ISTAT riusato
- Dati freschi fino al 2024 (bilanci), 2023 (CIG/RDC), 2022 (imprese)
- `package_show` è lentissimo sul nuovo portale: ho rimosso `package_show_sample` che lo usava

### Note

- I due dataset già in use (`inps_pensioni_trimestrale`, `pensioni_pa_dag`) non provengono dal CKAN, quindi non impattati
- Il Data Browser SDMX (`opendata.inps.it/databrowser/`) è protetto (401), ma accessibile via POST senza auth per dataflow specifici
- Issue collegate: `dataset-incubator#674` (Imprese per Provincia), `dataset-incubator#675` (Precariato)
