### PR TITLE
chore(registry): sync_datasets_in_use dal registry fusion (registry.json)

### DIFF
--- a/scripts/sync_datasets_in_use.py
+++ b/scripts/sync_datasets_in_use.py
@@ -1,7 +1,8 @@
-"""Sync datasets_in_use in sources_registry.yaml from DI's clean_catalog.json.
+"""Sync datasets_in_use in sources_registry.yaml from DI's registry.json.
 
-Reads dataset-incubator/registry/clean_catalog.json, groups datasets by source_id,
-and updates sources_registry.yaml so that each source lists its DI candidate slugs.
+Reads dataset-incubator/registry/registry.json (fusion), groups datasets by
+source_id, and updates sources_registry.yaml so that each source lists its
+DI candidate slugs.
 """
 
 import json
@@ -13,17 +14,16 @@ from ruamel.yaml import YAML
 
 from scripts._constants import REGISTRY_PATH
 
-DI_CATALOG_URL = (
-    "https://raw.githubusercontent.com/dataciviclab/dataset-incubator/"
-    "main/registry/clean_catalog.json"
+DI_REGISTRY_URL = (
+    "https://raw.githubusercontent.com/dataciviclab/dataset-incubator/main/registry/registry.json"
 )
 
 
-def fetch_di_catalog() -> list[dict]:
-    print(f"Fetching {DI_CATALOG_URL}...")
-    with urlopen(DI_CATALOG_URL) as resp:
-        catalog = json.loads(resp.read().decode())
-    return catalog["datasets"]
+def fetch_di_registry() -> list[dict]:
+    print(f"Fetching {DI_REGISTRY_URL}...")
+    with urlopen(DI_REGISTRY_URL) as resp:
+        registry = json.loads(resp.read().decode())
+    return registry["datasets"]
 
 
 def group_by_source_id(datasets: list[dict]) -> dict[str, list[str]]:
@@ -74,8 +74,8 @@ def update_registry(registry_path: Path, source_groups: dict[str, list[str]]) ->
 
 
 def main() -> int:
-    datasets = fetch_di_catalog()
-    print(f"DI catalog: {len(datasets)} datasets")
+    datasets = fetch_di_registry()
+    print(f"DI registry: {len(datasets)} datasets")
 
     groups = group_by_source_id(datasets)
     print(f"Source groups: {len(groups)}")


### PR DESCRIPTION
## Sintesi

Migra `sync_datasets_in_use.py` dal legacy `clean_catalog.json` al **fusion registry** (`registry/registry.json` di dataset-incubator). La sezione `datasets` ha struttura identica al vecchio clean_catalog, quindi raggruppamento e aggiornamento restano invariati.

## Contesto collegato

Migrazione registry (fusion ADR): DI produce `registry.json` unico; i vecchi artifact separati sono proiezioni legacy da rimuovere dopo la migrazione dei consumer.

## Cosa cambia

- [ ] Nuova fonte o modifica registro (sources_registry.yaml)
- [ ] Source-check o inventory-triage
- [x] Modifica script (radar, inventory, source-check, MCP)
- [ ] Modifica funnel o criteri di osservazione
- [ ] Workflow CI (radar.yml, observatory.yml)
- [ ] Skills o MCP tools
- [ ] Documentazione
- [ ] Altro

## Checklist

### Se modifichi script o MCP

- [x] `pytest tests/` passa (test_sync_datasets_in_use: 4 verdi)
- [x] `ruff check .` passa
- [ ] `mypy scripts/ so_mcp/` passa (verificato su file toccato)
- [x] Comando manuale verificato: `python scripts/sync_datasets_in_use.py` (fetch dal registry)

## Verifica

- Cambio minimo: URL `clean_catalog.json` → `registry.json`, rinomina `fetch_di_catalog` → `fetch_di_registry`. Le funzioni pure (`group_by_source_id`, `update_registry`) non sono toccate; i loro test restano validi.

- [x] Perimetro stretto: una PR = migrazione registry dello script
- [ ] Issue collegata o motivazione dell'assenza (migrazione cross-repo coordinata)

## Note per chi revisiona

- Il workflow `radar.yml` chiama `python scripts/sync_datasets_in_use.py` senza cambiamenti — la migrazione è interna allo script.
