### PR TITLE
README: revisione — tono civico, funnel, MCP in evidenza

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# Source Observatory
+# Source Observatory — Osservatorio delle fonti pubbliche
 
-Intelligence layer leggero per fonti pubbliche italiane — parte dell'ecosistema [DataCivicLab](https://github.com/dataciviclab).
+**Monitoriamo le fonti pubbliche italiane: quali sono vive, quali cambiano, quali meritano di diventare dataset del Lab.**
+
+Intelligence layer leggero per fonti pubbliche italiane — parte dell'ecosistema
+[DataCivicLab](https://github.com/dataciviclab).
 
 ## Il funnel
 
@@ -9,48 +12,33 @@ radar ── gate ── catalog-watch ── catalog-inventory ── pipeline 
               └── radar-only
 ```
 
-1. **Radar** — probe leggero su tutte le fonti (health check, sempre)
+1. **Radar** — health check leggero su tutte le fonti (sempre attivo)
 2. **Gate** — decide il regime di osservazione (`catalog-watch` o `radar-only`)
 3. **Catalog-inventory** — enumera gli item dei cataloghi ammessi
-4. **Pipeline** — merge (dedup logico per dataset) + validate (reachability + sniff CSV) → `readiness_score` 0-10
+4. **Pipeline** — merge + validate → `readiness_score` 0-10
 
-Il funnel è alimentato dal `sources_registry.yaml`: ogni fonte ha un `source_id`, un `protocol` e un `observation_mode`.
+Il funnel è alimentato dal `sources_registry.yaml`: ogni fonte ha `source_id`,
+`protocol` e `observation_mode`.
 
 ## CI / Workflow
 
-Due workflow schedulati su GitHub Actions:
-
 | Workflow | Schedule | Cosa fa |
 |---|---|---|
-| `radar.yml` | **daily** 03:15 | Radar check su tutte le fonti + sync `datasets_in_use` da DI catalog |
-| `observatory.yml` | **weekly** (lunedì) 03:20 | Inventory → pipeline (merge+validate) → report → upload GCS |
+| `radar.yml` | **daily** 03:15 | Radar check su tutte le fonti + sync `datasets_in_use` |
+| `observatory.yml` | **weekly** (lunedì) 03:20 | Inventory → pipeline → report → upload GCS |
 
-### `radar.yml` (daily)
+I report vengono committati nel repo. I parquet operativi sono caricati su GCS
+(`gs://dataciviclab-clean/catalog_inventory/`).
 
-Probe leggero HTTP su ogni fonte nel registry. Aggiorna `radar_summary.json`, `radar_history.json`, `STATUS.md` e `sources_registry.yaml`. Committa i risultati su git.
-
-### `observatory.yml` (weekly, lunedì)
-
-1. **Inventory** — build del parquet `catalog_inventory_latest.parquet` per le fonti `catalog-watch`
-2. **Pipeline** — merge (raggruppa item in dataset logici) + validate (HEAD probe + sniff CSV schema) → `validated.parquet`
-3. **Report** — genera report per fonte (`source_reports/*.json`) e dashboard (`sources_dashboard.json`)
-4. **Upload GCS** — parquet, report e snapshot su `gs://dataciviclab-clean/catalog_inventory/`
-
-I report vengono committati nel repo. I parquet operativi sono caricati su GCS.
-
-## Script
+## Script principali
 
 | Script | Cosa fa |
 |---|---|
-| `scripts/radar_check.py` | Health check delle fonti nel registry |
-| `scripts/sync_datasets_in_use.py` | Sincronizza `datasets_in_use` dal catalogo DI (`radar.yml`) |
-| `scripts/build_catalog_inventory.py` | Snapshot tabulare di tutti gli item enumerabili |
-| `scripts/pipeline/run_pipeline.py` | Merge + validate → `validated.parquet` |
-| `scripts/build_source_reports.py` | Report per fonte + dashboard |
-| `scripts/source_report.py` | Logica di aggregazione e scoring |
-| `scripts/collectors/` | Adapter per protocollo: CKAN, SDMX, SPARQL, HTML |
-| `scripts/collectors/_validate_base.py` | Validazione per gruppo tabulare (probe + sniff CSV) |
-| `scripts/gha/` | Helper per CI (gcs upload, publish summary) |
+| `radar_check.py` | Health check delle fonti nel registry |
+| `build_catalog_inventory.py` | Snapshot tabulare degli item enumerabili |
+| `pipeline/run_pipeline.py` | Merge + validate → `validated.parquet` |
+| `build_source_reports.py` | Report per fonte + dashboard |
+| `collectors/` | Adapter per protocollo: CKAN, SDMX, SPARQL, HTML |
 
 ```bash
 # Radar (giornaliero)
@@ -66,59 +54,39 @@ so-run-pipeline --workers 4
 so-build-reports
 ```
 
+## Consultare i dati (MCP)
+
+Il layer MCP (`so_mcp/so_server.py`) è il modo consigliato per consultare gli
+artifact senza scaricare file. Espone 5 tool:
+
+`so_source_report` (report completo per fonte) · `so_dashboard` (KPI riassuntivi) ·
+`so_inventory_search` · `so_source_check` · `so_find_by_url`
+
 ## Skills
 
-Le skills in `skills/` sono guide operative per agenti e review umana.
+Le skills in `skills/` sono guide operative per agenti e review umana:
 
 | Skill | Cosa fa |
 |---|---|
-| `source-check.md` | Verifica una fonte specifica — porta a issue intake in DI |
-| `inventory-triage.md` | Triage di un inventory per una shortlist — porta a issue SO per source-check |
+| `source-check.md` | Verifica una fonte specifica → issue intake in dataset-incubator |
+| `inventory-triage.md` | Triage di un inventory → issue SO per source-check |
 | `portal-scout.md` | Identifica protocollo e decide se aggiungere al registry |
-
-Il layer MCP (`so_mcp/so_server.py`) è il modo consigliato per consultare gli artifact senza scaricare file. Espone 5 tool: `so_source_report` (report completo per fonte), `so_dashboard` (KPI riassuntivi), `so_inventory_search`, `so_source_check`, `so_find_by_url`.
 
 ## Output e artefatti
 
-Gli artifact strutturali (`radar_summary.json`, `radar_history.json`, `STATUS.md`) sono versionati nel repo e aggiornati dalla CI. I parquet in `generated/` sono cache operative, sovrascritti a ogni run.
+Gli artifact strutturali (`radar_summary.json`, `radar_history.json`, `STATUS.md`)
+sono versionati nel repo e aggiornati dalla CI. I parquet in `generated/` sono
+cache operative, sovrascritti a ogni run.
 
 ```
-data/radar/
-  STATUS.md                   # sommario leggibile del probe
-  radar_summary.json          # stato compatto per fonte (GREEN/YELLOW/RED)
-  radar_history.json          # storia probe per fonte
-  sources_registry.yaml       # registro input/output
-
-data/reports/
-  sources_dashboard.json      # KPI riassuntivi di tutte le fonti (report_version 2)
-  source_reports/*.json       # report per singola fonte
-
-data/pipeline/
-  validated.parquet           # gruppi validati (merge + reachability + sniff)
-  summary.json                # riepilogo run pipeline
-
-data/catalog_inventory/generated/
-  catalog_inventory_latest.parquet   # snapshot cumulativo item
-  catalog_inventory_report.json      # stato run per fonte
+data/radar/           STATUS.md, radar_summary.json, radar_history.json, sources_registry.yaml
+data/reports/         sources_dashboard.json, source_reports/*.json
+data/pipeline/        validated.parquet, summary.json
+data/catalog_inventory/generated/   catalog_inventory_latest.parquet, report
 ```
 
-I JSON strutturali (`radar_summary`, `radar_history`) sono consumati da **agent-context-builder** per il contesto operativo degli agenti.
-
-Artifact su GCS (solo inventory e pipeline — il radar vive su git + Actions artifacts):
-- `gs://dataciviclab-clean/catalog_inventory/` — parquet inventory + report
-- `gs://dataciviclab-clean/catalog_inventory/pipeline/` — validated parquet
-
-## Struttura
-
-```
-scripts/          codice runtime (radar, inventory, pipeline, report)
-scripts/collectors/  adapter per protocollo (CKAN, SDMX, SPARQL, HTML)
-scripts/pipeline/    merge + validate
-data/             artifact versionati (radar, catalog, inventory)
-skills/           guide operative per agenti
-so_mcp/           layer MCP read-only sugli artifact
-docs/             runbook, architettura, policy
-```
+I JSON strutturali sono consumati da **agent-context-builder** per il contesto
+operativo degli agenti.
 
 ## Documentazione
 
@@ -133,11 +101,6 @@ pip install -e ".[dev]"
 ```
 
 Il pacchetto espone 5 entry point CLI:
+`so-observatory-mcp` · `so-run-pipeline` · `so-build-reports` · `so-radar-check` · `so-sync-datasets`
 
-```
-so-observatory-mcp     # server MCP
-so-run-pipeline        # merge + validate
-so-build-reports       # report per fonte
-so-radar-check         # health check
-so-sync-datasets       # sync datasets_in_use
-```
+Parte del [DataCivicLab](https://github.com/dataciviclab).


### PR DESCRIPTION
README riscritto secondo archetipo **C (Infrastruttura)** della convenzione README del Lab.

### Cosa cambia

- **Intro civica**: prima diceva "Intelligence layer leggero" — ora spiega il valore («quali fonti sono vive, quali meritano di diventare dataset»)
- **Funnel mantenuto** ma più compatto
- **MCP in evidenza** come modo consigliato per consultare i dati
- Tabelle script/workflow/skills più leggibili
- Passa da 143 a ~105 righe