### PR TITLE
fix(so): catalogo SDMX con detail=allstubs e timeout radar dedicato

### DIFF
--- a/scripts/collectors/sdmx.py
+++ b/scripts/collectors/sdmx.py
@@ -25,10 +25,29 @@ def _sdmx_api_base(url: str) -> str | None:
     return base
 
 
+def catalog_fetch_url(url: str) -> str:
+    """Aggiunge ``detail=allstubs`` alla URL del catalogo SDMX se assente.
+
+    Il catalogo completo (es. ``dataflow/IT1``) serializza migliaia di
+    dataflow in una singola risposta e può andare in timeout (ISTAT ~80s
+    anche in modalità ridotta). ``detail=allstubs`` riduce il payload a
+    id + nome — sufficiente per l'inventory, che usa solo id, agencyID
+    e Name.
+    """
+    if not url:
+        return url
+    base = url.split("#")[0]
+    if "detail=" in base:
+        return base
+    sep = "&" if "?" in base else "?"
+    return f"{base}{sep}detail=allstubs"
+
+
 def collect(source_id: str, source_cfg: dict[str, Any], captured_at: str) -> CollectorResult:
     endpoint = source_cfg["base_url"]
+    fetch_url = catalog_fetch_url(endpoint)
     client = HttpClient(timeout=330, max_retries=1)
