### PR TITLE
fix(so): collector SPARQL con binding JSON e query DCAT (?dataset)

### DIFF
--- a/scripts/collectors/sparql.py
+++ b/scripts/collectors/sparql.py
@@ -29,6 +29,19 @@ def _group_sparql_bindings(bindings: list[dict]) -> dict[str, dict]:
     return grouped
 
 
+def _binding_val(binding: dict, var: str) -> str:
+    """Valore di un binding SPARQL come stringa.
+
+    Gli endpoint che rispondono JSON (es. dati.camera.it) restituiscono il
+    formato SPARQL standard ``{var: {"type": ..., "value": ...}}``; quelli
+    XML (es. noipa) valori stringa semplici. Normalizza entrambi.
+    """
+    v = binding.get(var)
+    if isinstance(v, dict):
+        return str(v.get("value") or "")
+    return v or ""
+
+
 def collect(source_id: str, source_cfg: dict, captured_at: str) -> CollectorResult:
     """Enumerate SPARQL datasets (named graphs) from an endpoint."""
     ctx = source_cfg.get("sparql", {})
@@ -50,13 +63,15 @@ def collect(source_id: str, source_cfg: dict, captured_at: str) -> CollectorResu
 
     rows: list[dict] = []
     for idx, b in enumerate(bindings, start=1):
-        graph_uri = b.get("g", "")
+        # Query DCAT custom (es. dati_camera): binding ?dataset (+ ?title ?description)
+        # Query named-graphs (default): binding ?g
+        graph_uri = _binding_val(b, "dataset") or _binding_val(b, "g")
         if not graph_uri:
             continue
 
-        # Extract a readable name from the URI
+        # Estrai un nome leggibile dalla URI (fallback quando ?title assente)
         name = graph_uri.rstrip("/").split("/")[-1].replace("_", " ").replace("-", " ").strip()
-        title = name[:120] if name else graph_uri[:120]
+        title = _binding_val(b, "title") or (name[:120] if name else graph_uri[:120])
 
         rows.append(
             {

--- a/tests/test_sparql_collector.py
+++ b/tests/test_sparql_collector.py
@@ -60,6 +60,59 @@ def test_collect_error(monkeypatch):
     assert result.warning["type"] == "sparql_error"
 
 
+def test_collect_dcat_dataset_bindings(monkeypatch):
+    """Query DCAT custom (es. dati_camera): binding ?dataset + ?title.
+
+    Regressione: il collector cercava solo ?g (named graphs) e scartava
+    tutti i bindings delle query DCAT (dati_camera → inventory a 0).
+    Usa il formato JSON reale di execute_sparql: {var: {type, value}}.
+    """
+    monkeypatch.setattr(
+        sparql_collector,
+        "execute_sparql",
+        lambda ep, q, timeout: [
+            {
+                "dataset": {"type": "uri", "value": "http://dati.camera.it/ocd/dataset/BPR"},
+                "title": {
+                    "type": "literal",
+                    "value": "Dataset BPR - Bibliografia del Parlamento",
+                },
+            },
+            {"dataset": {"type": "uri", "value": ""}},  # dataset vuoto → skippato
+            {
+                "dataset": {"type": "uri", "value": "http://dati.camera.it/ocd/dataset/LEG"},
+                "title": {"type": "literal", "value": "Dataset LEG - Legislature"},
+            },
+        ],
+    )
+    result = sparql_collector.collect("fonte", _cfg(), "2026-08-01")
+    assert isinstance(result, CollectorResult)
+    assert len(result.rows) == 2
+    assert result.rows[0]["item_id"] == "http://dati.camera.it/ocd/dataset/BPR"
+    assert result.rows[0]["title"] == "Dataset BPR - Bibliografia del Parlamento"
+    assert result.rows[1]["item_id"] == "http://dati.camera.it/ocd/dataset/LEG"
+
+
+# ── _binding_val ──────────────────────────────────────────────────────────────
+
+
+def test_binding_val_plain_string():
+    """Valore stringa semplice (formato XML) → invariato."""
+    assert sparql_collector._binding_val({"g": "http://x.test/g"}, "g") == "http://x.test/g"
+
+
+def test_binding_val_json_dict():
+    """Valore dict (formato JSON SPARQL) → estrae 'value'."""
+    b = {"dataset": {"type": "uri", "value": "http://x.test/d1"}}
+    assert sparql_collector._binding_val(b, "dataset") == "http://x.test/d1"
+
+
+def test_binding_val_missing():
+    """Variabile assente o None → stringa vuota."""
+    assert sparql_collector._binding_val({}, "g") == ""
+    assert sparql_collector._binding_val({"g": None}, "g") == ""
+
+
 # ── validate_items ────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Sintesi

Il collector SPARQL non gestiva due casi che riguardano `dati_camera`:

1. `execute_sparql` (lab_connectors) restituisce il formato SPARQL JSON `{var: {"type": ..., "value": ...}}` per endpoint che rispondono JSON (es. `dati.camera.it`) — il collector assumeva valori stringa → `AttributeError: 'dict' object has no attribute 'rstrip'`
2. La query DCAT custom di camera seleziona `?dataset` (+ `?title ?description`), il collector cercava solo `?g` (named graphs) → tutti i bindings scartati → **inventory a 0** (baseline: 104)

Le fonti SPARQL che rispondono XML (noipa, senato, cultura) funzionavano per caso: il parser XML estrae stringhe semplici.

## Contesto collegato

Nessuna issue collegata — emerso durante verifica dello stato SPARQL del SO (radar `dati_camera` RED ma endpoint vivo alle query reali).

## Cosa cambia

- [ ] Nuova fonte o modifica registro (sources_registry.yaml)
- [ ] Source-check o inventory-triage
- [x] Modifica script (radar, inventory, source-check, MCP)
- [ ] Modifica funnel o criteri di osservazione
- [ ] Workflow CI (radar.yml, observatory.yml)
- [ ] Skills o MCP tools
- [ ] Documentazione
- [ ] Altro

## Checklist

### Se modifichi script o MCP

- [x] `pytest tests/` passa (11 su test_sparql_collector; nessun altro test SPARQL impattato)
- [x] `ruff check .` passa
- [x] `mypy scripts/ so_mcp/` passa (verificato su file toccati)
- [x] Comando manuale verificato (run reale inventory `dati_camera`, vedi sotto)

## Verifica

Run reali contro l'endpoint `https://dati.camera.it/sparql`, non fake:

1. **Collector diretto**: `collect('dati_camera', cfg, ...)` → **104 righe** con titoli reali (es. "Dataset BPR - Bibliografia del Parlamento italiano e degli studi elettorali")
2. **Inventory end-to-end**: `build_catalog_inventory --source-ids dati_camera` → `status ok, rows 104, method sparql_query` — **baseline di aprile ripristinata** (era 0)

Test aggiunti: 3 test `_binding_val` (stringa / dict JSON / assente) + 1 test regressione per il formato DCAT JSON (`?dataset` con valori `{type, value}`).

## Note per chi revisiona

- **Nessun cambio di contratto**: stessi campi item, `item_kind`/`format` invariati (`named_graph` / `SPARQL_NAMED_GRAPH`), `base_url`/query del registry intatte. Il fix normalizza i binding all'ingresso.
- Il radar RED di `dati_camera` (503) sembra un falso positivo intermittente: al momento del fix l'endpoint risponde 200 e le query funzionano. Non toccato in questa PR — eventuale valutazione separata.
- Nota: il pattern `?dataset` è specifico della query DCAT custom di camera; il ramo `?g` (named graphs) resta il default per le altre fonti SPARQL.