-    result = client.get(endpoint)
+    result = client.get(fetch_url)
 
     if result.is_error:
         raise RuntimeError(

--- a/scripts/radar_check.py
+++ b/scripts/radar_check.py
@@ -25,9 +25,13 @@ from scripts._constants import (
     save_registry,
     validate_schema,
 )
+from scripts.collectors.sdmx import catalog_fetch_url
 
 USER_AGENT = "DataCivicLab-SourceObservatory/1.0"
 TIMEOUT_SECONDS = 10
+# SDMX: i cataloghi serializzano migliaia di dataflow in una risposta unica
+# (es. ISTAT ~80s anche con detail=allstubs) → timeout dedicato più alto.
+SDMX_TIMEOUT_SECONDS = 180
 
 
 @dataclass
@@ -135,9 +139,9 @@ def _build_probe_result(
     )
 
 
-def _probe_once(base_url: str) -> ProbeResult:
+def _probe_once(base_url: str, timeout: int = TIMEOUT_SECONDS) -> ProbeResult:
     """Single probe attempt (no retry). Uses lab_connectors HttpClient with SSL fallback."""
-    client = HttpClient(timeout=TIMEOUT_SECONDS, user_agent=USER_AGENT)
+    client = HttpClient(timeout=timeout, user_agent=USER_AGENT)
     result = client.get(
         base_url,
         allow_redirects=True,
@@ -213,8 +217,11 @@ def probe_url(base_url: str) -> ProbeResult:
             )
         return result
 
-    # SDMX: HttpClient handles retry with backoff internally
-    return _probe_once(base_url)
+    # SDMX: catalogo lento (ISTAT ~80s anche con detail=allstubs).
+    # Timeout dedicato + payload ridotto per evitare ReadTimeout su cataloghi
+    # che serializzano migliaia di dataflow in una risposta unica.
+    sdmx_fetch_url = catalog_fetch_url(base_url)
+    return _probe_once(sdmx_fetch_url, timeout=SDMX_TIMEOUT_SECONDS)
 
 
 def build_status_report(

--- a/tests/test_radar_check.py
+++ b/tests/test_radar_check.py
@@ -160,6 +160,32 @@ class TestProbe:
         assert result.ssl_fallback_used is True
         assert "SSL verify failed" in (result.note or "")
 
+    def test_probe_url_sdmx_uses_allstubs_and_dedicated_timeout(self, monkeypatch) -> None:
+        """URL SDMX → fetch con ?detail=allstubs e timeout dedicato (180s).
+
+        Il catalogo SDMX completo (ISTAT) va in timeout con il timeout standard
+        (10s): la fetch deve usare detail=allstubs e SDMX_TIMEOUT_SECONDS.
+        """
+        fake = FakeHttpClient()
+        sdmx_url = "https://sdmx.test/dataflow/IT1"
+        fake.responses[sdmx_url + "?detail=allstubs"] = HttpResult(
+            response=fake_response(200, text="<ok/>", headers={"content-type": "application/xml"}),
+            err=None,
+            ssl_fallback_used=None,
+        )
+        captured: dict = {}
+
+        def _fake_client(**kw) -> FakeHttpClient:
+            captured.update(kw)
+            return fake
+
+        monkeypatch.setattr(radar_check, "HttpClient", _fake_client)
+        result = radar_check.probe_url(sdmx_url)
+        assert result.status == "GREEN"
+        assert result.http_code == "200"
+        assert captured.get("timeout") == radar_check.SDMX_TIMEOUT_SECONDS
+        assert captured.get("timeout") != radar_check.TIMEOUT_SECONDS
+
 
 class TestBuildReport:
     def test_build_status_report_basic(self) -> None:

--- a/tests/test_sdmx_collector.py
+++ b/tests/test_sdmx_collector.py
@@ -66,6 +66,32 @@ def test_api_base_with_query_string():
     assert result == "https://example.test/sdmx"
 
 
+# ─── catalog_fetch_url (detail=allstubs) ─────────────────────────────────────
+
+
+def test_catalog_fetch_url_empty():
+    """URL vuota → invariata."""
+    assert sdmx_collector.catalog_fetch_url("") == ""
+
+
+def test_catalog_fetch_url_no_query():
+    """URL senza query → aggiunge ?detail=allstubs."""
+    url = sdmx_collector.catalog_fetch_url("https://example.test/dataflow/IT1")
+    assert url == "https://example.test/dataflow/IT1?detail=allstubs"
+
+
+def test_catalog_fetch_url_with_query():
+    """URL con query esistente → aggiunge &detail=allstubs."""
+    url = sdmx_collector.catalog_fetch_url("https://example.test/dataflow/IT1?agency=IT1")
+    assert url == "https://example.test/dataflow/IT1?agency=IT1&detail=allstubs"
+
+
+def test_catalog_fetch_url_detail_present():
+    """URL con detail già presente → invariata (non duplica)."""
+    url = sdmx_collector.catalog_fetch_url("https://example.test/dataflow/IT1?detail=full")
+    assert url == "https://example.test/dataflow/IT1?detail=full"
+
+
 # ─── SDMX XML di esempio per collect() ────────────────────────────────────────
 
 _SDMX_XML = """\
@@ -92,7 +118,7 @@ _SDMX_XML = """\
 
 def test_collect(monkeypatch, fake_http):
     """collect() restituisce righe corrette da XML SDMX."""
-    fake_http.responses["https://example.test/dataflow/IT1"] = HttpResult(
+    fake_http.responses["https://example.test/dataflow/IT1?detail=allstubs"] = HttpResult(
         response=fake_response(200, _SDMX_XML, headers={"content-type": "application/xml"}),
         err=None,
     )
@@ -133,7 +159,7 @@ def test_collect(monkeypatch, fake_http):
 
 def test_collect_http_error(monkeypatch, fake_http):
     """collect() su errore HTTP → raise RuntimeError."""
-    fake_http.responses["https://example.test/dataflow/IT1"] = HttpResult(
+    fake_http.responses["https://example.test/dataflow/IT1?detail=allstubs"] = HttpResult(
         response=fake_response(500, "Internal Server Error"),
         err=None,
     )


### PR DESCRIPTION
## Sintesi

Il catalogo SDMX completo di ISTAT (`dataflow/IT1`) serializza ~4.900 dataflow in una risposta unica (~60-80s anche in modalità ridotta). Questo causava due problemi:

- **radar**: `TIMEOUT_SECONDS = 10` → ReadTimeout garantito → `istat_sdmx` sempre YELLOW
- **inventory**: il collector scaricava il catalogo **full** (payload pesante, vicino al limite dei 330s del client)

Fix: fetch del catalogo con `detail=allstubs` (payload ridotto a id+nome, che è tutto ciò che l'inventory usa) + timeout radar dedicato per SDMX.

## Contesto collegato

Nessuna issue collegata — fix nato da esplorazione tecnica (guida ondata/guida-api-istat): la risposta `allstubs` è verificata compatibile (id, agencyID, Name presenti).

## Cosa cambia

- [ ] Nuova fonte o modifica registro (sources_registry.yaml)
- [ ] Source-check o inventory-triage
- [x] Modifica script (radar, inventory, source-check, MCP)
- [ ] Modifica funnel o criteri di osservazione
- [ ] Workflow CI (radar.yml, observatory.yml)
- [ ] Skills o MCP tools
- [ ] Documentazione
- [ ] Altro

## Checklist

### Se modifichi script o MCP

- [x] `pytest tests/` passa (29 sui file toccati; 66+2 sui moduli consumatori)
- [x] `ruff check .` passa
- [x] `mypy scripts/ so_mcp/` passa (verificato su file toccati)
- [x] Comando manuale verificato (run reale radar + inventory, vedi sotto)

## Verifica

Run reali contro il servizio ISTAT, non fake:

1. **Probe radar**: `probe_url('https://esploradati.istat.it/SDMXWS/rest/dataflow/IT1')` → **GREEN / HTTP 200 in 58s** (prima: YELLOW ReadTimeout)
2. **Radar completo** (`scripts.radar_check`): `istat_sdmx` → **GREEN, http_code 200, note null** (era YELLOW `ReadTimeout`)
3. **Inventory** (`build_catalog_inventory --workers 16 --skip-red-sources`): `istat_sdmx` → **status ok, rows 4899, method dataflow_count**; `api_base_url` pulita (0 URL contaminati da `allstubs`), `distribution_url` corretta

Test aggiunti: 4 test `catalog_fetch_url` (URL vuota / senza query / con query / detail già presente), 1 test ramo SDMX in `probe_url` (verifica timeout 180s e URL con allstubs).

## Note per chi revisiona

- **Nessun cambio di contratto**: `base_url` del registry intatta, stessi item, stesso schema output. Unica fonte SDMX nel registry è `istat_sdmx`, quindi impatto circoscritto.
- `catalog_fetch_url()` non forza il parametro se `detail=` è già presente nell'URL (comportamento conservativo).
- I report radar e gli artifact inventory non sono in questa PR (i parquet sono in `.gitignore`): verranno rigenerati dalla CI post-merge, come da pratica esistente.
- Nota emersa dalla guida ondata (non inclusa in questo fix): il parametro `format=csv` nella `distribution_url` SDMX non è supportato da ISTAT (serve header `Accept`); eventuale fix separato.